### PR TITLE
Add failing test for abstract class constant access

### DIFF
--- a/tests/files/src/0067_abstract_class_constants.php
+++ b/tests/files/src/0067_abstract_class_constants.php
@@ -1,0 +1,6 @@
+<?php
+abstract class AbstractWithConstants {
+    public static $things = ['a', 'b'];
+}
+
+$test = AbstractWithConstants::$things;


### PR DESCRIPTION
It seems accessing class constants on an abstract class triggers a `TypeError Cannot instantiate abstract class XXX` which is wrong as we are merely accessing values and not instantiating it.

I'm switching to sending failing tests instead of repro cases in issues, I hope that's fine, but if you rather not let me know.