### PR TITLE
Add failing tests for docblock type detection

### DIFF
--- a/tests/files/src/0068_docblock_types.php
+++ b/tests/files/src/0068_docblock_types.php
@@ -1,0 +1,49 @@
+<?php
+namespace Foo\Bar {
+    class Baz {}
+}
+
+namespace Foo {
+    class Test {
+        /**
+         * @return Bar\Baz
+         */
+        public static function getBaz() {
+            return new Bar\Baz;
+        }
+
+        /**
+         * @return string|int|\Exception
+         */
+        public static function getException() {
+            return new \Exception;
+        }
+    }
+}
+
+namespace Foo2 {
+    use Foo\Bar\Baz;
+
+    class Test2 {
+        /**
+         * @param Baz $baz A baz instance
+         */
+        public static function takeBaz(Baz $baz) {
+            return $baz;
+        }
+
+        /**
+         * @return Baz[]
+         */
+        public static function createBazs() {
+            return [new Baz, new Baz];
+        }
+    }
+}
+
+namespace {
+    $baz = new \Foo\Bar\Baz;
+    foreach (\Foo2\Test2::createBazs() as $baz) {
+        \Foo2\Test2::takeBaz($baz);
+    }
+}


### PR DESCRIPTION
This highlights 2 different issues in detecting types when mixed with complex forms of docblocks:

- `test.php:12 TypeError return \Foo\Bar\baz but getBaz() is declared to return \Foo\bar`

If your docblock says you return `Bar\Baz` it just parses `Bar` and then drops the rest.

- `test.php:19 TypeError return \exception|\throwable but getException() is declared to return int|string`

Similar bug I assume but included for completeness just in case, returning `int|string|\Exception` parses the first two but drops the `\Exception` again I guess it just drops parsing when it sees a `\`.

- `test.php:39 TypeError return \Foo\Bar\baz[] but createBazs() is declared to return \Foo2\baz[]`

This is a bit weirder, if something returns `Baz[]` and there is a `use Foo\Bar\Baz` it doesn't resolve Baz according to the use statement but instead assumes it as `__NAMESPACE__\Baz` which I'd say is incorrect.

- `test.php:47 TypeError arg#1(baz) is \Foo2\baz but \Foo2\test2::takebaz() takes \Foo\Bar\baz defined at test.php:31`

Similarly when you use the function from the error above, it sees it as returning the right thing but it trusts the mis-parsed docblock and therefore assumes an incorrect type going forward.