### PR TITLE
Fix group use imports

### DIFF
--- a/src/Phan/Analyze/ScopeVisitor.php
+++ b/src/Phan/Analyze/ScopeVisitor.php
@@ -156,7 +156,15 @@ abstract class ScopeVisitor extends KindVisitorImplementation {
                 $alias = $child_node->children['alias'];
             }
 
-            if ($node->flags == T_FUNCTION) {
+            // if AST_USE does not have any flags set, then its AST_USE_ELEM
+            // children will (this will be for AST_GROUP_USE)
+            if ($node->flags !== 0) {
+                $node2 = $node;
+            } else {
+                $node2 = $child_node;
+            }
+
+            if ($node2->flags == T_FUNCTION) {
                 $parts = explode('\\', $target);
                 $function_name = array_pop($parts);
                 $target = FullyQualifiedFunctionName::make(
@@ -169,7 +177,7 @@ abstract class ScopeVisitor extends KindVisitorImplementation {
                 );
             }
 
-            $map[$alias] = [$child_node->flags, $target];
+            $map[$alias] = [$node2->flags, $target];
         }
 
         return $map;

--- a/src/Phan/Analyze/ScopeVisitor.php
+++ b/src/Phan/Analyze/ScopeVisitor.php
@@ -168,7 +168,7 @@ abstract class ScopeVisitor extends KindVisitorImplementation {
                 $parts = explode('\\', $target);
                 $function_name = array_pop($parts);
                 $target = FullyQualifiedFunctionName::make(
-                    implode('\\', $parts),
+                    $prefix . '\\' . implode('\\', $parts),
                     $function_name
                 );
             } else {


### PR DESCRIPTION
This occurs when using group use declarations with relative namespaces on the imported classes.

The first commit solves the following problem:
```PHP
namespace test {
    class A{}
};

namespace {
    use test\{A};
    new A();
};
```

And the second commit solves:
```PHP
namespace test {
    function a(){}
};

namespace {
    use test\{function a};
    a();
};
```

There doesn't yet seem to be support for constants either - maybe this will be added soon.