### PR TITLE
Improve travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: php
 php:
   - 7
 
+sudo: false
+
 before_install:
   - mkdir build
   - git clone https://github.com/nikic/php-ast.git build/ast
@@ -10,7 +12,7 @@ before_install:
   - phpize
   - ./configure
   - make
-  - sudo make install
+  - make install
   - echo "extension=ast.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - cd ./../../
   - travis_retry composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,14 @@ language: php
 
 php:
   - 7
+  - nightly
 
 sudo: false
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: "nightly"
 
 before_install:
   - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
 
 before_install:
   - mkdir build
-  - git clone https://github.com/nikic/php-ast.git build/ast
+  - git clone --depth 1 https://github.com/nikic/php-ast.git build/ast
   - cd ./build/ast/
   - phpize
   - ./configure

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
 cache:
   directories:
     - ./vendor
+    - ./build/ast
 
 before_install:
   - ./tests/setup.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ matrix:
   allow_failures:
     - php: "nightly"
 
+cache:
+  directories:
+    - ./vendor
+
 before_install:
   - mkdir build
   - git clone https://github.com/nikic/php-ast.git build/ast

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 7
 
 before_install:
+  - mkdir build
   - git clone https://github.com/nikic/php-ast.git build/ast
   - cd ./build/ast/
   - phpize
@@ -18,12 +19,10 @@ install:
   - composer --prefer-source install
 
 script:
-  - mkdir -p build
   - phpunit --colors -c phpunit.xml
   - php package.php
 
 before_deploy:
-  - mkdir -p build
   - php package.php
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   - composer --prefer-source install
 
 script:
-  - phpunit --colors -c phpunit.xml
+  - ./vendor/bin/phpunit --colors -c phpunit.xml
   - php package.php
 
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ php:
   - 7
   - nightly
 
+env:
+  - TEST_SUITE="AnalyzerTest"
+  - TEST_SUITE="PhanTest"
+  - TEST_SUITE="RasmusTest"
+  - TEST_SUITE="LanguageTest"
+
 sudo: false
 
 matrix:
@@ -18,20 +24,20 @@ cache:
 before_install:
   - mkdir build
   - git clone --depth 1 https://github.com/nikic/php-ast.git build/ast
-  - cd ./build/ast/
+  - pushd ./build/ast/
   - phpize
   - ./configure
   - make
   - make install
   - echo "extension=ast.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-  - cd ./../../
+  - popd
   - travis_retry composer self-update
 
 install:
   - composer --prefer-source install
 
 script:
-  - ./vendor/bin/phpunit --colors -c phpunit.xml
+  - ./vendor/bin/phpunit --colors --testsuite "$TEST_SUITE"
   - php package.php
 
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,16 +22,7 @@ cache:
     - ./vendor
 
 before_install:
-  - mkdir build
-  - git clone --depth 1 https://github.com/nikic/php-ast.git build/ast
-  - pushd ./build/ast/
-  - phpize
-  - ./configure
-  - make
-  - make install
-  - echo "extension=ast.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-  - popd
-  - travis_retry composer self-update
+  - ./tests/setup.sh
 
 install:
   - composer --prefer-source install

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-sqlite3": "0.7-dev"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.0.*"
+        "phpunit/phpunit": "~5.1"
     },
     "autoload": {
         "psr-4": {"Phan\\": "src/Phan"}

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "97be513226145be7f5e35aacf9d2db31",
-    "content-hash": "9290e5b737d376562f680a72c7f164a9",
+    "hash": "4784b565404bb7dbd2293dece638d6b5",
+    "content-hash": "46978487457b57fd978999bdb86e4a1a",
     "packages": [],
     "packages-dev": [
         {
@@ -455,16 +455,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.0.10",
+            "version": "5.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9104a4e2f6a3ebdc4eb036624949a1a2849373dd"
+                "reference": "c047ff05d2279404af9a7e89e2a7151c32c88022"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9104a4e2f6a3ebdc4eb036624949a1a2849373dd",
-                "reference": "9104a4e2f6a3ebdc4eb036624949a1a2849373dd",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c047ff05d2279404af9a7e89e2a7151c32c88022",
+                "reference": "c047ff05d2279404af9a7e89e2a7151c32c88022",
                 "shasum": ""
             },
             "require": {
@@ -480,7 +480,7 @@
                 "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": ">=1.0.6",
-                "phpunit/phpunit-mock-objects": ">=3.0",
+                "phpunit/phpunit-mock-objects": ">=3.0.5",
                 "sebastian/comparator": "~1.1",
                 "sebastian/diff": "~1.2",
                 "sebastian/environment": "~1.3",
@@ -499,7 +499,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0.x-dev"
+                    "dev-master": "5.1.x-dev"
                 }
             },
             "autoload": {
@@ -507,7 +507,7 @@
                     "src/"
                 ]
             },
