### PR TITLE
Failing tests for Interface and InstanceOf ($this) checking

### DIFF
--- a/tests/files/src/0093_this_instance_of.php
+++ b/tests/files/src/0093_this_instance_of.php
@@ -1,0 +1,32 @@
+<?php
+
+interface TestInterface
+{
+    public function testFunction(): TestInterface;
+}
+
+class TestClass
+{
+    public function otherFunction()
+    {
+        $something = new self;
+
+        if ($this instanceof TestInterface) {
+            $something = $this->testFunction();
+        }
+
+        return $something;
+    }
+
+}
+
+class TestAncestor extends TestClass implements TestInterface
+{
+    public function testFunction(): TestInterface
+    {
+        return $this;
+    }
+}
+
+$ancestor = new TestAncestor();
+$ancestor->otherFunction();


### PR DESCRIPTION
* Phan does not recognize `$this instanceof TestInterface` correctly
* Phan does displays strange error on interface result type declaration

```
TypeError Method \testinterface::testfunction is declared to return \testinterface but has no return value
UndefError call to undeclared method \testclass::testfunction' matches PCRE pattern "/^$/".
```