### PR TITLE
Add test that should pass without warning in PHP7 BC checks

### DIFF
--- a/tests/files/src/0047_backwards_compatibility.php
+++ b/tests/files/src/0047_backwards_compatibility.php
@@ -3,3 +3,11 @@ echo $foo->$bar['baz'];
 Foo::$bar['baz']();
 $foo->$bar['baz']();
 strlen($foo->$bar['baz']);
+
+// tests that should pass without warning below
+class Test {
+    public static $vals = array('a' => 'A', 'b' => 'B');
+    public static function get($letter) {
+        return self::$vals[$letter];
+    }
+}


### PR DESCRIPTION
As far as I can tell (https://3v4l.org/ekFCL) this is legit syntax that is not ambiguous. I'm not sure why it's detected as such. I couldn't reproduce it outside of a class using `Foo::$bar[$baz]` but with self in there it seems to trigger something.