### PR TITLE
phpunit config for quick test runing

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,3 +221,9 @@ that it is actually returning the passed in `string` instead of an `int` as decl
   [php7ast]: https://wiki.php.net/rfc/abstract_syntax_tree
   [php7dev]: https://github.com/rlerdorf/php7dev
   [uniform]: https://wiki.php.net/rfc/uniform_variable_syntax
+
+# Running tests
+
+```sh
+vendor/bin/phpunit
+```

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,24 @@
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.0/phpunit.xsd"
+
+        bootstrap="src/Phan/Bootstrap.php"
+
+        colors="true"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+
+        stopOnError="false"
+        stopOnFailure="false"
+        stopOnIncomplete="false"
+        stopOnSkipped="false"
+        stopOnRisky="false"
+
+        verbose="false">
+    <testsuites>
+        <testsuite name="Phan tests">
+            <directory>tests/Phan</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
with it you can run just `phpunit` from project root if phpunit installed globally or `vendor\bin\phpunit` to use composer-fetched phpunit (global one fallbacks to it if present)