### PR TITLE
Ignore composer.phar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 /.phan/database
+composer.phar


### PR DESCRIPTION
If folks have a local composer.phar, prevent that from being committed.