### PR TITLE
Catch uncaught IssueException for undefined class constants

### DIFF
--- a/src/Phan/Analyze/PropertyTypesAnalyzer.php
+++ b/src/Phan/Analyze/PropertyTypesAnalyzer.php
@@ -2,6 +2,7 @@
 namespace Phan\Analyze;
 
 use Phan\CodeBase;
+use Phan\Exception\IssueException;
 use Phan\Issue;
 use Phan\Language\Element\Clazz;
 use Phan\Language\FQSEN;
@@ -15,7 +16,12 @@ class PropertyTypesAnalyzer {
      */
     public static function analyzePropertyTypes(CodeBase $code_base, Clazz $clazz) {
         foreach ($clazz->getPropertyList($code_base) as $property) {
-            $union_type = $property->getUnionType();
+            try {
+                $union_type = $property->getUnionType();
+            } catch (IssueException $exception) {
+                $exception->getIssueInstance()();
+                continue;
+            }
 
             // Look at each type in the parameter's Union Type
             foreach ($union_type->getTypeSet() as $type) {

--- a/tests/files/expected/0113_uncaught_undef_class_const_exception.php.expected
+++ b/tests/files/expected/0113_uncaught_undef_class_const_exception.php.expected
@@ -1,0 +1,1 @@
+%s:5 PhanUndeclaredConstant Reference to undeclared constant \undefclassconst::MY_CONST

--- a/tests/files/src/0113_uncaught_undef_class_const_exception.php
+++ b/tests/files/src/0113_uncaught_undef_class_const_exception.php
@@ -1,0 +1,6 @@
+<?php
+
+class UndefClassConst
+{
+    public $a = UndefClassConst::MY_CONST;
+}


### PR DESCRIPTION
Undefined class constants set on properties create uncaught `IssueException`s. It can be reproduced with the following:
```PHP
class UndefClassConst
{
    public $a = UndefClassConst::MY_CONST;
}
```

I wasn't exactly sure which stack frame would be the best to catch these in, but everything seems to work fine with the current patch.