### PR TITLE
Remove unneeded area in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ test3.php:14 TypeError arg#2(str) is int but explode() takes string
 
 You can see the full list of command line options by running `phan -h`.
 
-To make sure it works you can run `phan` on itself with `phan -f src/**/*.php`.
+To make sure it works you can run `phan` on itself with `phan src/**/*.php src/**/**/*.php`.
 You can also run tests by running `./test` which will execute the tests within the `tests/`
 directory.
 

--- a/README.md
+++ b/README.md
@@ -72,9 +72,6 @@ test3.php:14 TypeError arg#2(str) is int but explode() takes string
 
 You can see the full list of command line options by running `phan -h`.
 
-To make sure it works you can run `phan` on itself with `phan src/**/*.php src/**/**/*.php`.
-You can also run tests by running `./test` which will execute the tests within the `tests/`
-directory.
 
 ## Generating a file list
 


### PR DESCRIPTION
I was getting a lot of php warnings when following the README instructions and after a little review I found out that
```  
 -f <filename>   A file containing a list of PHP files to be analyzed
``` 
So I think that this is possibly a typo in the README.

**(edited)**
After checking again I've found out that the README already has such (correct) information on top of it so I'll update my PR to delete the duplicated area.
 