### PR TITLE
Look for composer autoload in parent project as well

### DIFF
--- a/Phan/Bootstrap.php
+++ b/Phan/Bootstrap.php
@@ -12,7 +12,15 @@ define('CLASS_DIR', __DIR__ . '/../');
 set_include_path(get_include_path().PATH_SEPARATOR.CLASS_DIR);
 
 // Use the composer autoloader
-require_once(__DIR__.'/../vendor/autoload.php');
+foreach ([
+    __DIR__.'/../vendor/autoload.php',          // autoloader is in this project
+    __DIR__.'/../../../../vendor/autoload.php', // autoloader is in parent project
+    ] as $file) {
+    if (file_exists($file)) {
+        require_once($file);
+        break;
+    }
+}
 
 // Customize assertions
 assert_options(ASSERT_ACTIVE,   true);


### PR DESCRIPTION
When you install phan via `composer require`, the vendor/autoload.php file is in a different place to when you use `composer install`, so therefore we look for it in either place.