-            "notification-url": "http://packagist.org/downloads/",
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
@@ -525,7 +525,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-11-30 08:33:35"
+            "time": "2015-12-10 07:54:54"
         },
         {
             "name": "phpunit/phpunit-mock-objects",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,8 +17,17 @@
 
         verbose="false">
     <testsuites>
-        <testsuite name="Phan tests">
-            <directory>tests/Phan</directory>
+        <testsuite name="AnalyzerTest">
+            <file>tests/Phan/AnalyzerTest.php</file>
+        </testsuite>
+        <testsuite name="PhanTest">
+            <file>tests/Phan/PhanTest.php</file>
+        </testsuite>
+        <testsuite name="RasmusTest">
+            <file>tests/Phan/RasmusTest.php</file>
+        </testsuite>
+        <testsuite name="LanguageTest">
+            <directory>tests/Phan/Language</directory>
         </testsuite>
     </testsuites>
     <filter>

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,18 +1,52 @@
 #!/usr/bin/env bash
 
+function build {
+    phpize
+    ./configure
+    make
+}
+
+function cleanBuild {
+    make clean
+    build
+}
+
+function install {
+    make install
+    echo "extension=ast.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+}
+
 # Ensure the build directory exists
 [[ -d "build" ]] || mkdir build
 
-# Ensure that we have a copy of the ast extension
-[[ -d "build/ast" ]] || git clone --depth 1 https://github.com/nikic/php-ast.git build/ast
+# Ensure that we have a copy of the ast extension source code.
+if [[ ! -e "build/ast/config.m4" ]]; then
+    # If build/ast exists, but build/ast/config.m4 doesn't, nuke it and start over.
+    [[ ! -d "build/ast" ]] || rm -rf build/ast
+    git clone --depth 1 https://github.com/nikic/php-ast.git build/ast
+fi
 
 # Install the ast extension
 pushd ./build/ast
-  phpize
-  ./configure
-  make
-  make install
-  echo "extension=ast.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  # If we don't have ast.so, we have to build it.
+  if [[ ! -e "modules/ast.so" ]]; then
+      echo "No cached extension found. Building..."
+      build
+  else
+      # If there are new commits, we need to rebuild the extension.
+      git fetch origin master
+      newCommits=$(git rev-list HEAD...origin/master --count)
+      if [[ "$newCommits" != "0" ]]; then
+          echo "New commits found upstream. Updating and rebuilding..."
+          git pull origin master
+          cleanBuild
+      else
+          echo "Using cached extension."
+      fi
+  fi
+
+  # No matter what, we still have to move the .so into place and enable it.
+  install
 popd
 
 # Disable xdebug, since we aren't currently gathering code coverage data and

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -15,5 +15,3 @@ pushd ./build/ast
   echo "extension=ast.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 popd
 
-# Update composer.
-travis_retry composer self-update

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -15,3 +15,6 @@ pushd ./build/ast
   echo "extension=ast.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 popd
 
+# Disable xdebug, since we aren't currently gathering code coverage data and
+# having xdebug slows down Composer a bit.
+phpenv config-rm xdebug.ini

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Ensure the build directory exists
+[[ -d "build" ]] || mkdir build
+
+# Ensure that we have a copy of the ast extension
+[[ -d "build/ast" ]] || git clone --depth 1 https://github.com/nikic/php-ast.git build/ast
+
+# Install the ast extension
+pushd ./build/ast
+  phpize
+  ./configure
+  make
+  make install
+  echo "extension=ast.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+popd
+
+# Update composer.
+travis_retry composer self-update


### PR DESCRIPTION
Test time difference on Travis:
  * Before: 2 min 28 sec
  * After: 55 seconds (though most of the results are back in 20-30 seconds)

Changes:
  * Removes use of `sudo` to enable running on Travis' container infrastructure
  * Caches downloaded dependencies between builds
    * `./vendor` can be stored, and is automatically updated by composer when there are changes to `composer.local`
    * `./build/ast` can be stored (which shaves off about 6-10 seconds), but there's some update logic to make sure we're using a current version
  * Upgrades PHPUnit
  * Splits the testsuite into smaller chunks to parallelize them
  * Enables PHP nightly testing (though failures are ignored for now)
  * Skips updating Composer on every test run because Travis will do that for us every 30-60 days. 

Finishes up https://github.com/etsy/phan/issues/37