### PR TITLE
Handling type dependencies during the parsing pass

### DIFF
--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -133,6 +133,7 @@ class UnionType {
      * @param Context $context
      * @param CodeBase $code_base
      * @param Node|string|null $node
+     * @param bool $throw_code_base_exceptions
      *
      * @return UnionType
      *
@@ -142,7 +143,8 @@ class UnionType {
     public static function fromNode(
         Context $context,
         CodeBase $code_base,
-        $node
+        $node,
+        bool $throw_code_base_exceptions = false
     ) : UnionType {
         if(!($node instanceof Node)) {
             if($node === null) {
@@ -153,7 +155,11 @@ class UnionType {
         }
 
         return (new Element($node))->acceptKindVisitor(
-            new UnionTypeVisitor($context, $code_base)
+            new UnionTypeVisitor(
+                $context,
+                $code_base,
+                $throw_code_base_exceptions
+            )
         );
 	}
 


### PR DESCRIPTION
During the initial parsing phase we need to get types on things like properties and constants. When a property type is dependent on a constant type, we can end up emitting undefined class errors based on the order in which files are parsed.

This patch routes around that by setting the type to be `mixed` on elements that rely on elements defined elsewhere but not yet parsed.

# Example

If we have a file A.php

```php
<?php
class A {
    public static $flag = B::C;
}
```

and another B.php

```php
class B {
    const C = 1;
}
```

and run phan as `./phan A.php B.php`, the type of `B::C` will not be defined when trying to figure out the type of `A::$flag`. If we ran it as `./phan B.php A.php` the type of `B::C` would already be known when trying to get the type of `$flag`.

This patch makes it such that the type of `A::$flag` would be mixed if `A` is read before `B`, and `int` if `B` is read before `A`.


