### PR TITLE
Automated run to convert to PSR-2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "php": ">=7.0",
         "ext-ast": "*",
         "ext-sqlite3": "0.7-dev",
-        "symfony/console": "~2.3|~3.0"
+        "symfony/console": "~2.3|~3.0",
+        "squizlabs/php_codesniffer": "^2.5"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,86 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "9acdf601661fb65ac8ee607f2617e109",
-    "content-hash": "90b9ac5d45886a7816faa017d3a7f3bb",
+    "hash": "2df4644532ca5e0ac2c6ee21e9958be5",
+    "content-hash": "436e396cbcc0c0f2e8b80d274e3bd7be",
     "packages": [
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "2.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "6731851d6aaf1d0d6c58feff1065227b7fda3ba8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/6731851d6aaf1d0d6c58feff1065227b7fda3ba8",
+                "reference": "6731851d6aaf1d0d6c58feff1065227b7fda3ba8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "scripts/phpcs",
+                "scripts/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "CodeSniffer.php",
+                    "CodeSniffer/CLI.php",
+                    "CodeSniffer/Exception.php",
+                    "CodeSniffer/File.php",
+                    "CodeSniffer/Fixer.php",
+                    "CodeSniffer/Report.php",
+                    "CodeSniffer/Reporting.php",
+                    "CodeSniffer/Sniff.php",
+                    "CodeSniffer/Tokens.php",
+                    "CodeSniffer/Reports/",
+                    "CodeSniffer/Tokenizers/",
+                    "CodeSniffer/DocGenerators/",
+                    "CodeSniffer/Standards/AbstractPatternSniff.php",
+                    "CodeSniffer/Standards/AbstractScopeSniff.php",
+                    "CodeSniffer/Standards/AbstractVariableSniff.php",
+                    "CodeSniffer/Standards/IncorrectPatternException.php",
+                    "CodeSniffer/Standards/Generic/Sniffs/",
+                    "CodeSniffer/Standards/MySource/Sniffs/",
+                    "CodeSniffer/Standards/PEAR/Sniffs/",
+                    "CodeSniffer/Standards/PSR1/Sniffs/",
+                    "CodeSniffer/Standards/PSR2/Sniffs/",
+                    "CodeSniffer/Standards/Squiz/Sniffs/",
+                    "CodeSniffer/Standards/Zend/Sniffs/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2016-01-19 23:39:10"
+        },
         {
             "name": "symfony/console",
             "version": "v2.8.2",

--- a/format.sh
+++ b/format.sh
@@ -3,5 +3,5 @@
 find src \
     -type f \
     -path '*.php' \
-    -exec phpcbf \
+    -exec vendor/bin/phpcbf \
         --standard=PSR2 {} \;

--- a/format.sh
+++ b/format.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+find src \
+    -type f \
+    -path '*.php' \
+    -exec phpcbf \
+        --standard=PSR2 {} \;

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -148,7 +148,7 @@ class ContextNode
 
         $class_list = [];
         foreach ($union_type->asClassList($this->code_base)
- as $i => $clazz) {
+        as $i => $clazz) {
             $class_list[] = $clazz;
         }
 

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -31,7 +31,8 @@ use \ast\Node;
 /**
  * Methods for an AST node in context
  */
-class ContextNode {
+class ContextNode
+{
 
     /** @var CodeBase */
     private $code_base;
@@ -62,12 +63,13 @@ class ContextNode {
      *
      * @return string[]
      */
-    public function getQualifiedNameList() : array {
-        if(!($this->node instanceof Node)) {
+    public function getQualifiedNameList() : array
+    {
+        if (!($this->node instanceof Node)) {
             return [];
         }
 
-        return array_map(function($name_node)  {
+        return array_map(function ($name_node) {
             return (new ContextNode(
                 $this->code_base,
                 $this->context,
@@ -81,8 +83,8 @@ class ContextNode {
      *
      * @return string
      */
-    public function getQualifiedName(
-    ) : string {
+    public function getQualifiedName() : string
+    {
         return (string)UnionTypeVisitor::unionTypeFromClassNode(
             $this->code_base,
             $this->context,
@@ -94,15 +96,16 @@ class ContextNode {
      * @return string
      * A variable name associated with the given node
      */
-    public function getVariableName() : string {
-        if(!$this->node instanceof \ast\Node) {
+    public function getVariableName() : string
+    {
+        if (!$this->node instanceof \ast\Node) {
             return (string)$this->node;
         }
 
         $node = $this->node;
         $parent = $node;
 
-        while(($node instanceof \ast\Node)
+        while (($node instanceof \ast\Node)
             && ($node->kind != \ast\AST_VAR)
             && ($node->kind != \ast\AST_STATIC)
             && ($node->kind != \ast\AST_MAGIC_CONST)
@@ -111,15 +114,15 @@ class ContextNode {
             $node = array_values($node->children ?? [])[0];
         }
 
-        if(!$node instanceof \ast\Node) {
+        if (!$node instanceof \ast\Node) {
             return (string)$node;
         }
 
-        if(empty($node->children['name'])) {
+        if (empty($node->children['name'])) {
             return '';
         }
 
-        if($node->children['name'] instanceof \ast\Node) {
+        if ($node->children['name'] instanceof \ast\Node) {
             return '';
         }
 
@@ -135,7 +138,8 @@ class ContextNode {
      * An exception is thrown if a non-native type does not have
      * an associated class
      */
-    public function getClassList() {
+    public function getClassList()
+    {
         $union_type = UnionTypeVisitor::unionTypeFromClassNode(
             $this->code_base,
             $this->context,
@@ -144,8 +148,7 @@ class ContextNode {
 
         $class_list = [];
         foreach ($union_type->asClassList($this->code_base)
-            as $i => $clazz
-        ) {
+ as $i => $clazz) {
             $class_list[] = $clazz;
         }
 
@@ -192,15 +195,17 @@ class ContextNode {
             );
         }
 
-        assert(is_string($method_name),
-            "Method name must be a string. Found non-string at {$this->context}");
+        assert(
+            is_string($method_name),
+            "Method name must be a string. Found non-string at {$this->context}"
+        );
 
         try {
             $class_list = (new ContextNode(
                 $this->code_base,
                 $this->context,
                 $this->node->children['expr']
-                    ?? $this->node->children['class']
+                ?? $this->node->children['class']
             ))->getClassList();
         } catch (CodeBaseException $exception) {
             throw new IssueException(
@@ -220,7 +225,7 @@ class ContextNode {
                 $this->code_base,
                 $this->context,
                 $this->node->children['expr']
-                    ?? $this->node->children['class']
+                ?? $this->node->children['class']
             );
 
             if (!$union_type->isEmpty()
@@ -360,13 +365,15 @@ class ContextNode {
      * A IssueException is thrown if the variable doesn't
      * exist
      */
-    public function getVariable() : Variable {
+    public function getVariable() : Variable
+    {
         // Get the name of the variable
         $variable_name = $this->getVariableName();
 
-        if(empty($variable_name)) {
+        if (empty($variable_name)) {
             throw new NodeException(
-                $this->node, "Variable name not found"
+                $this->node,
+                "Variable name not found"
             );
         }
 
@@ -393,7 +400,8 @@ class ContextNode {
      * @throws NodeException
      * An exception is thrown if we can't understand the node
      */
-    public function getOrCreateVariable() : Variable {
+    public function getOrCreateVariable() : Variable
+    {
         try {
             return $this->getVariable();
         } catch (IssueException $exception) {
@@ -457,7 +465,7 @@ class ContextNode {
                 $this->code_base,
                 $this->context,
                 $this->node->children['expr'] ??
-                    $this->node->children['class']
+                $this->node->children['class']
             ))->getClassList();
         } catch (CodeBaseException $exception) {
             throw new IssueException(
@@ -475,13 +483,14 @@ class ContextNode {
             // Keep hunting if this class doesn't have the given
             // property
             if (!$class->hasPropertyWithName(
-                    $this->code_base,
-                    $property_name
+                $this->code_base,
+                $property_name
             )) {
                 // If there's a getter on properties than all
                 // bets are off.
                 if ($class->hasMethodWithName(
-                    $this->code_base, '__get'
+                    $this->code_base,
+                    '__get'
                 )) {
                     throw new UnanalyzableException(
                         $this->node,
@@ -607,11 +616,14 @@ class ContextNode {
      * An exception is thrown if we can't find the given
      * class
      */
-    public function getConst() : Constant {
-        assert($this->node->kind === \ast\AST_CONST,
-            "Node must be of type \ast\AST_CONST");
+    public function getConst() : Constant
+    {
+        assert(
+            $this->node->kind === \ast\AST_CONST,
+            "Node must be of type \ast\AST_CONST"
+        );
 
-        if($this->node->children['name']->kind !== \ast\AST_NAME) {
+        if ($this->node->children['name']->kind !== \ast\AST_NAME) {
             throw new NodeException(
                 $this->node,
                 "Can't determine constant name"
@@ -653,14 +665,17 @@ class ContextNode {
      * An exception is thrown if we hit a construct in which
      * we can't determine if the property exists or not
      */
-    public function getClassConst() : Constant {
-        assert($this->node->kind === \ast\AST_CLASS_CONST,
-            "Node must be of type \ast\AST_CLASS_CONST");
+    public function getClassConst() : Constant
+    {
+        assert(
+            $this->node->kind === \ast\AST_CLASS_CONST,
+            "Node must be of type \ast\AST_CLASS_CONST"
+        );
 
         $constant_name = $this->node->children['const'];
 
         // class name fetch
-        if($constant_name == 'class') {
+        if ($constant_name == 'class') {
             throw new UnanalyzableException(
                 $this->node,
                 "Can't get class constant for implicit 'class'"
@@ -723,9 +738,12 @@ class ContextNode {
      * @return string
      * A unique and stable name for an anonymous class
      */
-    public function getUnqualifiedNameForAnonymousClass() : string {
-        assert((bool)($this->node->flags & \ast\flags\CLASS_ANONYMOUS),
-            "Node must be an anonymous class node");
+    public function getUnqualifiedNameForAnonymousClass() : string
+    {
+        assert(
+            (bool)($this->node->flags & \ast\flags\CLASS_ANONYMOUS),
+            "Node must be an anonymous class node"
+        );
 
         $class_name = 'anonymous_class_'
             . substr(md5(implode('|', [
@@ -739,7 +757,8 @@ class ContextNode {
     /**
      * @return Method
      */
-    public function getClosure() : Method {
+    public function getClosure() : Method
+    {
         $closure_fqsen =
             FullyQualifiedFunctionName::fromClosureInContext(
                 $this->context
@@ -760,26 +779,27 @@ class ContextNode {
      *
      * @return void
      */
-    public function analyzeBackwardCompatibility() {
-        if(!Config::get()->backward_compatibility_checks) {
+    public function analyzeBackwardCompatibility()
+    {
+        if (!Config::get()->backward_compatibility_checks) {
             return;
         }
 
-        if(empty($this->node->children['expr'])) {
+        if (empty($this->node->children['expr'])) {
             return;
         }
 
-        if($this->node->kind === \ast\AST_STATIC_CALL ||
+        if ($this->node->kind === \ast\AST_STATIC_CALL ||
            $this->node->kind === \ast\AST_METHOD_CALL) {
             return;
         }
 
-        if($this->node->kind !== \ast\AST_DIM) {
-            if(!($this->node->children['expr'] instanceof Node)) {
+        if ($this->node->kind !== \ast\AST_DIM) {
+            if (!($this->node->children['expr'] instanceof Node)) {
                 return;
             }
 
-            if($this->node->children['expr']->kind !== \ast\AST_DIM) {
+            if ($this->node->children['expr']->kind !== \ast\AST_DIM) {
                 (new ContextNode(
                     $this->code_base,
                     $this->context,
@@ -795,13 +815,13 @@ class ContextNode {
             $lnode = $temp;
         }
 
-        if(!($temp->kind == \ast\AST_PROP
+        if (!($temp->kind == \ast\AST_PROP
             || $temp->kind == \ast\AST_STATIC_PROP
         )) {
             return;
         }
 
-        while($temp instanceof Node
+        while ($temp instanceof Node
             && ($temp->kind == \ast\AST_PROP
             || $temp->kind == \ast\AST_STATIC_PROP)
         ) {
@@ -812,19 +832,19 @@ class ContextNode {
             $temp = array_values($temp->children)[0];
         }
 
-        if(!($temp instanceof Node)) {
+        if (!($temp instanceof Node)) {
             return;
         }
 
         // Foo::$bar['baz'](); is a problem
         // Foo::$bar['baz'] is not
-        if($lnode->kind === \ast\AST_STATIC_PROP
+        if ($lnode->kind === \ast\AST_STATIC_PROP
             && $this->node->kind !== \ast\AST_CALL
         ) {
             return;
         }
 
-        if((
+        if ((
                 (
                     $lnode->children['prop'] instanceof Node
                     && $lnode->children['prop']->kind == \ast\AST_VAR
@@ -858,9 +878,9 @@ class ContextNode {
             $ftemp->seek($this->node->lineno-1);
             $line = $ftemp->current();
             unset($ftemp);
-            if(strpos($line,'}[') === false
-                || strpos($line,']}') === false
-                || strpos($line,'>{') === false
+            if (strpos($line, '}[') === false
+                || strpos($line, ']}') === false
+                || strpos($line, '>{') === false
             ) {
                 Issue::emit(
                     Issue::CompatiblePHP7,

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -42,7 +42,8 @@ use Phan\Phan;
  * Determine the UnionType associated with a
  * given node
  */
-class UnionTypeVisitor extends KindVisitorImplementation {
+class UnionTypeVisitor extends KindVisitorImplementation
+{
 
     /**
      * @var CodeBase
@@ -115,8 +116,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
         $node,
         bool $should_catch_issue_exception = true
     ) : UnionType {
-        if(!($node instanceof Node)) {
-            if($node === null || $node === 'null') {
+        if (!($node instanceof Node)) {
+            if ($node === null || $node === 'null') {
                 return new UnionType();
             }
 
@@ -126,7 +127,9 @@ class UnionTypeVisitor extends KindVisitorImplementation {
         if ($should_catch_issue_exception) {
             try {
                 return (new self(
-                    $code_base, $context, $should_catch_issue_exception
+                    $code_base,
+                    $context,
+                    $should_catch_issue_exception
                 ))($node);
             } catch (IssueException $exception) {
                 Phan::getIssueCollector()->collectIssue($exception->getIssueInstance());
@@ -135,7 +138,9 @@ class UnionTypeVisitor extends KindVisitorImplementation {
         }
 
         return (new self(
-            $code_base, $context, $should_catch_issue_exception
+            $code_base,
+            $context,
+            $should_catch_issue_exception
         ))($node);
     }
 
@@ -150,7 +155,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * @return UnionType
      * The set of types associated with the given node
      */
-    public function visit(Node $node) : UnionType {
+    public function visit(Node $node) : UnionType
+    {
         /*
         throw new NodeException($node,
             'Visitor not implemented for node of type '
@@ -171,7 +177,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitPostInc(Node $node) : UnionType {
+    public function visitPostInc(Node $node) : UnionType
+    {
         return self::unionTypeFromNode(
             $this->code_base,
             $this->context,
@@ -190,7 +197,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitPostDec(Node $node) : UnionType {
+    public function visitPostDec(Node $node) : UnionType
+    {
         return self::unionTypeFromNode(
             $this->code_base,
             $this->context,
@@ -209,7 +217,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitPreDec(Node $node) : UnionType {
+    public function visitPreDec(Node $node) : UnionType
+    {
         return self::unionTypeFromNode(
             $this->code_base,
             $this->context,
@@ -228,7 +237,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitPreInc(Node $node) : UnionType {
+    public function visitPreInc(Node $node) : UnionType
+    {
         return self::unionTypeFromNode(
             $this->code_base,
             $this->context,
@@ -247,7 +257,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitClone(Node $node) : UnionType {
+    public function visitClone(Node $node) : UnionType
+    {
         return self::unionTypeFromNode(
             $this->code_base,
             $this->context,
@@ -266,7 +277,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitCoalesce(Node $node) : UnionType {
+    public function visitCoalesce(Node $node) : UnionType
+    {
         $union_type = new UnionType();
 
         $left_type = self::unionTypeFromNode(
@@ -300,7 +312,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitEmpty(Node $node) : UnionType {
+    public function visitEmpty(Node $node) : UnionType
+    {
         return BoolType::instance()->asUnionType();
     }
 
@@ -315,7 +328,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitIsset(Node $node) : UnionType {
+    public function visitIsset(Node $node) : UnionType
+    {
         return BoolType::instance()->asUnionType();
     }
 
@@ -330,7 +344,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitIncludeOrEval(Node $node) : UnionType {
+    public function visitIncludeOrEval(Node $node) : UnionType
+    {
         // require() can return arbitrary objects. Lets just
         // say that we don't know what it is and move on
         return new UnionType();
@@ -347,7 +362,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitMagicConst(Node $node) : UnionType {
+    public function visitMagicConst(Node $node) : UnionType
+    {
         // This is for things like __METHOD__
         return StringType::instance()->asUnionType();
     }
@@ -363,7 +379,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitAssignRef(Node $node) : UnionType {
+    public function visitAssignRef(Node $node) : UnionType
+    {
         // TODO
         return new UnionType();
     }
@@ -379,7 +396,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitShellExec(Node $node) : UnionType {
+    public function visitShellExec(Node $node) : UnionType
+    {
         return StringType::instance()->asUnionType();
     }
 
@@ -394,7 +412,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitName(Node $node) : UnionType {
+    public function visitName(Node $node) : UnionType
+    {
         if ($node->flags & \ast\flags\NAME_NOT_FQ) {
             if ('parent' === $node->children['name']) {
                 $class = $this->context->getClassInScope($this->code_base);
@@ -437,29 +456,32 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitType(Node $node) : UnionType {
+    public function visitType(Node $node) : UnionType
+    {
         switch ($node->flags) {
-        case \ast\flags\TYPE_ARRAY:
+            case \ast\flags\TYPE_ARRAY:
             return ArrayType::instance()->asUnionType();
-        case \ast\flags\TYPE_BOOL:
-            return BoolType::instance()->asUnionType();
-        case \ast\flags\TYPE_CALLABLE:
-            return CallableType::instance()->asUnionType();
-        case \ast\flags\TYPE_DOUBLE:
-            return FloatType::instance()->asUnionType();
-        case \ast\flags\TYPE_LONG:
-            return IntType::instance()->asUnionType();
-        case \ast\flags\TYPE_NULL:
-            return NullType::instance()->asUnionType();
-        case \ast\flags\TYPE_OBJECT:
-            return ObjectType::instance()->asUnionType();
-        case \ast\flags\TYPE_STRING:
-            return StringType::instance()->asUnionType();
-        default:
-            assert(false,
-                "All flags must match. Found "
-                . Debug::astFlagDescription($node->flags ?? 0));
-            break;
+            case \ast\flags\TYPE_BOOL:
+                return BoolType::instance()->asUnionType();
+            case \ast\flags\TYPE_CALLABLE:
+                return CallableType::instance()->asUnionType();
+            case \ast\flags\TYPE_DOUBLE:
+                return FloatType::instance()->asUnionType();
+            case \ast\flags\TYPE_LONG:
+                return IntType::instance()->asUnionType();
+            case \ast\flags\TYPE_NULL:
+                return NullType::instance()->asUnionType();
+            case \ast\flags\TYPE_OBJECT:
+                return ObjectType::instance()->asUnionType();
+            case \ast\flags\TYPE_STRING:
+                return StringType::instance()->asUnionType();
+            default:
+                assert(
+                    false,
+                    "All flags must match. Found "
+                    . Debug::astFlagDescription($node->flags ?? 0)
+                );
+                break;
         }
     }
 
@@ -474,20 +496,21 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitConditional(Node $node) : UnionType {
+    public function visitConditional(Node $node) : UnionType
+    {
 
         $true_type = UnionType::fromNode(
             $this->context,
             $this->code_base,
             $node->children['trueExpr'] ??
-                $node->children['true'] ?? ''
+            $node->children['true'] ?? ''
         );
 
         $false_type = UnionType::fromNode(
             $this->context,
             $this->code_base,
             $node->children['falseExpr'] ??
-                $node->children['false'] ?? ''
+            $node->children['false'] ?? ''
         );
 
         $union_type = new UnionType();
@@ -524,8 +547,9 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitArray(Node $node) : UnionType {
-        if(!empty($node->children)
+    public function visitArray(Node $node) : UnionType
+    {
+        if (!empty($node->children)
             && $node->children[0] instanceof Node
             && $node->children[0]->kind == \ast\AST_ARRAY_ELEM
         ) {
@@ -533,13 +557,13 @@ class UnionTypeVisitor extends KindVisitorImplementation {
 
             // Check the first 5 (completely arbitrary) elements
             // and assume the rest are the same type
-            for($i=0; $i<5; $i++) {
+            for ($i=0; $i<5; $i++) {
                 // Check to see if we're out of elements
-                if(empty($node->children[$i])) {
+                if (empty($node->children[$i])) {
                     break;
                 }
 
-                if($node->children[$i]->children['value'] instanceof Node) {
+                if ($node->children[$i]->children['value'] instanceof Node) {
                     $element_types[] = UnionType::fromNode(
                         $this->context,
                         $this->code_base,
@@ -556,7 +580,7 @@ class UnionTypeVisitor extends KindVisitorImplementation {
             $element_types =
                 array_values(array_unique($element_types));
 
-            if(count($element_types) == 1) {
+            if (count($element_types) == 1) {
                 return $element_types[0]->asGenericArrayTypes();
             }
         }
@@ -575,7 +599,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitBinaryOp(Node $node) : UnionType {
+    public function visitBinaryOp(Node $node) : UnionType
+    {
         return (new BinaryOperatorFlagVisitor(
             $this->code_base,
             $this->context
@@ -593,7 +618,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitGreater(Node $node) : UnionType {
+    public function visitGreater(Node $node) : UnionType
+    {
         return $this->visitBinaryOp($node);
     }
 
@@ -608,7 +634,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitGreaterEqual(Node $node) : UnionType {
+    public function visitGreaterEqual(Node $node) : UnionType
+    {
         return $this->visitBinaryOp($node);
     }
 
@@ -623,27 +650,28 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitCast(Node $node) : UnionType {
-        switch($node->flags) {
-        case \ast\flags\TYPE_NULL:
+    public function visitCast(Node $node) : UnionType
+    {
+        switch ($node->flags) {
+            case \ast\flags\TYPE_NULL:
             return NullType::instance()->asUnionType();
-        case \ast\flags\TYPE_BOOL:
-            return BoolType::instance()->asUnionType();
-        case \ast\flags\TYPE_LONG:
-            return IntType::instance()->asUnionType();
-        case \ast\flags\TYPE_DOUBLE:
+                case \ast\flags\TYPE_BOOL:
+                return BoolType::instance()->asUnionType();
+                    case \ast\flags\TYPE_LONG:
+                    return IntType::instance()->asUnionType();
+            case \ast\flags\TYPE_DOUBLE:
             return FloatType::instance()->asUnionType();
-        case \ast\flags\TYPE_STRING:
-            return StringType::instance()->asUnionType();
-        case \ast\flags\TYPE_ARRAY:
-            return ArrayType::instance()->asUnionType();
-        case \ast\flags\TYPE_OBJECT:
-            return ObjectType::instance()->asUnionType();
-        default:
-            throw new NodeException(
-                $node,
-                'Unknown type (' . $node->flags . ') in cast'
-            );
+                case \ast\flags\TYPE_STRING:
+                return StringType::instance()->asUnionType();
+                    case \ast\flags\TYPE_ARRAY:
+                return ArrayType::instance()->asUnionType();
+                    case \ast\flags\TYPE_OBJECT:
+                return ObjectType::instance()->asUnionType();
+                    default:
+                throw new NodeException(
+                    $node,
+                    'Unknown type (' . $node->flags . ') in cast'
+                );
         }
     }
 
@@ -658,7 +686,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitNew(Node $node) : UnionType {
+    public function visitNew(Node $node) : UnionType
+    {
         return $this->visitClassNode($node->children['class']);
     }
 
@@ -674,7 +703,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitInstanceOf(Node $node) : UnionType {
+    public function visitInstanceOf(Node $node) : UnionType
+    {
         try {
             // Confirm that the right-side exists
             $union_type = $this->visitClassNode(
@@ -698,7 +728,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitDim(Node $node) : UnionType {
+    public function visitDim(Node $node) : UnionType
+    {
         $union_type = self::unionTypeFromNode(
             $this->code_base,
             $this->context,
@@ -715,7 +746,7 @@ class UnionTypeVisitor extends KindVisitorImplementation {
             $union_type->genericArrayElementTypes();
 
         // If we have generics, we're all set
-        if(!$generic_types->isEmpty()) {
+        if (!$generic_types->isEmpty()) {
             return $generic_types;
         }
 
@@ -778,7 +809,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitClosure(Decl $node) : UnionType {
+    public function visitClosure(Decl $node) : UnionType
+    {
         // The type of a closure is the fqsen pointing
         // at its definition
         $closure_fqsen =
@@ -804,10 +836,11 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitVar(Node $node) : UnionType {
+    public function visitVar(Node $node) : UnionType
+    {
 
         // $$var or ${...} (whose idea was that anyway?)
-        if(($node->children['name'] instanceof Node)
+        if (($node->children['name'] instanceof Node)
             && ($node->children['name']->kind == \ast\AST_VAR
             || $node->children['name']->kind == \ast\AST_BINARY_OP)
         ) {
@@ -815,7 +848,7 @@ class UnionTypeVisitor extends KindVisitorImplementation {
         }
 
         // This is nonsense. Give up.
-        if($node->children['name'] instanceof Node) {
+        if ($node->children['name'] instanceof Node) {
             return new UnionType();
         }
 
@@ -823,7 +856,7 @@ class UnionTypeVisitor extends KindVisitorImplementation {
             $node->children['name'];
 
         if (!$this->context->getScope()->hasVariableWithName($variable_name)) {
-            if(!Variable::isSuperglobalVariableWithName($variable_name)) {
+            if (!Variable::isSuperglobalVariableWithName($variable_name)) {
                 Issue::emit(
                     Issue::UndeclaredVariable,
                     $this->context->getFile(),
@@ -853,7 +886,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitEncapsList(Node $node) : UnionType {
+    public function visitEncapsList(Node $node) : UnionType
+    {
         return StringType::instance()->asUnionType();
     }
 
@@ -868,9 +902,10 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitConst(Node $node) : UnionType {
-        if($node->children['name']->kind == \ast\AST_NAME) {
-            if(defined($node->children['name']->children['name'])) {
+    public function visitConst(Node $node) : UnionType
+    {
+        if ($node->children['name']->kind == \ast\AST_NAME) {
+            if (defined($node->children['name']->children['name'])) {
                 return Type::fromObject(
                     constant($node->children['name']->children['name'])
                 )->asUnionType();
@@ -896,12 +931,13 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * @throws IssueException
      * An exception is thrown if we can't find the constant
      */
-    public function visitClassConst(Node $node) : UnionType {
+    public function visitClassConst(Node $node) : UnionType
+    {
 
         $constant_name = $node->children['const'];
 
         // class name fetch
-        if($constant_name == 'class') {
+        if ($constant_name == 'class') {
             return StringType::instance()->asUnionType();
         }
 
@@ -935,7 +971,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitProp(Node $node) : UnionType {
+    public function visitProp(Node $node) : UnionType
+    {
         try {
             $property = (new ContextNode(
                 $this->code_base,
@@ -944,7 +981,7 @@ class UnionTypeVisitor extends KindVisitorImplementation {
             ))->getProperty($node->children['prop']);
 
             return $property->getUnionType();
-        }  catch (IssueException $exception) {
+        } catch (IssueException $exception) {
             Phan::getIssueCollector()->collectIssue($exception->getIssueInstance());
         } catch (CodeBaseException $exception) {
             $property_name = $node->children['prop'];
@@ -976,7 +1013,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitStaticProp(Node $node) : UnionType {
+    public function visitStaticProp(Node $node) : UnionType
+    {
         return $this->visitProp($node);
     }
 
@@ -992,8 +1030,9 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitCall(Node $node) : UnionType {
-        if($node->children['expr']->kind !== \ast\AST_NAME) {
+    public function visitCall(Node $node) : UnionType
+    {
+        if ($node->children['expr']->kind !== \ast\AST_NAME) {
             // Things like `$func()`
             return new UnionType();
         }
@@ -1042,7 +1081,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitStaticCall(Node $node) : UnionType {
+    public function visitStaticCall(Node $node) : UnionType
+    {
         return $this->visitMethodCall($node);
     }
 
@@ -1057,7 +1097,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitMethodCall(Node $node) : UnionType {
+    public function visitMethodCall(Node $node) : UnionType
+    {
         $method_name = $node->children['method'];
 
         // Give up on any complicated nonsense where the
@@ -1069,17 +1110,17 @@ class UnionTypeVisitor extends KindVisitorImplementation {
 
         // Method names can some times turn up being
         // other method calls.
-        assert(is_string($method_name),
-            "Method name must be a string. Something else given.");
+        assert(
+            is_string($method_name),
+            "Method name must be a string. Something else given."
+        );
 
         try {
             $class_fqsen = null;
             foreach ($this->classListFromNode(
                 $node->children['class'] ?? $node->children['expr']
             )
-                as $i => $class
-            ) {
-
+ as $i => $class) {
                 $class_fqsen = $class->getFQSEN();
 
                 if (!$class->hasMethodWithName(
@@ -1097,7 +1138,7 @@ class UnionTypeVisitor extends KindVisitorImplementation {
                     );
 
                     return $method->getUnionType();
-                }  catch (IssueException $exception) {
+                } catch (IssueException $exception) {
                     $exception->getIssueInstance()();
                     return new UnionType();
                 }
@@ -1128,7 +1169,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitAssign(Node $node) : UnionType {
+    public function visitAssign(Node $node) : UnionType
+    {
         return self::unionTypeFromNode(
             $this->code_base,
             $this->context,
@@ -1147,10 +1189,11 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitUnaryOp(Node $node) : UnionType {
+    public function visitUnaryOp(Node $node) : UnionType
+    {
         // Shortcut some easy operators
         switch ($node->flags) {
-        case \ast\flags\UNARY_BOOL_NOT:
+            case \ast\flags\UNARY_BOOL_NOT:
             return BoolType::instance()->asUnionType();
         }
 
@@ -1172,7 +1215,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitUnaryMinus(Node $node) : UnionType {
+    public function visitUnaryMinus(Node $node) : UnionType
+    {
         return Type::fromObject($node->children['expr'])->asUnionType();
     }
 
@@ -1188,7 +1232,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * An exception is thrown if we can't find a class for
      * the given type
      */
-    private function visitClassNode(Node $node) : UnionType {
+    private function visitClassNode(Node $node) : UnionType
+    {
 
         // Things of the form `new $class_name();`
         if ($node->kind == \ast\AST_VAR) {
@@ -1208,17 +1253,17 @@ class UnionTypeVisitor extends KindVisitorImplementation {
                 ))->getUnqualifiedNameForAnonymousClass();
 
             // Turn that into a fully qualified name
-            $fqsen = FullyQualifiedClassName::fromStringInContext(
-                $anonymous_class_name,
-                $this->context
-            );
+                $fqsen = FullyQualifiedClassName::fromStringInContext(
+                    $anonymous_class_name,
+                    $this->context
+                );
 
             // Turn that into a union type
-            return Type::fromFullyQualifiedString((string)$fqsen)->asUnionType();
+                return Type::fromFullyQualifiedString((string)$fqsen)->asUnionType();
         }
 
         // Things of the form `new $method->name()`
-        if($node->kind !== \ast\AST_NAME) {
+        if ($node->kind !== \ast\AST_NAME) {
             return new UnionType();
         }
 
@@ -1250,7 +1295,7 @@ class UnionTypeVisitor extends KindVisitorImplementation {
         }
 
         // Reference to a parent class
-        if($class_name === 'parent') {
+        if ($class_name === 'parent') {
             $class = $this->context->getClassInScope(
                 $this->code_base
             );
@@ -1303,7 +1348,7 @@ class UnionTypeVisitor extends KindVisitorImplementation {
 
         // For simple nodes or very complicated nodes,
         // recurse
-        if(!($node instanceof \ast\Node)
+        if (!($node instanceof \ast\Node)
             || $node->kind != \ast\AST_NAME
         ) {
             return self::unionTypeFromNode(
@@ -1316,7 +1361,7 @@ class UnionTypeVisitor extends KindVisitorImplementation {
         $class_name = $node->children['name'];
 
         // Check to see if the name is fully qualified
-        if(!($node->flags & \ast\flags\NAME_NOT_FQ)) {
+        if (!($node->flags & \ast\flags\NAME_NOT_FQ)) {
             if (0 !== strpos($class_name, '\\')) {
                 $class_name = '\\' . $class_name;
             }
@@ -1378,7 +1423,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
         }
 
         return UnionType::fromStringInContext(
-            $class_name, $context
+            $class_name,
+            $context
         );
     }
 
@@ -1390,7 +1436,8 @@ class UnionTypeVisitor extends KindVisitorImplementation {
      * An exception is thrown if we can't find a class for
      * the given type
      */
-    private function classListFromNode(Node $node) {
+    private function classListFromNode(Node $node)
+    {
         // Get the types associated with the node
         $union_type = self::unionTypeFromNode(
             $this->code_base,
@@ -1401,8 +1448,7 @@ class UnionTypeVisitor extends KindVisitorImplementation {
         // Iterate over each viable class type to see if any
         // have the constant we're looking for
         foreach ($union_type->nonNativeTypes()->getTypeSet()
-            as $class_type
-        ) {
+        as $class_type) {
             // Get the class FQSEN
             $class_fqsen = $class_type->asFQSEN();
 
@@ -1420,5 +1466,4 @@ class UnionTypeVisitor extends KindVisitorImplementation {
             yield $this->code_base->getClassByFQSEN($class_fqsen);
         }
     }
-
 }

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -460,7 +460,7 @@ class UnionTypeVisitor extends KindVisitorImplementation
     {
         switch ($node->flags) {
             case \ast\flags\TYPE_ARRAY:
-            return ArrayType::instance()->asUnionType();
+                return ArrayType::instance()->asUnionType();
             case \ast\flags\TYPE_BOOL:
                 return BoolType::instance()->asUnionType();
             case \ast\flags\TYPE_CALLABLE:
@@ -654,20 +654,20 @@ class UnionTypeVisitor extends KindVisitorImplementation
     {
         switch ($node->flags) {
             case \ast\flags\TYPE_NULL:
-            return NullType::instance()->asUnionType();
-                case \ast\flags\TYPE_BOOL:
+                return NullType::instance()->asUnionType();
+            case \ast\flags\TYPE_BOOL:
                 return BoolType::instance()->asUnionType();
-                    case \ast\flags\TYPE_LONG:
-                    return IntType::instance()->asUnionType();
+            case \ast\flags\TYPE_LONG:
+                return IntType::instance()->asUnionType();
             case \ast\flags\TYPE_DOUBLE:
-            return FloatType::instance()->asUnionType();
-                case \ast\flags\TYPE_STRING:
+                return FloatType::instance()->asUnionType();
+            case \ast\flags\TYPE_STRING:
                 return StringType::instance()->asUnionType();
-                    case \ast\flags\TYPE_ARRAY:
+            case \ast\flags\TYPE_ARRAY:
                 return ArrayType::instance()->asUnionType();
-                    case \ast\flags\TYPE_OBJECT:
+            case \ast\flags\TYPE_OBJECT:
                 return ObjectType::instance()->asUnionType();
-                    default:
+            default:
                 throw new NodeException(
                     $node,
                     'Unknown type (' . $node->flags . ') in cast'
@@ -1120,7 +1120,7 @@ class UnionTypeVisitor extends KindVisitorImplementation
             foreach ($this->classListFromNode(
                 $node->children['class'] ?? $node->children['expr']
             )
- as $i => $class) {
+            as $i => $class) {
                 $class_fqsen = $class->getFQSEN();
 
                 if (!$class->hasMethodWithName(
@@ -1194,7 +1194,7 @@ class UnionTypeVisitor extends KindVisitorImplementation
         // Shortcut some easy operators
         switch ($node->flags) {
             case \ast\flags\UNARY_BOOL_NOT:
-            return BoolType::instance()->asUnionType();
+                return BoolType::instance()->asUnionType();
         }
 
         return self::unionTypeFromNode(
@@ -1448,7 +1448,7 @@ class UnionTypeVisitor extends KindVisitorImplementation
         // Iterate over each viable class type to see if any
         // have the constant we're looking for
         foreach ($union_type->nonNativeTypes()->getTypeSet()
-        as $class_type) {
+ as $class_type) {
             // Get the class FQSEN
             $class_fqsen = $class_type->asFQSEN();
 

--- a/src/Phan/AST/Visitor/Element.php
+++ b/src/Phan/AST/Visitor/Element.php
@@ -283,59 +283,59 @@ class Element
     {
         switch ($this->node->flags ?? 0) {
             case \ast\flags\BINARY_ADD:
-            return $visitor->visitBinaryAdd($this->node);
-                case \ast\flags\BINARY_BITWISE_AND:
+                return $visitor->visitBinaryAdd($this->node);
+            case \ast\flags\BINARY_BITWISE_AND:
                 return $visitor->visitBinaryBitwiseAnd($this->node);
-                    case \ast\flags\BINARY_BITWISE_OR:
-                    return $visitor->visitBinaryBitwiseOr($this->node);
+            case \ast\flags\BINARY_BITWISE_OR:
+                return $visitor->visitBinaryBitwiseOr($this->node);
             case \ast\flags\BINARY_BITWISE_XOR:
-            return $visitor->visitBinaryBitwiseXor($this->node);
-                case \ast\flags\BINARY_BOOL_XOR:
+                return $visitor->visitBinaryBitwiseXor($this->node);
+            case \ast\flags\BINARY_BOOL_XOR:
                 return $visitor->visitBinaryBoolXor($this->node);
-                    case \ast\flags\BINARY_CONCAT:
+            case \ast\flags\BINARY_CONCAT:
                 return $visitor->visitBinaryConcat($this->node);
-                    case \ast\flags\BINARY_DIV:
+            case \ast\flags\BINARY_DIV:
                 return $visitor->visitBinaryDiv($this->node);
-                    case \ast\flags\BINARY_IS_EQUAL:
+            case \ast\flags\BINARY_IS_EQUAL:
                 return $visitor->visitBinaryIsEqual($this->node);
-                    case \ast\flags\BINARY_IS_IDENTICAL:
+            case \ast\flags\BINARY_IS_IDENTICAL:
                 return $visitor->visitBinaryIsIdentical($this->node);
-                    case \ast\flags\BINARY_IS_NOT_EQUAL:
+            case \ast\flags\BINARY_IS_NOT_EQUAL:
                 return $visitor->visitBinaryIsNotEqual($this->node);
-                    case \ast\flags\BINARY_IS_NOT_IDENTICAL:
+            case \ast\flags\BINARY_IS_NOT_IDENTICAL:
                 return $visitor->visitBinaryIsNotIdentical($this->node);
-                    case \ast\flags\BINARY_IS_SMALLER:
+            case \ast\flags\BINARY_IS_SMALLER:
                 return $visitor->visitBinaryIsSmaller($this->node);
-                    case \ast\flags\BINARY_IS_SMALLER_OR_EQUAL:
+            case \ast\flags\BINARY_IS_SMALLER_OR_EQUAL:
                 return $visitor->visitBinaryIsSmallerOrEqual($this->node);
-                    case \ast\flags\BINARY_MOD:
+            case \ast\flags\BINARY_MOD:
                 return $visitor->visitBinaryMod($this->node);
-                    case \ast\flags\BINARY_MUL:
+            case \ast\flags\BINARY_MUL:
                 return $visitor->visitBinaryMul($this->node);
-                    case \ast\flags\BINARY_POW:
+            case \ast\flags\BINARY_POW:
                 return $visitor->visitBinaryPow($this->node);
-                    case \ast\flags\BINARY_SHIFT_LEFT:
+            case \ast\flags\BINARY_SHIFT_LEFT:
                 return $visitor->visitBinaryShiftLeft($this->node);
-                    case \ast\flags\BINARY_SHIFT_RIGHT:
+            case \ast\flags\BINARY_SHIFT_RIGHT:
                 return $visitor->visitBinaryShiftRight($this->node);
-                    case \ast\flags\BINARY_SPACESHIP:
+            case \ast\flags\BINARY_SPACESHIP:
                 return $visitor->visitBinarySpaceship($this->node);
-                    case \ast\flags\BINARY_SUB:
+            case \ast\flags\BINARY_SUB:
                 return $visitor->visitBinarySub($this->node);
-                    case \ast\flags\BINARY_BOOL_AND:
+            case \ast\flags\BINARY_BOOL_AND:
                 return $visitor->visitBinaryBoolAnd($this->node);
-                    case \ast\flags\BINARY_BOOL_OR:
+            case \ast\flags\BINARY_BOOL_OR:
                 return $visitor->visitBinaryBoolOr($this->node);
-                    case \ast\flags\BINARY_IS_GREATER:
+            case \ast\flags\BINARY_IS_GREATER:
                 return $visitor->visitBinaryIsGreater($this->node);
-                    case \ast\flags\BINARY_IS_GREATER_OR_EQUAL:
+            case \ast\flags\BINARY_IS_GREATER_OR_EQUAL:
                 return $visitor->visitBinaryIsGreaterOrEqual($this->node);
-                    default:
-                        assert(
-                            false,
-                            "All flags must match. Found "
-                            . Debug::astFlagDescription($this->node->flags ?? 0)
-                        );
+            default:
+                assert(
+                    false,
+                    "All flags must match. Found "
+                    . Debug::astFlagDescription($this->node->flags ?? 0)
+                );
                 break;
         }
     }
@@ -350,9 +350,9 @@ class Element
     {
         switch ($this->node->flags) {
             case \ast\flags\CLASS_ABSTRACT:
-            return $visitor->visitClassAbstract($this->node);
+                return $visitor->visitClassAbstract($this->node);
             case \ast\flags\CLASS_FINAL:
-            return $visitor->visitClassFinal($this->node);
+                return $visitor->visitClassFinal($this->node);
             case \ast\flags\CLASS_INTERFACE:
                 return $visitor->visitClassInterface($this->node);
             case \ast\flags\CLASS_TRAIT:
@@ -379,9 +379,9 @@ class Element
     {
         switch ($this->node->flags) {
             case \ast\flags\MODIFIER_ABSTRACT:
-            return $visitor->visitModifierAbstract($this->node);
+                return $visitor->visitModifierAbstract($this->node);
             case \ast\flags\MODIFIER_FINAL:
-            return $visitor->visitModifierFinal($this->node);
+                return $visitor->visitModifierFinal($this->node);
             case \ast\flags\MODIFIER_PRIVATE:
                 return $visitor->visitModifierPrivate($this->node);
             case \ast\flags\MODIFIER_PROTECTED:
@@ -410,9 +410,9 @@ class Element
     {
         switch ($this->node->flags) {
             case \ast\flags\NAME_FQ:
-            return $visitor->visitNameFq($this->node);
+                return $visitor->visitNameFq($this->node);
             case \ast\flags\NAME_NOT_FQ:
-            return $visitor->visitNameNotFq($this->node);
+                return $visitor->visitNameNotFq($this->node);
             case \ast\flags\NAME_RELATIVE:
                 return $visitor->visitNameRelative($this->node);
             default:
@@ -435,9 +435,9 @@ class Element
     {
         switch ($this->node->flags) {
             case \ast\flags\PARAM_REF:
-            return $visitor->visitParamRef($this->node);
+                return $visitor->visitParamRef($this->node);
             case \ast\flags\PARAM_VARIADIC:
-            return $visitor->visitParamVariadic($this->node);
+                return $visitor->visitParamVariadic($this->node);
             default:
                 assert(
                     false,
@@ -458,9 +458,9 @@ class Element
     {
         switch ($this->node->flags) {
             case \ast\flags\TYPE_ARRAY:
-            return $visitor->visitUnionTypeArray($this->node);
+                return $visitor->visitUnionTypeArray($this->node);
             case \ast\flags\TYPE_BOOL:
-            return $visitor->visitUnionTypeBool($this->node);
+                return $visitor->visitUnionTypeBool($this->node);
             case \ast\flags\TYPE_CALLABLE:
                 return $visitor->visitUnionTypeCallable($this->node);
             case \ast\flags\TYPE_DOUBLE:
@@ -493,9 +493,9 @@ class Element
     {
         switch ($this->node->flags) {
             case \ast\flags\UNARY_BITWISE_NOT:
-            return $visitor->visitUnaryBitwiseNot($this->node);
+                return $visitor->visitUnaryBitwiseNot($this->node);
             case \ast\flags\UNARY_BOOL_NOT:
-            return $visitor->visitUnaryBoolNot($this->node);
+                return $visitor->visitUnaryBoolNot($this->node);
             case \ast\flags\UNARY_MINUS:
                 return $visitor->visitUnaryMinus($this->node);
             case \ast\flags\UNARY_PLUS:
@@ -522,9 +522,9 @@ class Element
     {
         switch ($this->node->flags) {
             case \ast\flags\EXEC_EVAL:
-            return $visitor->visitExecEval($this->node);
+                return $visitor->visitExecEval($this->node);
             case \ast\flags\EXEC_INCLUDE:
-            return $visitor->visitExecInclude($this->node);
+                return $visitor->visitExecInclude($this->node);
             case \ast\flags\EXEC_INCLUDE_ONCE:
                 return $visitor->visitExecIncludeOnce($this->node);
             case \ast\flags\EXEC_REQUIRE:
@@ -551,9 +551,9 @@ class Element
     {
         switch ($this->node->flags) {
             case \ast\flags\MAGIC_CLASS:
-            return $visitor->visitMagicClass($this->node);
+                return $visitor->visitMagicClass($this->node);
             case \ast\flags\MAGIC_DIR:
-            return $visitor->visitMagicDir($this->node);
+                return $visitor->visitMagicDir($this->node);
             case \ast\flags\MAGIC_FILE:
                 return $visitor->visitMagicFile($this->node);
             case \ast\flags\MAGIC_FUNCTION:
@@ -586,9 +586,9 @@ class Element
     {
         switch ($this->node->flags) {
             case \ast\flags\USE_CONST:
-            return $visitor->visitUseConst($this->node);
+                return $visitor->visitUseConst($this->node);
             case \ast\flags\USE_FUNCTION:
-            return $visitor->visitUseFunction($this->node);
+                return $visitor->visitUseFunction($this->node);
             case \ast\flags\USE_NORMAL:
                 return $visitor->visitUseNormal($this->node);
             default:
@@ -611,9 +611,9 @@ class Element
     {
         switch ($this->node->flags) {
             case \ast\flags\ASSIGN_ADD:
-            return $visitor->visitAssignAdd($this->node);
+                return $visitor->visitAssignAdd($this->node);
             case \ast\flags\ASSIGN_BITWISE_AND:
-            return $visitor->visitAssignBitwiseAnd($this->node);
+                return $visitor->visitAssignBitwiseAnd($this->node);
             case \ast\flags\ASSIGN_BITWISE_OR:
                 return $visitor->visitAssignBitwiseOr($this->node);
             case \ast\flags\ASSIGN_BITWISE_XOR:

--- a/src/Phan/AST/Visitor/Element.php
+++ b/src/Phan/AST/Visitor/Element.php
@@ -4,7 +4,8 @@ namespace Phan\AST\Visitor;
 use \Phan\Debug;
 use \ast\Node;
 
-class Element {
+class Element
+{
     use \Phan\Profile;
 
     /**
@@ -16,7 +17,8 @@ class Element {
      * @param Node $node
      * Any AST node.
      */
-    public function __construct(Node $node) {
+    public function __construct(Node $node)
+    {
         $this->node = $node;
     }
 
@@ -24,208 +26,209 @@ class Element {
      * Accepts a visitor that differentiates on the kind value
      * of the AST node.
      */
-    public function acceptKindVisitor(KindVisitor $visitor) {
+    public function acceptKindVisitor(KindVisitor $visitor)
+    {
         switch ($this->node->kind) {
-        case \ast\AST_ARG_LIST:
-            return $visitor->visitArgList($this->node);
-        case \ast\AST_ARRAY:
-            return $visitor->visitArray($this->node);
-        case \ast\AST_ARRAY_ELEM:
-            return $visitor->visitArrayElem($this->node);
-        case \ast\AST_ASSIGN:
-            return $visitor->visitAssign($this->node);
-        case \ast\AST_ASSIGN_OP:
-            return $visitor->visitAssignOp($this->node);
-        case \ast\AST_ASSIGN_REF:
-            return $visitor->visitAssignRef($this->node);
-        case \ast\AST_BINARY_OP:
-            return $visitor->visitBinaryOp($this->node);
-        case \ast\AST_BREAK:
-            return $visitor->visitBreak($this->node);
-        case \ast\AST_CALL:
-            return $visitor->visitCall($this->node);
-        case \ast\AST_CAST:
-            return $visitor->visitCast($this->node);
-        case \ast\AST_CATCH:
-            return $visitor->visitCatch($this->node);
-        case \ast\AST_CLASS:
-            return $visitor->visitClass($this->node);
-        case \ast\AST_CLASS_CONST:
-            return $visitor->visitClassConst($this->node);
-        case \ast\AST_CLASS_CONST_DECL:
-            return $visitor->visitClassConstDecl($this->node);
-        case \ast\AST_CLOSURE:
-            return $visitor->visitClosure($this->node);
-        case \ast\AST_CLOSURE_USES:
-            return $visitor->visitClosureUses($this->node);
-        case \ast\AST_CLOSURE_VAR:
-            return $visitor->visitClosureVar($this->node);
-        case \ast\AST_COALESCE:
-            return $visitor->visitCoalesce($this->node);
-        case \ast\AST_CONST:
-            return $visitor->visitConst($this->node);
-        case \ast\AST_CONST_DECL:
-            return $visitor->visitConstDecl($this->node);
-        case \ast\AST_CONST_ELEM:
-            return $visitor->visitConstElem($this->node);
-        case \ast\AST_DECLARE:
-            return $visitor->visitDeclare($this->node);
-        case \ast\AST_DIM:
-            return $visitor->visitDim($this->node);
-        case \ast\AST_DO_WHILE:
-            return $visitor->visitDoWhile($this->node);
-        case \ast\AST_ECHO:
-            return $visitor->visitEcho($this->node);
-        case \ast\AST_EMPTY:
-            return $visitor->visitEmpty($this->node);
-        case \ast\AST_ENCAPS_LIST:
-            return $visitor->visitEncapsList($this->node);
-        case \ast\AST_EXIT:
-            return $visitor->visitExit($this->node);
-        case \ast\AST_EXPR_LIST:
-            return $visitor->visitExprList($this->node);
-        case \ast\AST_FOREACH:
-            return $visitor->visitForeach($this->node);
-        case \ast\AST_FUNC_DECL:
-            return $visitor->visitFuncDecl($this->node);
-        case \ast\AST_ISSET:
-            return $visitor->visitIsset($this->node);
-        case \ast\AST_GLOBAL:
-            return $visitor->visitGlobal($this->node);
-        case \ast\AST_GREATER:
-            return $visitor->visitGreater($this->node);
-        case \ast\AST_GREATER_EQUAL:
-            return $visitor->visitGreaterEqual($this->node);
-        case \ast\AST_GROUP_USE:
-            return $visitor->visitGroupUse($this->node);
-        case \ast\AST_IF:
-            return $visitor->visitIf($this->node);
-        case \ast\AST_IF_ELEM:
-            return $visitor->visitIfElem($this->node);
-        case \ast\AST_INSTANCEOF:
-            return $visitor->visitInstanceof($this->node);
-        case \ast\AST_LIST:
-            return $visitor->visitList($this->node);
-        case \ast\AST_MAGIC_CONST:
-            return $visitor->visitMagicConst($this->node);
-        case \ast\AST_METHOD:
-            return $visitor->visitMethod($this->node);
-        case \ast\AST_METHOD_CALL:
-            return $visitor->visitMethodCall($this->node);
-        case \ast\AST_NAME:
-            return $visitor->visitName($this->node);
-        case \ast\AST_NAMESPACE:
-            return $visitor->visitNamespace($this->node);
-        case \ast\AST_NEW:
-            return $visitor->visitNew($this->node);
-        case \ast\AST_PARAM:
-            return $visitor->visitParam($this->node);
-        case \ast\AST_PARAM_LIST:
-            return $visitor->visitParamList($this->node);
-        case \ast\AST_PRE_INC:
-            return $visitor->visitPreInc($this->node);
-        case \ast\AST_PRINT:
-            return $visitor->visitPrint($this->node);
-        case \ast\AST_PROP:
-            return $visitor->visitProp($this->node);
-        case \ast\AST_PROP_DECL:
-            return $visitor->visitPropDecl($this->node);
-        case \ast\AST_PROP_ELEM:
-            return $visitor->visitPropElem($this->node);
-        case \ast\AST_RETURN:
-            return $visitor->visitReturn($this->node);
-        case \ast\AST_STATIC:
-            return $visitor->visitStatic($this->node);
-        case \ast\AST_STATIC_CALL:
-            return $visitor->visitStaticCall($this->node);
-        case \ast\AST_STATIC_PROP:
-            return $visitor->visitStaticProp($this->node);
-        case \ast\AST_STMT_LIST:
-            return $visitor->visitStmtList($this->node);
-        case \ast\AST_SWITCH:
-            return $visitor->visitSwitch($this->node);
-        case \ast\AST_SWITCH_CASE:
-            return $visitor->visitSwitchCase($this->node);
-        case \ast\AST_SWITCH_LIST:
-            return $visitor->visitSwitchList($this->node);
-        case \ast\AST_TYPE:
-            return $visitor->visitType($this->node);
-        case \ast\AST_UNARY_MINUS:
-            return $visitor->visitUnaryMinus($this->node);
-        case \ast\AST_UNARY_OP:
-            return $visitor->visitUnaryOp($this->node);
-        case \ast\AST_USE:
-            return $visitor->visitUse($this->node);
-        case \ast\AST_USE_ELEM:
-            return $visitor->visitUseElem($this->node);
-        case \ast\AST_USE_TRAIT:
-            return $visitor->visitUseTrait($this->node);
-        case \ast\AST_VAR:
-            return $visitor->visitVar($this->node);
-        case \ast\AST_WHILE:
-            return $visitor->visitWhile($this->node);
-        case \ast\AST_AND:
-            return $visitor->visitAnd($this->node);
-        case \ast\AST_CATCH_LIST:
-            return $visitor->visitCatchList($this->node);
-        case \ast\AST_CLONE:
-            return $visitor->visitClone($this->node);
-        case \ast\AST_CONDITIONAL:
-            return $visitor->visitConditional($this->node);
-        case \ast\AST_CONTINUE:
-            return $visitor->visitContinue($this->node);
-        case \ast\AST_FOR:
-            return $visitor->visitFor($this->node);
-        case \ast\AST_GOTO:
-            return $visitor->visitGoto($this->node);
-        case \ast\AST_HALT_COMPILER:
-            return $visitor->visitHaltCompiler($this->node);
-        case \ast\AST_INCLUDE_OR_EVAL:
-            return $visitor->visitIncludeOrEval($this->node);
-        case \ast\AST_LABEL:
-            return $visitor->visitLabel($this->node);
-        case \ast\AST_METHOD_REFERENCE:
-            return $visitor->visitMethodReference($this->node);
-        case \ast\AST_NAME_LIST:
-            return $visitor->visitNameList($this->node);
-        case \ast\AST_OR:
-            return $visitor->visitOr($this->node);
-        case \ast\AST_POST_DEC:
-            return $visitor->visitPostDec($this->node);
-        case \ast\AST_POST_INC:
-            return $visitor->visitPostInc($this->node);
-        case \ast\AST_PRE_DEC:
-            return $visitor->visitPreDec($this->node);
-        case \ast\AST_REF:
-            return $visitor->visitRef($this->node);
-        case \ast\AST_SHELL_EXEC:
-            return $visitor->visitShellExec($this->node);
-        case \ast\AST_SILENCE:
-            return $visitor->visitSilence($this->node);
-        case \ast\AST_THROW:
-            return $visitor->visitThrow($this->node);
-        case \ast\AST_TRAIT_ADAPTATIONS:
-            return $visitor->visitTraitAdaptations($this->node);
-        case \ast\AST_TRAIT_ALIAS:
-            return $visitor->visitTraitAlias($this->node);
-        case \ast\AST_TRAIT_PRECEDENCE:
-            return $visitor->visitTraitPrecedence($this->node);
-        case \ast\AST_TRY:
-            return $visitor->visitTry($this->node);
-        case \ast\AST_UNARY_PLUS:
-            return $visitor->visitUnaryPlus($this->node);
-        case \ast\AST_UNPACK:
-            return $visitor->visitUnpack($this->node);
-        case \ast\AST_UNSET:
-            return $visitor->visitUnset($this->node);
-        case \ast\AST_YIELD:
-            return $visitor->visitYield($this->node);
-        case \ast\AST_YIELD_FROM:
-            return $visitor->visitYieldFrom($this->node);
-        default:
-            Debug::printNode($this->node);
-            assert(false, 'All node kinds must match');
-            break;
+            case \ast\AST_ARG_LIST:
+                return $visitor->visitArgList($this->node);
+            case \ast\AST_ARRAY:
+                return $visitor->visitArray($this->node);
+            case \ast\AST_ARRAY_ELEM:
+                return $visitor->visitArrayElem($this->node);
+            case \ast\AST_ASSIGN:
+                return $visitor->visitAssign($this->node);
+            case \ast\AST_ASSIGN_OP:
+                return $visitor->visitAssignOp($this->node);
+            case \ast\AST_ASSIGN_REF:
+                return $visitor->visitAssignRef($this->node);
+            case \ast\AST_BINARY_OP:
+                return $visitor->visitBinaryOp($this->node);
+            case \ast\AST_BREAK:
+                return $visitor->visitBreak($this->node);
+            case \ast\AST_CALL:
+                return $visitor->visitCall($this->node);
+            case \ast\AST_CAST:
+                return $visitor->visitCast($this->node);
+            case \ast\AST_CATCH:
+                return $visitor->visitCatch($this->node);
+            case \ast\AST_CLASS:
+                return $visitor->visitClass($this->node);
+            case \ast\AST_CLASS_CONST:
+                return $visitor->visitClassConst($this->node);
+            case \ast\AST_CLASS_CONST_DECL:
+                return $visitor->visitClassConstDecl($this->node);
+            case \ast\AST_CLOSURE:
+                return $visitor->visitClosure($this->node);
+            case \ast\AST_CLOSURE_USES:
+                return $visitor->visitClosureUses($this->node);
+            case \ast\AST_CLOSURE_VAR:
+                return $visitor->visitClosureVar($this->node);
+            case \ast\AST_COALESCE:
+                return $visitor->visitCoalesce($this->node);
+            case \ast\AST_CONST:
+                return $visitor->visitConst($this->node);
+            case \ast\AST_CONST_DECL:
+                return $visitor->visitConstDecl($this->node);
+            case \ast\AST_CONST_ELEM:
+                return $visitor->visitConstElem($this->node);
+            case \ast\AST_DECLARE:
+                return $visitor->visitDeclare($this->node);
+            case \ast\AST_DIM:
+                return $visitor->visitDim($this->node);
+            case \ast\AST_DO_WHILE:
+                return $visitor->visitDoWhile($this->node);
+            case \ast\AST_ECHO:
+                return $visitor->visitEcho($this->node);
+            case \ast\AST_EMPTY:
+                return $visitor->visitEmpty($this->node);
+            case \ast\AST_ENCAPS_LIST:
+                return $visitor->visitEncapsList($this->node);
+            case \ast\AST_EXIT:
+                return $visitor->visitExit($this->node);
+            case \ast\AST_EXPR_LIST:
+                return $visitor->visitExprList($this->node);
+            case \ast\AST_FOREACH:
+                return $visitor->visitForeach($this->node);
+            case \ast\AST_FUNC_DECL:
+                return $visitor->visitFuncDecl($this->node);
+            case \ast\AST_ISSET:
+                return $visitor->visitIsset($this->node);
+            case \ast\AST_GLOBAL:
+                return $visitor->visitGlobal($this->node);
+            case \ast\AST_GREATER:
+                return $visitor->visitGreater($this->node);
+            case \ast\AST_GREATER_EQUAL:
+                return $visitor->visitGreaterEqual($this->node);
+            case \ast\AST_GROUP_USE:
+                return $visitor->visitGroupUse($this->node);
+            case \ast\AST_IF:
+                return $visitor->visitIf($this->node);
+            case \ast\AST_IF_ELEM:
+                return $visitor->visitIfElem($this->node);
+            case \ast\AST_INSTANCEOF:
+                return $visitor->visitInstanceof($this->node);
+            case \ast\AST_LIST:
+                return $visitor->visitList($this->node);
+            case \ast\AST_MAGIC_CONST:
+                return $visitor->visitMagicConst($this->node);
+            case \ast\AST_METHOD:
+                return $visitor->visitMethod($this->node);
+            case \ast\AST_METHOD_CALL:
+                return $visitor->visitMethodCall($this->node);
+            case \ast\AST_NAME:
+                return $visitor->visitName($this->node);
+            case \ast\AST_NAMESPACE:
+                return $visitor->visitNamespace($this->node);
+            case \ast\AST_NEW:
+                return $visitor->visitNew($this->node);
+            case \ast\AST_PARAM:
+                return $visitor->visitParam($this->node);
+            case \ast\AST_PARAM_LIST:
+                return $visitor->visitParamList($this->node);
+            case \ast\AST_PRE_INC:
+                return $visitor->visitPreInc($this->node);
+            case \ast\AST_PRINT:
+                return $visitor->visitPrint($this->node);
+            case \ast\AST_PROP:
+                return $visitor->visitProp($this->node);
+            case \ast\AST_PROP_DECL:
+                return $visitor->visitPropDecl($this->node);
+            case \ast\AST_PROP_ELEM:
+                return $visitor->visitPropElem($this->node);
+            case \ast\AST_RETURN:
+                return $visitor->visitReturn($this->node);
+            case \ast\AST_STATIC:
+                return $visitor->visitStatic($this->node);
+            case \ast\AST_STATIC_CALL:
+                return $visitor->visitStaticCall($this->node);
+            case \ast\AST_STATIC_PROP:
+                return $visitor->visitStaticProp($this->node);
+            case \ast\AST_STMT_LIST:
+                return $visitor->visitStmtList($this->node);
+            case \ast\AST_SWITCH:
+                return $visitor->visitSwitch($this->node);
+            case \ast\AST_SWITCH_CASE:
+                return $visitor->visitSwitchCase($this->node);
+            case \ast\AST_SWITCH_LIST:
+                return $visitor->visitSwitchList($this->node);
+            case \ast\AST_TYPE:
+                return $visitor->visitType($this->node);
+            case \ast\AST_UNARY_MINUS:
+                return $visitor->visitUnaryMinus($this->node);
+            case \ast\AST_UNARY_OP:
+                return $visitor->visitUnaryOp($this->node);
+            case \ast\AST_USE:
+                return $visitor->visitUse($this->node);
+            case \ast\AST_USE_ELEM:
+                return $visitor->visitUseElem($this->node);
+            case \ast\AST_USE_TRAIT:
+                return $visitor->visitUseTrait($this->node);
+            case \ast\AST_VAR:
+                return $visitor->visitVar($this->node);
+            case \ast\AST_WHILE:
+                return $visitor->visitWhile($this->node);
+            case \ast\AST_AND:
+                return $visitor->visitAnd($this->node);
+            case \ast\AST_CATCH_LIST:
+                return $visitor->visitCatchList($this->node);
+            case \ast\AST_CLONE:
+                return $visitor->visitClone($this->node);
+            case \ast\AST_CONDITIONAL:
+                return $visitor->visitConditional($this->node);
+            case \ast\AST_CONTINUE:
+                return $visitor->visitContinue($this->node);
+            case \ast\AST_FOR:
+                return $visitor->visitFor($this->node);
+            case \ast\AST_GOTO:
+                return $visitor->visitGoto($this->node);
+            case \ast\AST_HALT_COMPILER:
+                return $visitor->visitHaltCompiler($this->node);
+            case \ast\AST_INCLUDE_OR_EVAL:
+                return $visitor->visitIncludeOrEval($this->node);
+            case \ast\AST_LABEL:
+                return $visitor->visitLabel($this->node);
+            case \ast\AST_METHOD_REFERENCE:
+                return $visitor->visitMethodReference($this->node);
+            case \ast\AST_NAME_LIST:
+                return $visitor->visitNameList($this->node);
+            case \ast\AST_OR:
+                return $visitor->visitOr($this->node);
+            case \ast\AST_POST_DEC:
+                return $visitor->visitPostDec($this->node);
+            case \ast\AST_POST_INC:
+                return $visitor->visitPostInc($this->node);
+            case \ast\AST_PRE_DEC:
+                return $visitor->visitPreDec($this->node);
+            case \ast\AST_REF:
+                return $visitor->visitRef($this->node);
+            case \ast\AST_SHELL_EXEC:
+                return $visitor->visitShellExec($this->node);
+            case \ast\AST_SILENCE:
+                return $visitor->visitSilence($this->node);
+            case \ast\AST_THROW:
+                return $visitor->visitThrow($this->node);
+            case \ast\AST_TRAIT_ADAPTATIONS:
+                return $visitor->visitTraitAdaptations($this->node);
+            case \ast\AST_TRAIT_ALIAS:
+                return $visitor->visitTraitAlias($this->node);
+            case \ast\AST_TRAIT_PRECEDENCE:
+                return $visitor->visitTraitPrecedence($this->node);
+            case \ast\AST_TRY:
+                return $visitor->visitTry($this->node);
+            case \ast\AST_UNARY_PLUS:
+                return $visitor->visitUnaryPlus($this->node);
+            case \ast\AST_UNPACK:
+                return $visitor->visitUnpack($this->node);
+            case \ast\AST_UNSET:
+                return $visitor->visitUnset($this->node);
+            case \ast\AST_YIELD:
+                return $visitor->visitYield($this->node);
+            case \ast\AST_YIELD_FROM:
+                return $visitor->visitYieldFrom($this->node);
+            default:
+                Debug::printNode($this->node);
+                assert(false, 'All node kinds must match');
+                break;
         }
     }
 
@@ -235,37 +238,40 @@ class Element {
      *
      * @suppress PhanUnreferencedMethod
      */
-    public function acceptAssignFlagVisitor(FlagVisitor $visitor) {
+    public function acceptAssignFlagVisitor(FlagVisitor $visitor)
+    {
         switch ($this->node->flags) {
-        case \ast\flags\ASSIGN_ADD:
-            return $visitor->visitAssignAdd($this->node);
-        case \ast\flags\ASSIGN_BITWISE_AND:
-            return $visitor->visitAssignBitwiseAnd($this->node);
-        case \ast\flags\ASSIGN_BITWISE_OR:
-            return $visitor->visitAssignBitwiseOr($this->node);
-        case \ast\flags\ASSIGN_BITWISE_XOR:
-            return $visitor->visitAssignBitwiseXor($this->node);
-        case \ast\flags\ASSIGN_CONCAT:
-            return $visitor->visitAssignConcat($this->node);
-        case \ast\flags\ASSIGN_DIV:
-            return $visitor->visitAssignDiv($this->node);
-        case \ast\flags\ASSIGN_MOD:
-            return $visitor->visitAssignMod($this->node);
-        case \ast\flags\ASSIGN_MUL:
-            return $visitor->visitAssignMul($this->node);
-        case \ast\flags\ASSIGN_POW:
-            return $visitor->visitAssignPow($this->node);
-        case \ast\flags\ASSIGN_SHIFT_LEFT:
-            return $visitor->visitAssignShiftLeft($this->node);
-        case \ast\flags\ASSIGN_SHIFT_RIGHT:
-            return $visitor->visitAssignShiftRight($this->node);
-        case \ast\flags\ASSIGN_SUB:
-            return $visitor->visitAssignSub($this->node);
-        default:
-            assert(false,
-                "All flags must match. Found "
-                . Debug::astFlagDescription($this->node->flags ?? 0));
-            break;
+            case \ast\flags\ASSIGN_ADD:
+                return $visitor->visitAssignAdd($this->node);
+            case \ast\flags\ASSIGN_BITWISE_AND:
+                return $visitor->visitAssignBitwiseAnd($this->node);
+            case \ast\flags\ASSIGN_BITWISE_OR:
+                return $visitor->visitAssignBitwiseOr($this->node);
+            case \ast\flags\ASSIGN_BITWISE_XOR:
+                return $visitor->visitAssignBitwiseXor($this->node);
+            case \ast\flags\ASSIGN_CONCAT:
+                return $visitor->visitAssignConcat($this->node);
+            case \ast\flags\ASSIGN_DIV:
+                return $visitor->visitAssignDiv($this->node);
+            case \ast\flags\ASSIGN_MOD:
+                return $visitor->visitAssignMod($this->node);
+            case \ast\flags\ASSIGN_MUL:
+                return $visitor->visitAssignMul($this->node);
+            case \ast\flags\ASSIGN_POW:
+                return $visitor->visitAssignPow($this->node);
+            case \ast\flags\ASSIGN_SHIFT_LEFT:
+                return $visitor->visitAssignShiftLeft($this->node);
+            case \ast\flags\ASSIGN_SHIFT_RIGHT:
+                return $visitor->visitAssignShiftRight($this->node);
+            case \ast\flags\ASSIGN_SUB:
+                return $visitor->visitAssignSub($this->node);
+            default:
+                assert(
+                    false,
+                    "All flags must match. Found "
+                    . Debug::astFlagDescription($this->node->flags ?? 0)
+                );
+                break;
         }
     }
 
@@ -273,61 +279,64 @@ class Element {
      * Accepts a visitor that differentiates on the flag value
      * of the AST node.
      */
-    public function acceptBinaryFlagVisitor(FlagVisitor $visitor) {
+    public function acceptBinaryFlagVisitor(FlagVisitor $visitor)
+    {
         switch ($this->node->flags ?? 0) {
-        case \ast\flags\BINARY_ADD:
+            case \ast\flags\BINARY_ADD:
             return $visitor->visitBinaryAdd($this->node);
-        case \ast\flags\BINARY_BITWISE_AND:
-            return $visitor->visitBinaryBitwiseAnd($this->node);
-        case \ast\flags\BINARY_BITWISE_OR:
-            return $visitor->visitBinaryBitwiseOr($this->node);
-        case \ast\flags\BINARY_BITWISE_XOR:
+                case \ast\flags\BINARY_BITWISE_AND:
+                return $visitor->visitBinaryBitwiseAnd($this->node);
+                    case \ast\flags\BINARY_BITWISE_OR:
+                    return $visitor->visitBinaryBitwiseOr($this->node);
+            case \ast\flags\BINARY_BITWISE_XOR:
             return $visitor->visitBinaryBitwiseXor($this->node);
-        case \ast\flags\BINARY_BOOL_XOR:
-            return $visitor->visitBinaryBoolXor($this->node);
-        case \ast\flags\BINARY_CONCAT:
-            return $visitor->visitBinaryConcat($this->node);
-        case \ast\flags\BINARY_DIV:
-            return $visitor->visitBinaryDiv($this->node);
-        case \ast\flags\BINARY_IS_EQUAL:
-            return $visitor->visitBinaryIsEqual($this->node);
-        case \ast\flags\BINARY_IS_IDENTICAL:
-            return $visitor->visitBinaryIsIdentical($this->node);
-        case \ast\flags\BINARY_IS_NOT_EQUAL:
-            return $visitor->visitBinaryIsNotEqual($this->node);
-        case \ast\flags\BINARY_IS_NOT_IDENTICAL:
-            return $visitor->visitBinaryIsNotIdentical($this->node);
-        case \ast\flags\BINARY_IS_SMALLER:
-            return $visitor->visitBinaryIsSmaller($this->node);
-        case \ast\flags\BINARY_IS_SMALLER_OR_EQUAL:
-            return $visitor->visitBinaryIsSmallerOrEqual($this->node);
-        case \ast\flags\BINARY_MOD:
-            return $visitor->visitBinaryMod($this->node);
-        case \ast\flags\BINARY_MUL:
-            return $visitor->visitBinaryMul($this->node);
-        case \ast\flags\BINARY_POW:
-            return $visitor->visitBinaryPow($this->node);
-        case \ast\flags\BINARY_SHIFT_LEFT:
-            return $visitor->visitBinaryShiftLeft($this->node);
-        case \ast\flags\BINARY_SHIFT_RIGHT:
-            return $visitor->visitBinaryShiftRight($this->node);
-        case \ast\flags\BINARY_SPACESHIP:
-            return $visitor->visitBinarySpaceship($this->node);
-        case \ast\flags\BINARY_SUB:
-            return $visitor->visitBinarySub($this->node);
-        case \ast\flags\BINARY_BOOL_AND:
-            return $visitor->visitBinaryBoolAnd($this->node);
-        case \ast\flags\BINARY_BOOL_OR:
-            return $visitor->visitBinaryBoolOr($this->node);
-        case \ast\flags\BINARY_IS_GREATER:
-            return $visitor->visitBinaryIsGreater($this->node);
-        case \ast\flags\BINARY_IS_GREATER_OR_EQUAL:
-            return $visitor->visitBinaryIsGreaterOrEqual($this->node);
-        default:
-            assert(false,
-                "All flags must match. Found "
-                . Debug::astFlagDescription($this->node->flags ?? 0));
-            break;
+                case \ast\flags\BINARY_BOOL_XOR:
+                return $visitor->visitBinaryBoolXor($this->node);
+                    case \ast\flags\BINARY_CONCAT:
+                return $visitor->visitBinaryConcat($this->node);
+                    case \ast\flags\BINARY_DIV:
+                return $visitor->visitBinaryDiv($this->node);
+                    case \ast\flags\BINARY_IS_EQUAL:
+                return $visitor->visitBinaryIsEqual($this->node);
+                    case \ast\flags\BINARY_IS_IDENTICAL:
+                return $visitor->visitBinaryIsIdentical($this->node);
+                    case \ast\flags\BINARY_IS_NOT_EQUAL:
+                return $visitor->visitBinaryIsNotEqual($this->node);
+                    case \ast\flags\BINARY_IS_NOT_IDENTICAL:
+                return $visitor->visitBinaryIsNotIdentical($this->node);
+                    case \ast\flags\BINARY_IS_SMALLER:
+                return $visitor->visitBinaryIsSmaller($this->node);
+                    case \ast\flags\BINARY_IS_SMALLER_OR_EQUAL:
+                return $visitor->visitBinaryIsSmallerOrEqual($this->node);
+                    case \ast\flags\BINARY_MOD:
+                return $visitor->visitBinaryMod($this->node);
+                    case \ast\flags\BINARY_MUL:
+                return $visitor->visitBinaryMul($this->node);
+                    case \ast\flags\BINARY_POW:
+                return $visitor->visitBinaryPow($this->node);
+                    case \ast\flags\BINARY_SHIFT_LEFT:
+                return $visitor->visitBinaryShiftLeft($this->node);
+                    case \ast\flags\BINARY_SHIFT_RIGHT:
+                return $visitor->visitBinaryShiftRight($this->node);
+                    case \ast\flags\BINARY_SPACESHIP:
+                return $visitor->visitBinarySpaceship($this->node);
+                    case \ast\flags\BINARY_SUB:
+                return $visitor->visitBinarySub($this->node);
+                    case \ast\flags\BINARY_BOOL_AND:
+                return $visitor->visitBinaryBoolAnd($this->node);
+                    case \ast\flags\BINARY_BOOL_OR:
+                return $visitor->visitBinaryBoolOr($this->node);
+                    case \ast\flags\BINARY_IS_GREATER:
+                return $visitor->visitBinaryIsGreater($this->node);
+                    case \ast\flags\BINARY_IS_GREATER_OR_EQUAL:
+                return $visitor->visitBinaryIsGreaterOrEqual($this->node);
+                    default:
+                        assert(
+                            false,
+                            "All flags must match. Found "
+                            . Debug::astFlagDescription($this->node->flags ?? 0)
+                        );
+                break;
         }
     }
 
@@ -337,23 +346,26 @@ class Element {
      *
      * @suppress PhanUnreferencedMethod
      */
-    public function acceptClassFlagVisitor(FlagVisitor $visitor) {
+    public function acceptClassFlagVisitor(FlagVisitor $visitor)
+    {
         switch ($this->node->flags) {
-        case \ast\flags\CLASS_ABSTRACT:
+            case \ast\flags\CLASS_ABSTRACT:
             return $visitor->visitClassAbstract($this->node);
-        case \ast\flags\CLASS_FINAL:
+            case \ast\flags\CLASS_FINAL:
             return $visitor->visitClassFinal($this->node);
-        case \ast\flags\CLASS_INTERFACE:
-            return $visitor->visitClassInterface($this->node);
-        case \ast\flags\CLASS_TRAIT:
-            return $visitor->visitClassTrait($this->node);
-        case \ast\flags\CLASS_ANONYMOUS:
-            return $visitor->visitClassAnonymous($this->node);
-        default:
-            assert(false,
-                "All flags must match. Found "
-                . Debug::astFlagDescription($this->node->flags ?? 0));
-            break;
+            case \ast\flags\CLASS_INTERFACE:
+                return $visitor->visitClassInterface($this->node);
+            case \ast\flags\CLASS_TRAIT:
+                return $visitor->visitClassTrait($this->node);
+            case \ast\flags\CLASS_ANONYMOUS:
+                return $visitor->visitClassAnonymous($this->node);
+            default:
+                assert(
+                    false,
+                    "All flags must match. Found "
+                    . Debug::astFlagDescription($this->node->flags ?? 0)
+                );
+                break;
         }
     }
 
@@ -363,25 +375,28 @@ class Element {
      *
      * @suppress PhanUnreferencedMethod
      */
-    public function acceptModifierFlagVisitor(FlagVisitor $visitor) {
+    public function acceptModifierFlagVisitor(FlagVisitor $visitor)
+    {
         switch ($this->node->flags) {
-        case \ast\flags\MODIFIER_ABSTRACT:
+            case \ast\flags\MODIFIER_ABSTRACT:
             return $visitor->visitModifierAbstract($this->node);
-        case \ast\flags\MODIFIER_FINAL:
+            case \ast\flags\MODIFIER_FINAL:
             return $visitor->visitModifierFinal($this->node);
-        case \ast\flags\MODIFIER_PRIVATE:
-            return $visitor->visitModifierPrivate($this->node);
-        case \ast\flags\MODIFIER_PROTECTED:
-            return $visitor->visitModifierProtected($this->node);
-        case \ast\flags\MODIFIER_PUBLIC:
-            return $visitor->visitModifierPublic($this->node);
-        case \ast\flags\MODIFIER_STATIC:
-            return $visitor->visitModifierStatic($this->node);
-        default:
-            assert(false,
-                "All flags must match. Found "
-                . Debug::astFlagDescription($this->node->flags ?? 0));
-            break;
+            case \ast\flags\MODIFIER_PRIVATE:
+                return $visitor->visitModifierPrivate($this->node);
+            case \ast\flags\MODIFIER_PROTECTED:
+                return $visitor->visitModifierProtected($this->node);
+            case \ast\flags\MODIFIER_PUBLIC:
+                return $visitor->visitModifierPublic($this->node);
+            case \ast\flags\MODIFIER_STATIC:
+                return $visitor->visitModifierStatic($this->node);
+            default:
+                assert(
+                    false,
+                    "All flags must match. Found "
+                    . Debug::astFlagDescription($this->node->flags ?? 0)
+                );
+                break;
         }
     }
 
@@ -391,19 +406,22 @@ class Element {
      *
      * @suppress PhanUnreferencedMethod
      */
-    public function acceptNameFlagVisitor(FlagVisitor $visitor) {
+    public function acceptNameFlagVisitor(FlagVisitor $visitor)
+    {
         switch ($this->node->flags) {
-        case \ast\flags\NAME_FQ:
+            case \ast\flags\NAME_FQ:
             return $visitor->visitNameFq($this->node);
-        case \ast\flags\NAME_NOT_FQ:
+            case \ast\flags\NAME_NOT_FQ:
             return $visitor->visitNameNotFq($this->node);
-        case \ast\flags\NAME_RELATIVE:
-            return $visitor->visitNameRelative($this->node);
-        default:
-            assert(false,
-                "All flags must match. Found "
-                . Debug::astFlagDescription($this->node->flags ?? 0));
-            break;
+            case \ast\flags\NAME_RELATIVE:
+                return $visitor->visitNameRelative($this->node);
+            default:
+                assert(
+                    false,
+                    "All flags must match. Found "
+                    . Debug::astFlagDescription($this->node->flags ?? 0)
+                );
+                break;
         }
     }
 
@@ -413,17 +431,20 @@ class Element {
      *
      * @suppress PhanUnreferencedMethod
      */
-    public function acceptParamFlagVisitor(FlagVisitor $visitor) {
+    public function acceptParamFlagVisitor(FlagVisitor $visitor)
+    {
         switch ($this->node->flags) {
-        case \ast\flags\PARAM_REF:
+            case \ast\flags\PARAM_REF:
             return $visitor->visitParamRef($this->node);
-        case \ast\flags\PARAM_VARIADIC:
+            case \ast\flags\PARAM_VARIADIC:
             return $visitor->visitParamVariadic($this->node);
-        default:
-            assert(false,
-                "All flags must match. Found "
-                . Debug::astFlagDescription($this->node->flags ?? 0));
-            break;
+            default:
+                assert(
+                    false,
+                    "All flags must match. Found "
+                    . Debug::astFlagDescription($this->node->flags ?? 0)
+                );
+                break;
         }
     }
 
@@ -433,29 +454,32 @@ class Element {
      *
      * @suppress PhanUnreferencedMethod
      */
-    public function acceptTypeFlagVisitor(FlagVisitor $visitor) {
+    public function acceptTypeFlagVisitor(FlagVisitor $visitor)
+    {
         switch ($this->node->flags) {
-        case \ast\flags\TYPE_ARRAY:
+            case \ast\flags\TYPE_ARRAY:
             return $visitor->visitUnionTypeArray($this->node);
-        case \ast\flags\TYPE_BOOL:
+            case \ast\flags\TYPE_BOOL:
             return $visitor->visitUnionTypeBool($this->node);
-        case \ast\flags\TYPE_CALLABLE:
-            return $visitor->visitUnionTypeCallable($this->node);
-        case \ast\flags\TYPE_DOUBLE:
-            return $visitor->visitUnionTypeDouble($this->node);
-        case \ast\flags\TYPE_LONG:
-            return $visitor->visitUnionTypeLong($this->node);
-        case \ast\flags\TYPE_NULL:
-            return $visitor->visitUnionTypeNull($this->node);
-        case \ast\flags\TYPE_OBJECT:
-            return $visitor->visitUnionTypeObject($this->node);
-        case \ast\flags\TYPE_STRING:
-            return $visitor->visitUnionTypeString($this->node);
-        default:
-            assert(false,
-                "All flags must match. Found "
-                . Debug::astFlagDescription($this->node->flags ?? 0));
-            break;
+            case \ast\flags\TYPE_CALLABLE:
+                return $visitor->visitUnionTypeCallable($this->node);
+            case \ast\flags\TYPE_DOUBLE:
+                return $visitor->visitUnionTypeDouble($this->node);
+            case \ast\flags\TYPE_LONG:
+                return $visitor->visitUnionTypeLong($this->node);
+            case \ast\flags\TYPE_NULL:
+                return $visitor->visitUnionTypeNull($this->node);
+            case \ast\flags\TYPE_OBJECT:
+                return $visitor->visitUnionTypeObject($this->node);
+            case \ast\flags\TYPE_STRING:
+                return $visitor->visitUnionTypeString($this->node);
+            default:
+                assert(
+                    false,
+                    "All flags must match. Found "
+                    . Debug::astFlagDescription($this->node->flags ?? 0)
+                );
+                break;
         }
     }
 
@@ -465,23 +489,26 @@ class Element {
      *
      * @suppress PhanUnreferencedMethod
      */
-    public function acceptUnaryFlagVisitor(FlagVisitor $visitor) {
+    public function acceptUnaryFlagVisitor(FlagVisitor $visitor)
+    {
         switch ($this->node->flags) {
-        case \ast\flags\UNARY_BITWISE_NOT:
+            case \ast\flags\UNARY_BITWISE_NOT:
             return $visitor->visitUnaryBitwiseNot($this->node);
-        case \ast\flags\UNARY_BOOL_NOT:
+            case \ast\flags\UNARY_BOOL_NOT:
             return $visitor->visitUnaryBoolNot($this->node);
-        case \ast\flags\UNARY_MINUS:
-            return $visitor->visitUnaryMinus($this->node);
-        case \ast\flags\UNARY_PLUS:
-            return $visitor->visitUnaryPlus($this->node);
-        case \ast\flags\UNARY_SILENCE:
-            return $visitor->visitUnarySilence($this->node);
-        default:
-            assert(false,
-                "All flags must match. Found "
-                . Debug::astFlagDescription($this->node->flags ?? 0));
-            break;
+            case \ast\flags\UNARY_MINUS:
+                return $visitor->visitUnaryMinus($this->node);
+            case \ast\flags\UNARY_PLUS:
+                return $visitor->visitUnaryPlus($this->node);
+            case \ast\flags\UNARY_SILENCE:
+                return $visitor->visitUnarySilence($this->node);
+            default:
+                assert(
+                    false,
+                    "All flags must match. Found "
+                    . Debug::astFlagDescription($this->node->flags ?? 0)
+                );
+                break;
         }
     }
 
@@ -491,23 +518,26 @@ class Element {
      *
      * @suppress PhanUnreferencedMethod
      */
-    public function acceptExecFlagVisitor(FlagVisitor $visitor) {
+    public function acceptExecFlagVisitor(FlagVisitor $visitor)
+    {
         switch ($this->node->flags) {
-        case \ast\flags\EXEC_EVAL:
+            case \ast\flags\EXEC_EVAL:
             return $visitor->visitExecEval($this->node);
-        case \ast\flags\EXEC_INCLUDE:
+            case \ast\flags\EXEC_INCLUDE:
             return $visitor->visitExecInclude($this->node);
-        case \ast\flags\EXEC_INCLUDE_ONCE:
-            return $visitor->visitExecIncludeOnce($this->node);
-        case \ast\flags\EXEC_REQUIRE:
-            return $visitor->visitExecRequire($this->node);
-        case \ast\flags\EXEC_REQUIRE_ONCE:
-            return $visitor->visitExecRequireOnce($this->node);
-        default:
-            assert(false,
-                "All flags must match. Found "
-                . Debug::astFlagDescription($this->node->flags ?? 0));
-            break;
+            case \ast\flags\EXEC_INCLUDE_ONCE:
+                return $visitor->visitExecIncludeOnce($this->node);
+            case \ast\flags\EXEC_REQUIRE:
+                return $visitor->visitExecRequire($this->node);
+            case \ast\flags\EXEC_REQUIRE_ONCE:
+                return $visitor->visitExecRequireOnce($this->node);
+            default:
+                assert(
+                    false,
+                    "All flags must match. Found "
+                    . Debug::astFlagDescription($this->node->flags ?? 0)
+                );
+                break;
         }
     }
 
@@ -517,29 +547,32 @@ class Element {
      *
      * @suppress PhanUnreferencedMethod
      */
-    public function acceptMagicFlagVisitor(FlagVisitor $visitor) {
+    public function acceptMagicFlagVisitor(FlagVisitor $visitor)
+    {
         switch ($this->node->flags) {
-        case \ast\flags\MAGIC_CLASS:
+            case \ast\flags\MAGIC_CLASS:
             return $visitor->visitMagicClass($this->node);
-        case \ast\flags\MAGIC_DIR:
+            case \ast\flags\MAGIC_DIR:
             return $visitor->visitMagicDir($this->node);
-        case \ast\flags\MAGIC_FILE:
-            return $visitor->visitMagicFile($this->node);
-        case \ast\flags\MAGIC_FUNCTION:
-            return $visitor->visitMagicFunction($this->node);
-        case \ast\flags\MAGIC_LINE:
-            return $visitor->visitMagicLine($this->node);
-        case \ast\flags\MAGIC_METHOD:
-            return $visitor->visitMagicMethod($this->node);
-        case \ast\flags\MAGIC_NAMESPACE:
-            return $visitor->visitMagicNamespace($this->node);
-        case \ast\flags\MAGIC_TRAIT:
-            return $visitor->visitMagicTrait($this->node);
-        default:
-            assert(false,
-                "All flags must match. Found "
-                . Debug::astFlagDescription($this->node->flags ?? 0));
-            break;
+            case \ast\flags\MAGIC_FILE:
+                return $visitor->visitMagicFile($this->node);
+            case \ast\flags\MAGIC_FUNCTION:
+                return $visitor->visitMagicFunction($this->node);
+            case \ast\flags\MAGIC_LINE:
+                return $visitor->visitMagicLine($this->node);
+            case \ast\flags\MAGIC_METHOD:
+                return $visitor->visitMagicMethod($this->node);
+            case \ast\flags\MAGIC_NAMESPACE:
+                return $visitor->visitMagicNamespace($this->node);
+            case \ast\flags\MAGIC_TRAIT:
+                return $visitor->visitMagicTrait($this->node);
+            default:
+                assert(
+                    false,
+                    "All flags must match. Found "
+                    . Debug::astFlagDescription($this->node->flags ?? 0)
+                );
+                break;
         }
     }
 
@@ -549,19 +582,22 @@ class Element {
      *
      * @suppress PhanUnreferencedMethod
      */
-    public function acceptUseFlagVisitor(FlagVisitor $visitor) {
+    public function acceptUseFlagVisitor(FlagVisitor $visitor)
+    {
         switch ($this->node->flags) {
-        case \ast\flags\USE_CONST:
+            case \ast\flags\USE_CONST:
             return $visitor->visitUseConst($this->node);
-        case \ast\flags\USE_FUNCTION:
+            case \ast\flags\USE_FUNCTION:
             return $visitor->visitUseFunction($this->node);
-        case \ast\flags\USE_NORMAL:
-            return $visitor->visitUseNormal($this->node);
-        default:
-            assert(false,
-                "All flags must match. Found "
-                . Debug::astFlagDescription($this->node->flags ?? 0));
-            break;
+            case \ast\flags\USE_NORMAL:
+                return $visitor->visitUseNormal($this->node);
+            default:
+                assert(
+                    false,
+                    "All flags must match. Found "
+                    . Debug::astFlagDescription($this->node->flags ?? 0)
+                );
+                break;
         }
     }
 
@@ -571,178 +607,180 @@ class Element {
      *
      * @suppress PhanUnreferencedMethod
      */
-    public function acceptAnyFlagVisitor(FlagVisitor $visitor) {
+    public function acceptAnyFlagVisitor(FlagVisitor $visitor)
+    {
         switch ($this->node->flags) {
-        case \ast\flags\ASSIGN_ADD:
+            case \ast\flags\ASSIGN_ADD:
             return $visitor->visitAssignAdd($this->node);
-        case \ast\flags\ASSIGN_BITWISE_AND:
+            case \ast\flags\ASSIGN_BITWISE_AND:
             return $visitor->visitAssignBitwiseAnd($this->node);
-        case \ast\flags\ASSIGN_BITWISE_OR:
-            return $visitor->visitAssignBitwiseOr($this->node);
-        case \ast\flags\ASSIGN_BITWISE_XOR:
-            return $visitor->visitAssignBitwiseXor($this->node);
-        case \ast\flags\ASSIGN_CONCAT:
-            return $visitor->visitAssignConcat($this->node);
-        case \ast\flags\ASSIGN_DIV:
-            return $visitor->visitAssignDiv($this->node);
-        case \ast\flags\ASSIGN_MOD:
-            return $visitor->visitAssignMod($this->node);
-        case \ast\flags\ASSIGN_MUL:
-            return $visitor->visitAssignMul($this->node);
-        case \ast\flags\ASSIGN_POW:
-            return $visitor->visitAssignPow($this->node);
-        case \ast\flags\ASSIGN_SHIFT_LEFT:
-            return $visitor->visitAssignShiftLeft($this->node);
-        case \ast\flags\ASSIGN_SHIFT_RIGHT:
-            return $visitor->visitAssignShiftRight($this->node);
-        case \ast\flags\ASSIGN_SUB:
-            return $visitor->visitAssignSub($this->node);
-        case \ast\flags\BINARY_ADD:
-            return $visitor->visitBinaryAdd($this->node);
-        case \ast\flags\BINARY_BITWISE_AND:
-            return $visitor->visitBinaryBitwiseAnd($this->node);
-        case \ast\flags\BINARY_BITWISE_OR:
-            return $visitor->visitBinaryBitwiseOr($this->node);
-        case \ast\flags\BINARY_BITWISE_XOR:
-            return $visitor->visitBinaryBitwiseXor($this->node);
-        case \ast\flags\BINARY_BOOL_XOR:
-            return $visitor->visitBinaryBoolXor($this->node);
-        case \ast\flags\BINARY_CONCAT:
-            return $visitor->visitBinaryConcat($this->node);
-        case \ast\flags\BINARY_DIV:
-            return $visitor->visitBinaryDiv($this->node);
-        case \ast\flags\BINARY_IS_EQUAL:
-            return $visitor->visitBinaryIsEqual($this->node);
-        case \ast\flags\BINARY_IS_IDENTICAL:
-            return $visitor->visitBinaryIsIdentical($this->node);
-        case \ast\flags\BINARY_IS_NOT_EQUAL:
-            return $visitor->visitBinaryIsNotEqual($this->node);
-        case \ast\flags\BINARY_IS_NOT_IDENTICAL:
-            return $visitor->visitBinaryIsNotIdentical($this->node);
-        case \ast\flags\BINARY_IS_SMALLER:
-            return $visitor->visitBinaryIsSmaller($this->node);
-        case \ast\flags\BINARY_IS_SMALLER_OR_EQUAL:
-            return $visitor->visitBinaryIsSmallerOrEqual($this->node);
-        case \ast\flags\BINARY_MOD:
-            return $visitor->visitBinaryMod($this->node);
-        case \ast\flags\BINARY_MUL:
-            return $visitor->visitBinaryMul($this->node);
-        case \ast\flags\BINARY_POW:
-            return $visitor->visitBinaryPow($this->node);
-        case \ast\flags\BINARY_SHIFT_LEFT:
-            return $visitor->visitBinaryShiftLeft($this->node);
-        case \ast\flags\BINARY_SHIFT_RIGHT:
-            return $visitor->visitBinaryShiftRight($this->node);
-        case \ast\flags\BINARY_SPACESHIP:
-            return $visitor->visitBinarySpaceship($this->node);
-        case \ast\flags\BINARY_SUB:
-            return $visitor->visitBinarySub($this->node);
-        case \ast\flags\CLASS_ABSTRACT:
-            return $visitor->visitClassAbstract($this->node);
-        case \ast\flags\CLASS_FINAL:
-            return $visitor->visitClassFinal($this->node);
-        case \ast\flags\CLASS_INTERFACE:
-            return $visitor->visitClassInterface($this->node);
-        case \ast\flags\CLASS_TRAIT:
-            return $visitor->visitClassTrait($this->node);
-        case \ast\flags\MODIFIER_ABSTRACT:
-            return $visitor->visitModifierAbstract($this->node);
-        case \ast\flags\MODIFIER_FINAL:
-            return $visitor->visitModifierFinal($this->node);
-        case \ast\flags\MODIFIER_PRIVATE:
-            return $visitor->visitModifierPrivate($this->node);
-        case \ast\flags\MODIFIER_PROTECTED:
-            return $visitor->visitModifierProtected($this->node);
-        case \ast\flags\MODIFIER_PUBLIC:
-            return $visitor->visitModifierPublic($this->node);
-        case \ast\flags\MODIFIER_STATIC:
-            return $visitor->visitModifierStatic($this->node);
-        case \ast\flags\NAME_FQ:
-            return $visitor->visitNameFq($this->node);
-        case \ast\flags\NAME_NOT_FQ:
-            return $visitor->visitNameNotFq($this->node);
-        case \ast\flags\NAME_RELATIVE:
-            return $visitor->visitNameRelative($this->node);
-        case \ast\flags\PARAM_REF:
-            return $visitor->visitParamRef($this->node);
-        case \ast\flags\PARAM_VARIADIC:
-            return $visitor->visitParamVariadic($this->node);
-        case \ast\flags\RETURNS_REF:
-            return $visitor->visitReturnsRef($this->node);
-        case \ast\flags\TYPE_ARRAY:
-            return $visitor->visitUnionTypeArray($this->node);
-        case \ast\flags\TYPE_BOOL:
-            return $visitor->visitUnionTypeBool($this->node);
-        case \ast\flags\TYPE_CALLABLE:
-            return $visitor->visitUnionTypeCallable($this->node);
-        case \ast\flags\TYPE_DOUBLE:
-            return $visitor->visitUnionTypeDouble($this->node);
-        case \ast\flags\TYPE_LONG:
-            return $visitor->visitUnionTypeLong($this->node);
-        case \ast\flags\TYPE_NULL:
-            return $visitor->visitUnionTypeNull($this->node);
-        case \ast\flags\TYPE_OBJECT:
-            return $visitor->visitUnionTypeObject($this->node);
-        case \ast\flags\TYPE_STRING:
-            return $visitor->visitUnionTypeString($this->node);
-        case \ast\flags\UNARY_BITWISE_NOT:
-            return $visitor->visitUnaryBitwiseNot($this->node);
-        case \ast\flags\UNARY_BOOL_NOT:
-            return $visitor->visitUnaryBoolNot($this->node);
-        case \ast\flags\BINARY_BOOL_AND:
-            return $visitor->visitBinaryBoolAnd($this->node);
-        case \ast\flags\BINARY_BOOL_OR:
-            return $visitor->visitBinaryBoolOr($this->node);
-        case \ast\flags\BINARY_IS_GREATER:
-            return $visitor->visitBinaryIsGreater($this->node);
-        case \ast\flags\BINARY_IS_GREATER_OR_EQUAL:
-            return $visitor->visitBinaryIsGreaterOrEqual($this->node);
-        case \ast\flags\CLASS_ANONYMOUS:
-            return $visitor->visitClassAnonymous($this->node);
-        case \ast\flags\EXEC_EVAL:
-            return $visitor->visitExecEval($this->node);
-        case \ast\flags\EXEC_INCLUDE:
-            return $visitor->visitExecInclude($this->node);
-        case \ast\flags\EXEC_INCLUDE_ONCE:
-            return $visitor->visitExecIncludeOnce($this->node);
-        case \ast\flags\EXEC_REQUIRE:
-            return $visitor->visitExecRequire($this->node);
-        case \ast\flags\EXEC_REQUIRE_ONCE:
-            return $visitor->visitExecRequireOnce($this->node);
-        case \ast\flags\MAGIC_CLASS:
-            return $visitor->visitMagicClass($this->node);
-        case \ast\flags\MAGIC_DIR:
-            return $visitor->visitMagicDir($this->node);
-        case \ast\flags\MAGIC_FILE:
-            return $visitor->visitMagicFile($this->node);
-        case \ast\flags\MAGIC_FUNCTION:
-            return $visitor->visitMagicFunction($this->node);
-        case \ast\flags\MAGIC_LINE:
-            return $visitor->visitMagicLine($this->node);
-        case \ast\flags\MAGIC_METHOD:
-            return $visitor->visitMagicMethod($this->node);
-        case \ast\flags\MAGIC_NAMESPACE:
-            return $visitor->visitMagicNamespace($this->node);
-        case \ast\flags\MAGIC_TRAIT:
-            return $visitor->visitMagicTrait($this->node);
-        case \ast\flags\UNARY_MINUS:
-            return $visitor->visitUnaryMinus($this->node);
-        case \ast\flags\UNARY_PLUS:
-            return $visitor->visitUnaryPlus($this->node);
-        case \ast\flags\UNARY_SILENCE:
-            return $visitor->visitUnarySilence($this->node);
-        case \ast\flags\USE_CONST:
-            return $visitor->visitUseConst($this->node);
-        case \ast\flags\USE_FUNCTION:
-            return $visitor->visitUseFunction($this->node);
-        case \ast\flags\USE_NORMAL:
-            return $visitor->visitUseNormal($this->node);
-        default:
-            assert(false,
-                "All flags must match. Found "
-                . Debug::astFlagDescription($this->node->flags ?? 0));
-            break;
+            case \ast\flags\ASSIGN_BITWISE_OR:
+                return $visitor->visitAssignBitwiseOr($this->node);
+            case \ast\flags\ASSIGN_BITWISE_XOR:
+                return $visitor->visitAssignBitwiseXor($this->node);
+            case \ast\flags\ASSIGN_CONCAT:
+                return $visitor->visitAssignConcat($this->node);
+            case \ast\flags\ASSIGN_DIV:
+                return $visitor->visitAssignDiv($this->node);
+            case \ast\flags\ASSIGN_MOD:
+                return $visitor->visitAssignMod($this->node);
+            case \ast\flags\ASSIGN_MUL:
+                return $visitor->visitAssignMul($this->node);
+            case \ast\flags\ASSIGN_POW:
+                return $visitor->visitAssignPow($this->node);
+            case \ast\flags\ASSIGN_SHIFT_LEFT:
+                return $visitor->visitAssignShiftLeft($this->node);
+            case \ast\flags\ASSIGN_SHIFT_RIGHT:
+                return $visitor->visitAssignShiftRight($this->node);
+            case \ast\flags\ASSIGN_SUB:
+                return $visitor->visitAssignSub($this->node);
+            case \ast\flags\BINARY_ADD:
+                return $visitor->visitBinaryAdd($this->node);
+            case \ast\flags\BINARY_BITWISE_AND:
+                return $visitor->visitBinaryBitwiseAnd($this->node);
+            case \ast\flags\BINARY_BITWISE_OR:
+                return $visitor->visitBinaryBitwiseOr($this->node);
+            case \ast\flags\BINARY_BITWISE_XOR:
+                return $visitor->visitBinaryBitwiseXor($this->node);
+            case \ast\flags\BINARY_BOOL_XOR:
+                return $visitor->visitBinaryBoolXor($this->node);
+            case \ast\flags\BINARY_CONCAT:
+                return $visitor->visitBinaryConcat($this->node);
+            case \ast\flags\BINARY_DIV:
+                return $visitor->visitBinaryDiv($this->node);
+            case \ast\flags\BINARY_IS_EQUAL:
+                return $visitor->visitBinaryIsEqual($this->node);
+            case \ast\flags\BINARY_IS_IDENTICAL:
+                return $visitor->visitBinaryIsIdentical($this->node);
+            case \ast\flags\BINARY_IS_NOT_EQUAL:
+                return $visitor->visitBinaryIsNotEqual($this->node);
+            case \ast\flags\BINARY_IS_NOT_IDENTICAL:
+                return $visitor->visitBinaryIsNotIdentical($this->node);
+            case \ast\flags\BINARY_IS_SMALLER:
+                return $visitor->visitBinaryIsSmaller($this->node);
+            case \ast\flags\BINARY_IS_SMALLER_OR_EQUAL:
+                return $visitor->visitBinaryIsSmallerOrEqual($this->node);
+            case \ast\flags\BINARY_MOD:
+                return $visitor->visitBinaryMod($this->node);
+            case \ast\flags\BINARY_MUL:
+                return $visitor->visitBinaryMul($this->node);
+            case \ast\flags\BINARY_POW:
+                return $visitor->visitBinaryPow($this->node);
+            case \ast\flags\BINARY_SHIFT_LEFT:
+                return $visitor->visitBinaryShiftLeft($this->node);
+            case \ast\flags\BINARY_SHIFT_RIGHT:
+                return $visitor->visitBinaryShiftRight($this->node);
+            case \ast\flags\BINARY_SPACESHIP:
+                return $visitor->visitBinarySpaceship($this->node);
+            case \ast\flags\BINARY_SUB:
+                return $visitor->visitBinarySub($this->node);
+            case \ast\flags\CLASS_ABSTRACT:
+                return $visitor->visitClassAbstract($this->node);
+            case \ast\flags\CLASS_FINAL:
+                return $visitor->visitClassFinal($this->node);
+            case \ast\flags\CLASS_INTERFACE:
+                return $visitor->visitClassInterface($this->node);
+            case \ast\flags\CLASS_TRAIT:
+                return $visitor->visitClassTrait($this->node);
+            case \ast\flags\MODIFIER_ABSTRACT:
+                return $visitor->visitModifierAbstract($this->node);
+            case \ast\flags\MODIFIER_FINAL:
+                return $visitor->visitModifierFinal($this->node);
+            case \ast\flags\MODIFIER_PRIVATE:
+                return $visitor->visitModifierPrivate($this->node);
+            case \ast\flags\MODIFIER_PROTECTED:
+                return $visitor->visitModifierProtected($this->node);
+            case \ast\flags\MODIFIER_PUBLIC:
+                return $visitor->visitModifierPublic($this->node);
+            case \ast\flags\MODIFIER_STATIC:
+                return $visitor->visitModifierStatic($this->node);
+            case \ast\flags\NAME_FQ:
+                return $visitor->visitNameFq($this->node);
+            case \ast\flags\NAME_NOT_FQ:
+                return $visitor->visitNameNotFq($this->node);
+            case \ast\flags\NAME_RELATIVE:
+                return $visitor->visitNameRelative($this->node);
+            case \ast\flags\PARAM_REF:
+                return $visitor->visitParamRef($this->node);
+            case \ast\flags\PARAM_VARIADIC:
+                return $visitor->visitParamVariadic($this->node);
+            case \ast\flags\RETURNS_REF:
+                return $visitor->visitReturnsRef($this->node);
+            case \ast\flags\TYPE_ARRAY:
+                return $visitor->visitUnionTypeArray($this->node);
+            case \ast\flags\TYPE_BOOL:
+                return $visitor->visitUnionTypeBool($this->node);
+            case \ast\flags\TYPE_CALLABLE:
+                return $visitor->visitUnionTypeCallable($this->node);
+            case \ast\flags\TYPE_DOUBLE:
+                return $visitor->visitUnionTypeDouble($this->node);
+            case \ast\flags\TYPE_LONG:
+                return $visitor->visitUnionTypeLong($this->node);
+            case \ast\flags\TYPE_NULL:
+                return $visitor->visitUnionTypeNull($this->node);
+            case \ast\flags\TYPE_OBJECT:
+                return $visitor->visitUnionTypeObject($this->node);
+            case \ast\flags\TYPE_STRING:
+                return $visitor->visitUnionTypeString($this->node);
+            case \ast\flags\UNARY_BITWISE_NOT:
+                return $visitor->visitUnaryBitwiseNot($this->node);
+            case \ast\flags\UNARY_BOOL_NOT:
+                return $visitor->visitUnaryBoolNot($this->node);
+            case \ast\flags\BINARY_BOOL_AND:
+                return $visitor->visitBinaryBoolAnd($this->node);
+            case \ast\flags\BINARY_BOOL_OR:
+                return $visitor->visitBinaryBoolOr($this->node);
+            case \ast\flags\BINARY_IS_GREATER:
+                return $visitor->visitBinaryIsGreater($this->node);
+            case \ast\flags\BINARY_IS_GREATER_OR_EQUAL:
+                return $visitor->visitBinaryIsGreaterOrEqual($this->node);
+            case \ast\flags\CLASS_ANONYMOUS:
+                return $visitor->visitClassAnonymous($this->node);
+            case \ast\flags\EXEC_EVAL:
+                return $visitor->visitExecEval($this->node);
+            case \ast\flags\EXEC_INCLUDE:
+                return $visitor->visitExecInclude($this->node);
+            case \ast\flags\EXEC_INCLUDE_ONCE:
+                return $visitor->visitExecIncludeOnce($this->node);
+            case \ast\flags\EXEC_REQUIRE:
+                return $visitor->visitExecRequire($this->node);
+            case \ast\flags\EXEC_REQUIRE_ONCE:
+                return $visitor->visitExecRequireOnce($this->node);
+            case \ast\flags\MAGIC_CLASS:
+                return $visitor->visitMagicClass($this->node);
+            case \ast\flags\MAGIC_DIR:
+                return $visitor->visitMagicDir($this->node);
+            case \ast\flags\MAGIC_FILE:
+                return $visitor->visitMagicFile($this->node);
+            case \ast\flags\MAGIC_FUNCTION:
+                return $visitor->visitMagicFunction($this->node);
+            case \ast\flags\MAGIC_LINE:
+                return $visitor->visitMagicLine($this->node);
+            case \ast\flags\MAGIC_METHOD:
+                return $visitor->visitMagicMethod($this->node);
+            case \ast\flags\MAGIC_NAMESPACE:
+                return $visitor->visitMagicNamespace($this->node);
+            case \ast\flags\MAGIC_TRAIT:
+                return $visitor->visitMagicTrait($this->node);
+            case \ast\flags\UNARY_MINUS:
+                return $visitor->visitUnaryMinus($this->node);
+            case \ast\flags\UNARY_PLUS:
+                return $visitor->visitUnaryPlus($this->node);
+            case \ast\flags\UNARY_SILENCE:
+                return $visitor->visitUnarySilence($this->node);
+            case \ast\flags\USE_CONST:
+                return $visitor->visitUseConst($this->node);
+            case \ast\flags\USE_FUNCTION:
+                return $visitor->visitUseFunction($this->node);
+            case \ast\flags\USE_NORMAL:
+                return $visitor->visitUseNormal($this->node);
+            default:
+                assert(
+                    false,
+                    "All flags must match. Found "
+                    . Debug::astFlagDescription($this->node->flags ?? 0)
+                );
+                break;
         }
     }
-
 }

--- a/src/Phan/AST/Visitor/FlagVisitor.php
+++ b/src/Phan/AST/Visitor/FlagVisitor.php
@@ -6,7 +6,8 @@ use \ast\Node;
 /**
  * A visitor of AST nodes based on the node's flag value
  */
-interface FlagVisitor {
+interface FlagVisitor
+{
 
     /**
      * Visit a node with flag `\ast\flags\ASSIGN_ADD`
@@ -417,6 +418,4 @@ interface FlagVisitor {
      * Visit a node with flag `\ast\flags\USE_NORMAL`
      */
     public function visitUseNormal(Node $node);
-
-
 }

--- a/src/Phan/AST/Visitor/FlagVisitorImplementation.php
+++ b/src/Phan/AST/Visitor/FlagVisitorImplementation.php
@@ -7,336 +7,418 @@ use \ast\Node;
  * A visitor of AST nodes based on the node's flag value
  * which does nothing upon visiting a node
  */
-abstract class FlagVisitorImplementation implements FlagVisitor {
+abstract class FlagVisitorImplementation implements FlagVisitor
+{
 
     abstract public function visit(Node $node);
 
-    public function visitAssignAdd(Node $node) {
+    public function visitAssignAdd(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitAssignBitwiseAnd(Node $node) {
+    public function visitAssignBitwiseAnd(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitAssignBitwiseOr(Node $node) {
+    public function visitAssignBitwiseOr(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitAssignBitwiseXor(Node $node) {
+    public function visitAssignBitwiseXor(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitAssignConcat(Node $node) {
+    public function visitAssignConcat(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitAssignDiv(Node $node) {
+    public function visitAssignDiv(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitAssignMod(Node $node) {
+    public function visitAssignMod(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitAssignMul(Node $node) {
+    public function visitAssignMul(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitAssignPow(Node $node) {
+    public function visitAssignPow(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitAssignShiftLeft(Node $node) {
+    public function visitAssignShiftLeft(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitAssignShiftRight(Node $node) {
+    public function visitAssignShiftRight(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitAssignSub(Node $node) {
+    public function visitAssignSub(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitBinaryAdd(Node $node) {
+    public function visitBinaryAdd(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitBinaryBitwiseAnd(Node $node) {
+    public function visitBinaryBitwiseAnd(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitBinaryBitwiseOr(Node $node) {
+    public function visitBinaryBitwiseOr(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitBinaryBitwiseXor(Node $node) {
+    public function visitBinaryBitwiseXor(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitBinaryBoolXor(Node $node) {
+    public function visitBinaryBoolXor(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitBinaryConcat(Node $node) {
+    public function visitBinaryConcat(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitBinaryDiv(Node $node) {
+    public function visitBinaryDiv(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitBinaryIsEqual(Node $node) {
+    public function visitBinaryIsEqual(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitBinaryIsIdentical(Node $node) {
+    public function visitBinaryIsIdentical(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitBinaryIsNotEqual(Node $node) {
+    public function visitBinaryIsNotEqual(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitBinaryIsNotIdentical(Node $node) {
+    public function visitBinaryIsNotIdentical(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitBinaryIsSmaller(Node $node) {
+    public function visitBinaryIsSmaller(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitBinaryIsSmallerOrEqual(Node $node) {
+    public function visitBinaryIsSmallerOrEqual(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitBinaryMod(Node $node) {
+    public function visitBinaryMod(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitBinaryMul(Node $node) {
+    public function visitBinaryMul(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitBinaryPow(Node $node) {
+    public function visitBinaryPow(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitBinaryShiftLeft(Node $node) {
+    public function visitBinaryShiftLeft(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitBinaryShiftRight(Node $node) {
+    public function visitBinaryShiftRight(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitBinarySpaceship(Node $node) {
+    public function visitBinarySpaceship(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitBinarySub(Node $node) {
+    public function visitBinarySub(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitClassAbstract(Node $node) {
+    public function visitClassAbstract(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitClassFinal(Node $node) {
+    public function visitClassFinal(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitClassInterface(Node $node) {
+    public function visitClassInterface(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitClassTrait(Node $node) {
+    public function visitClassTrait(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitModifierAbstract(Node $node) {
+    public function visitModifierAbstract(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitModifierFinal(Node $node) {
+    public function visitModifierFinal(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitModifierPrivate(Node $node) {
+    public function visitModifierPrivate(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitModifierProtected(Node $node) {
+    public function visitModifierProtected(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitModifierPublic(Node $node) {
+    public function visitModifierPublic(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitModifierStatic(Node $node) {
+    public function visitModifierStatic(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitNameFq(Node $node) {
+    public function visitNameFq(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitNameNotFq(Node $node) {
+    public function visitNameNotFq(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitNameRelative(Node $node) {
+    public function visitNameRelative(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitParamRef(Node $node) {
+    public function visitParamRef(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitParamVariadic(Node $node) {
+    public function visitParamVariadic(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitReturnsRef(Node $node) {
+    public function visitReturnsRef(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitUnionTypeArray(Node $node) {
+    public function visitUnionTypeArray(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitUnionTypeBool(Node $node) {
+    public function visitUnionTypeBool(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitUnionTypeCallable(Node $node) {
+    public function visitUnionTypeCallable(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitUnionTypeDouble(Node $node) {
+    public function visitUnionTypeDouble(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitUnionTypeLong(Node $node) {
+    public function visitUnionTypeLong(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitUnionTypeNull(Node $node) {
+    public function visitUnionTypeNull(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitUnionTypeObject(Node $node) {
+    public function visitUnionTypeObject(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitUnionTypeString(Node $node) {
+    public function visitUnionTypeString(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitUnaryBitwiseNot(Node $node) {
+    public function visitUnaryBitwiseNot(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitUnaryBoolNot(Node $node) {
+    public function visitUnaryBoolNot(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitBinaryBoolAnd(Node $node) {
+    public function visitBinaryBoolAnd(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitBinaryBoolOr(Node $node) {
+    public function visitBinaryBoolOr(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitBinaryIsGreater(Node $node) {
+    public function visitBinaryIsGreater(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitBinaryIsGreaterOrEqual(Node $node) {
+    public function visitBinaryIsGreaterOrEqual(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitClassAnonymous(Node $node) {
+    public function visitClassAnonymous(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitExecEval(Node $node) {
+    public function visitExecEval(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitExecInclude(Node $node) {
+    public function visitExecInclude(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitExecIncludeOnce(Node $node) {
+    public function visitExecIncludeOnce(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitExecRequire(Node $node) {
+    public function visitExecRequire(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitExecRequireOnce(Node $node) {
+    public function visitExecRequireOnce(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitMagicClass(Node $node) {
+    public function visitMagicClass(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitMagicDir(Node $node) {
+    public function visitMagicDir(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitMagicFile(Node $node) {
+    public function visitMagicFile(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitMagicFunction(Node $node) {
+    public function visitMagicFunction(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitMagicLine(Node $node) {
+    public function visitMagicLine(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitMagicMethod(Node $node) {
+    public function visitMagicMethod(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitMagicNamespace(Node $node) {
+    public function visitMagicNamespace(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitMagicTrait(Node $node) {
+    public function visitMagicTrait(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitUnaryMinus(Node $node) {
+    public function visitUnaryMinus(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitUnaryPlus(Node $node) {
+    public function visitUnaryPlus(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitUnarySilence(Node $node) {
+    public function visitUnarySilence(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitUseConst(Node $node) {
+    public function visitUseConst(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitUseFunction(Node $node) {
+    public function visitUseFunction(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitUseNormal(Node $node) {
+    public function visitUseNormal(Node $node)
+    {
         return $this->visit($node);
     }
-
 }

--- a/src/Phan/AST/Visitor/KindVisitor.php
+++ b/src/Phan/AST/Visitor/KindVisitor.php
@@ -7,7 +7,8 @@ use \ast\Node\Decl;
 /**
  * A visitor of AST nodes based on the node's kind value
  */
-interface KindVisitor {
+interface KindVisitor
+{
 
     /**
      * Visit a node with kind `\ast\AST_ARRAY`

--- a/src/Phan/AST/Visitor/KindVisitorImplementation.php
+++ b/src/Phan/AST/Visitor/KindVisitorImplementation.php
@@ -8,7 +8,8 @@ use \ast\Node\Decl;
  * A visitor of AST nodes based on the node's kind value
  * which does nothing upon visiting a node of any kind
  */
-abstract class KindVisitorImplementation implements KindVisitor {
+abstract class KindVisitorImplementation implements KindVisitor
+{
 
     abstract public function visit(Node $node);
 
@@ -16,400 +17,499 @@ abstract class KindVisitorImplementation implements KindVisitor {
      * @param Node $node
      * A node to visit
      */
-    public function __invoke(Node $node) {
+    public function __invoke(Node $node)
+    {
         return (new Element($node))->acceptKindVisitor($this);
     }
 
-    public function visitArgList(Node $node) {
+    public function visitArgList(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitArray(Node $node) {
+    public function visitArray(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitArrayElem(Node $node) {
+    public function visitArrayElem(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitAssign(Node $node) {
+    public function visitAssign(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitAssignOp(Node $node) {
+    public function visitAssignOp(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitAssignRef(Node $node) {
+    public function visitAssignRef(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitBinaryOp(Node $node) {
+    public function visitBinaryOp(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitBreak(Node $node) {
+    public function visitBreak(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitCall(Node $node) {
+    public function visitCall(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitCast(Node $node) {
+    public function visitCast(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitCatch(Node $node) {
+    public function visitCatch(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitClass(Decl $node) {
+    public function visitClass(Decl $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitClassConst(Node $node) {
+    public function visitClassConst(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitClassConstDecl(Node $node) {
+    public function visitClassConstDecl(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitClosure(Decl $node) {
+    public function visitClosure(Decl $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitClosureUses(Node $node) {
+    public function visitClosureUses(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitClosureVar(Node $node) {
+    public function visitClosureVar(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitCoalesce(Node $node) {
+    public function visitCoalesce(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitConst(Node $node) {
+    public function visitConst(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitConstDecl(Node $node) {
+    public function visitConstDecl(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitConstElem(Node $node) {
+    public function visitConstElem(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitDeclare(Node $node) {
+    public function visitDeclare(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitDim(Node $node) {
+    public function visitDim(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitDoWhile(Node $node) {
+    public function visitDoWhile(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitEcho(Node $node) {
+    public function visitEcho(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitEmpty(Node $node) {
+    public function visitEmpty(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitEncapsList(Node $node) {
+    public function visitEncapsList(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitExit(Node $node) {
+    public function visitExit(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitExprList(Node $node) {
+    public function visitExprList(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitForeach(Node $node) {
+    public function visitForeach(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitFuncDecl(Decl $node) {
+    public function visitFuncDecl(Decl $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitIsset(Node $node) {
+    public function visitIsset(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitGlobal(Node $node) {
+    public function visitGlobal(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitGreater(Node $node) {
+    public function visitGreater(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitGreaterEqual(Node $node) {
+    public function visitGreaterEqual(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitGroupUse(Node $node) {
+    public function visitGroupUse(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitIf(Node $node) {
+    public function visitIf(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitIfElem(Node $node) {
+    public function visitIfElem(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitInstanceof(Node $node) {
+    public function visitInstanceof(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitList(Node $node) {
+    public function visitList(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitMagicConst(Node $node) {
+    public function visitMagicConst(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitMethod(Decl $node) {
+    public function visitMethod(Decl $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitMethodCall(Node $node) {
+    public function visitMethodCall(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitName(Node $node) {
+    public function visitName(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitNamespace(Node $node) {
+    public function visitNamespace(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitNew(Node $node) {
+    public function visitNew(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitParam(Node $node) {
+    public function visitParam(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitParamList(Node $node) {
+    public function visitParamList(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitPreInc(Node $node) {
+    public function visitPreInc(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitPrint(Node $node) {
+    public function visitPrint(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitProp(Node $node) {
+    public function visitProp(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitPropDecl(Node $node) {
+    public function visitPropDecl(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitPropElem(Node $node) {
+    public function visitPropElem(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitReturn(Node $node) {
+    public function visitReturn(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitStatic(Node $node) {
+    public function visitStatic(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitStaticCall(Node $node) {
+    public function visitStaticCall(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitStaticProp(Node $node) {
+    public function visitStaticProp(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitStmtList(Node $node) {
+    public function visitStmtList(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitSwitch(Node $node) {
+    public function visitSwitch(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitSwitchCase(Node $node) {
+    public function visitSwitchCase(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitSwitchList(Node $node) {
+    public function visitSwitchList(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitType(Node $node) {
+    public function visitType(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitUnaryMinus(Node $node) {
+    public function visitUnaryMinus(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitUnaryOp(Node $node) {
+    public function visitUnaryOp(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitUse(Node $node) {
+    public function visitUse(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitUseElem(Node $node) {
+    public function visitUseElem(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitUseTrait(Node $node) {
+    public function visitUseTrait(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitVar(Node $node) {
+    public function visitVar(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitWhile(Node $node) {
+    public function visitWhile(Node $node)
+    {
         return $this->visit($node);
     }
 
 
-    public function visitAnd(Node $node) {
+    public function visitAnd(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitCatchList(Node $node) {
+    public function visitCatchList(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitClone(Node $node) {
+    public function visitClone(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitConditional(Node $node) {
+    public function visitConditional(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitContinue(Node $node) {
+    public function visitContinue(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitFor(Node $node) {
+    public function visitFor(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitGoto(Node $node) {
+    public function visitGoto(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitHaltCompiler(Node $node) {
+    public function visitHaltCompiler(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitIncludeOrEval(Node $node) {
+    public function visitIncludeOrEval(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitLabel(Node $node) {
+    public function visitLabel(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitMethodReference(Node $node) {
+    public function visitMethodReference(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitNameList(Node $node) {
+    public function visitNameList(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitOr(Node $node) {
+    public function visitOr(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitPostDec(Node $node) {
+    public function visitPostDec(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitPostInc(Node $node) {
+    public function visitPostInc(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitPreDec(Node $node) {
+    public function visitPreDec(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitRef(Node $node) {
+    public function visitRef(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitShellExec(Node $node) {
+    public function visitShellExec(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitSilence(Node $node) {
+    public function visitSilence(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitThrow(Node $node) {
+    public function visitThrow(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitTraitAdaptations(Node $node) {
+    public function visitTraitAdaptations(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitTraitAlias(Node $node) {
+    public function visitTraitAlias(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitTraitPrecedence(Node $node) {
+    public function visitTraitPrecedence(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitTry(Node $node) {
+    public function visitTry(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitUnaryPlus(Node $node) {
+    public function visitUnaryPlus(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitUnpack(Node $node) {
+    public function visitUnpack(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitUnset(Node $node) {
+    public function visitUnset(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitYield(Node $node) {
+    public function visitYield(Node $node)
+    {
         return $this->visit($node);
     }
 
-    public function visitYieldFrom(Node $node) {
+    public function visitYieldFrom(Node $node)
+    {
         return $this->visit($node);
     }
 }

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -265,7 +265,7 @@ class Analysis
             // operate in a context independent of eachother
             switch ($child_node->kind) {
                 case \ast\AST_IF_ELEM:
-                $child_context = $node_context;
+                    $child_context = $node_context;
                     break;
             }
 
@@ -308,9 +308,9 @@ class Analysis
             case \ast\AST_METHOD:
             case \ast\AST_FUNC_DECL:
             case \ast\AST_CLOSURE:
-            return $context;
+                return $context;
             default:
-            return $node_context;
+                return $node_context;
         }
     }
 

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -20,7 +20,8 @@ use Phan\Language\FQSEN;
 /**
  * This class is the entry point into the static analyzer.
  */
-class Analysis {
+class Analysis
+{
 
 
     /**
@@ -38,7 +39,8 @@ class Analysis {
      *
      * @return Context
      */
-    public static function parseFile(CodeBase $code_base, string $file_path) : Context {
+    public static function parseFile(CodeBase $code_base, string $file_path) : Context
+    {
 
         $context = (new Context)->withFile($file_path);
 
@@ -95,7 +97,8 @@ class Analysis {
      * @return Context
      * The context from within the node is returned
      */
-    public static function parseNodeInContext(CodeBase $code_base, Context $context, Node $node) : Context {
+    public static function parseNodeInContext(CodeBase $code_base, Context $context, Node $node) : Context
+    {
 
         // Visit the given node populating the code base
         // with anything we learn and get a new context
@@ -110,8 +113,7 @@ class Analysis {
 
         // Recurse into each child node
         $child_context = $context;
-        foreach($node->children ?? [] as $child_node) {
-
+        foreach ($node->children ?? [] as $child_node) {
             // Skip any non Node children.
             if (!($child_node instanceof Node)) {
                 continue;
@@ -141,14 +143,15 @@ class Analysis {
      *
      * @return null
      */
-    public static function analyzeClasses(CodeBase $code_base) {
+    public static function analyzeClasses(CodeBase $code_base)
+    {
 
         $class_count = 2 * count($code_base->getClassMap());
 
         // Take a pass to import all details from ancestors
         $i = 0;
         foreach ($code_base->getClassMap() as $fqsen_string => $clazz) {
-            CLI::progress('classes',  ++$i/$class_count);
+            CLI::progress('classes', ++$i/$class_count);
 
             // Make sure the parent classes exist
             ParentClassExistsAnalyzer::analyzeParentClassExists($code_base, $clazz);
@@ -163,7 +166,7 @@ class Analysis {
 
         // Run a few checks on all of the classes
         foreach ($code_base->getClassMap() as $fqsen_string => $clazz) {
-            CLI::progress('classes',  ++$i/$class_count);
+            CLI::progress('classes', ++$i/$class_count);
 
             if ($clazz->getContext()->isInternal()) {
                 continue;
@@ -181,12 +184,13 @@ class Analysis {
      *
      * @return null
      */
-    public static function analyzeFunctions(CodeBase $code_base) {
+    public static function analyzeFunctions(CodeBase $code_base)
+    {
         $function_count = count($code_base->getMethodMap(), COUNT_RECURSIVE);
         $i = 0;
         foreach ($code_base->getMethodMap() as $fqsen_string => $method_map) {
             foreach ($method_map as $name => $method) {
-                CLI::progress('method',  (++$i)/$function_count);
+                CLI::progress('method', (++$i)/$function_count);
 
                 if ($method->getContext()->isInternal()) {
                     continue;
@@ -243,7 +247,7 @@ class Analysis {
         // With a context that is inside of the node passed
         // to this method, we analyze all children of the
         // node.
-		foreach($node->children ?? [] as $child_node) {
+        foreach ($node->children ?? [] as $child_node) {
             // Skip any non Node children.
             if (!($child_node instanceof Node)) {
                 continue;
@@ -260,9 +264,9 @@ class Analysis {
             // their siblings. Child nodes of conditionals
             // operate in a context independent of eachother
             switch ($child_node->kind) {
-            case \ast\AST_IF_ELEM:
+                case \ast\AST_IF_ELEM:
                 $child_context = $node_context;
-                break;
+                    break;
             }
 
             // Step into each child node and get an
@@ -276,7 +280,7 @@ class Analysis {
             );
 
             $child_context_list[] = $child_context;
-		}
+        }
 
         // For if statements, we need to merge the contexts
         // of all child context into a single scope based
@@ -300,12 +304,12 @@ class Analysis {
         // context to be the incoming context. Otherwise,
         // we pass our new context up to our parent
         switch ($node->kind) {
-        case \ast\AST_CLASS:
-        case \ast\AST_METHOD:
-        case \ast\AST_FUNC_DECL:
-        case \ast\AST_CLOSURE:
+            case \ast\AST_CLASS:
+            case \ast\AST_METHOD:
+            case \ast\AST_FUNC_DECL:
+            case \ast\AST_CLOSURE:
             return $context;
-        default:
+            default:
             return $node_context;
         }
     }
@@ -316,7 +320,8 @@ class Analysis {
      *
      * @return void
      */
-    public static function analyzeDeadCode(CodeBase $code_base) {
+    public static function analyzeDeadCode(CodeBase $code_base)
+    {
         // Check to see if dead code detection is enabled. Keep
         // in mind that the results here are just a guess and
         // we can't tell with certainty that anything is
@@ -340,7 +345,8 @@ class Analysis {
      * True if the given node should be visited or false if
      * it should be skipped entirely
      */
-    private static function shouldVisit(Node $node) {
+    private static function shouldVisit(Node $node)
+    {
 
         // When doing dead code detection, we need to go
         // super deep
@@ -349,35 +355,35 @@ class Analysis {
         }
 
         switch ($node->kind) {
-        case \ast\AST_ARRAY_ELEM:
-        case \ast\AST_ASSIGN_OP:
-        case \ast\AST_BREAK:
-        case \ast\AST_CAST:
-        case \ast\AST_CLONE:
-        case \ast\AST_CLOSURE_USES:
-        case \ast\AST_CLOSURE_VAR:
-        case \ast\AST_COALESCE:
-        case \ast\AST_CONST_DECL:
-        case \ast\AST_CONST_ELEM:
-        case \ast\AST_CONTINUE:
-        case \ast\AST_EMPTY:
-        case \ast\AST_ENCAPS_LIST:
-        case \ast\AST_EXIT:
-        case \ast\AST_INCLUDE_OR_EVAL:
-        case \ast\AST_ISSET:
-        case \ast\AST_MAGIC_CONST:
-        case \ast\AST_NAME:
-        case \ast\AST_NAME_LIST:
-        case \ast\AST_PARAM:
-        case \ast\AST_PARAM_LIST:
-        case \ast\AST_POST_INC:
-        case \ast\AST_PRE_INC:
-        case \ast\AST_STATIC_PROP:
-        case \ast\AST_TYPE:
-        case \ast\AST_UNARY_OP:
-        case \ast\AST_UNSET:
-        case \ast\AST_YIELD:
-            return false;
+            case \ast\AST_ARRAY_ELEM:
+            case \ast\AST_ASSIGN_OP:
+            case \ast\AST_BREAK:
+            case \ast\AST_CAST:
+            case \ast\AST_CLONE:
+            case \ast\AST_CLOSURE_USES:
+            case \ast\AST_CLOSURE_VAR:
+            case \ast\AST_COALESCE:
+            case \ast\AST_CONST_DECL:
+            case \ast\AST_CONST_ELEM:
+            case \ast\AST_CONTINUE:
+            case \ast\AST_EMPTY:
+            case \ast\AST_ENCAPS_LIST:
+            case \ast\AST_EXIT:
+            case \ast\AST_INCLUDE_OR_EVAL:
+            case \ast\AST_ISSET:
+            case \ast\AST_MAGIC_CONST:
+            case \ast\AST_NAME:
+            case \ast\AST_NAME_LIST:
+            case \ast\AST_PARAM:
+            case \ast\AST_PARAM_LIST:
+            case \ast\AST_POST_INC:
+            case \ast\AST_PRE_INC:
+            case \ast\AST_STATIC_PROP:
+            case \ast\AST_TYPE:
+            case \ast\AST_UNARY_OP:
+            case \ast\AST_UNSET:
+            case \ast\AST_YIELD:
+                return false;
         }
 
         return true;

--- a/src/Phan/Analyze/Analyzable.php
+++ b/src/Phan/Analyze/Analyzable.php
@@ -13,7 +13,8 @@ use \ast\Node;
  * the AST node that defines them and allows us to
  * reanalyze them later on
  */
-trait Analyzable {
+trait Analyzable
+{
 
     /**
      * @var Node
@@ -36,7 +37,8 @@ trait Analyzable {
      * reference to this so that we can come to it
      * and
      */
-    public function setNode(Node $node) {
+    public function setNode(Node $node)
+    {
         // Don't waste the memory if we're in quick mode
         if (Config::get()->quick_mode) {
             return;
@@ -49,7 +51,8 @@ trait Analyzable {
      * @return bool
      * True if we have a node defined on this object
      */
-    public function hasNode() : bool {
+    public function hasNode() : bool
+    {
         return !empty($this->node);
     }
 
@@ -57,7 +60,8 @@ trait Analyzable {
      * @return Node
      * The AST node associated with this object
      */
-    public function getNode() : Node {
+    public function getNode() : Node
+    {
         return $this->node;
     }
 
@@ -66,7 +70,8 @@ trait Analyzable {
      * Analyze the node associated with this object
      * in the given context
      */
-    public function analyze(Context $context, CodeBase $code_base) : Context {
+    public function analyze(Context $context, CodeBase $code_base) : Context
+    {
         // Don't do anything if we care about being
         // fast
         if (Config::get()->quick_mode) {

--- a/src/Phan/Analyze/ArgumentType.php
+++ b/src/Phan/Analyze/ArgumentType.php
@@ -287,7 +287,7 @@ class ArgumentType
             $alternate_found = false;
 
             foreach ($method->alternateGenerator($code_base)
-            as $alternate_id => $alternate_method) {
+ as $alternate_id => $alternate_method) {
                 if (empty($alternate_method->getParameterList()[$i])) {
                     continue;
                 }
@@ -422,15 +422,15 @@ class ArgumentType
             // (string glue, array pieces),
             // (array pieces, string glue) or
             // (array pieces)
-            if ($argcount == 1) {
-                self::analyzeNodeUnionTypeCast(
-                    $arglist->children[0],
-                    $context,
-                    $code_base,
-                    ArrayType::instance()->asUnionType(),
-                    function (UnionType $node_type) use ($context, $method) {
+                if ($argcount == 1) {
+                    self::analyzeNodeUnionTypeCast(
+                        $arglist->children[0],
+                        $context,
+                        $code_base,
+                        ArrayType::instance()->asUnionType(),
+                        function (UnionType $node_type) use ($context, $method) {
                         // "arg#1(pieces) is %s but {$method->getFQSEN()}() takes array when passed only 1 arg"
-                        return Issue::fromType(Issue::ParamSpecial2)(
+                            return Issue::fromType(Issue::ParamSpecial2)(
                             $context->getFile(),
                             $context->getLineNumberStart(), [
                                 1,
@@ -439,107 +439,107 @@ class ArgumentType
                                 'string',
                                 'array'
                             ]
-                        );
-                    }
-                );
-                return;
-            } elseif ($argcount == 2) {
-                $arg1_type = UnionType::fromNode(
-                    $context,
-                    $code_base,
-                    $arglist->children[0]
-                );
+                            );
+                        }
+                    );
+                    return;
+                } elseif ($argcount == 2) {
+                    $arg1_type = UnionType::fromNode(
+                        $context,
+                        $code_base,
+                        $arglist->children[0]
+                    );
 
-                $arg2_type = UnionType::fromNode(
-                    $context,
-                    $code_base,
-                    $arglist->children[1]
-                );
+                    $arg2_type = UnionType::fromNode(
+                        $context,
+                        $code_base,
+                        $arglist->children[1]
+                    );
 
-                if ((string)$arg1_type == 'array') {
-                    if (!$arg1_type->canCastToUnionType(
-                        StringType::instance()->asUnionType()
-                    )) {
-                        Issue::emit(
-                            Issue::ParamSpecial1,
-                            $context->getFile(),
-                            $context->getLineNumberStart(),
-                            2,
-                            'glue',
-                            (string)$arg2_type,
-                            (string)$method->getFQSEN(),
-                            'string',
-                            1,
-                            'array'
-                        );
+                    if ((string)$arg1_type == 'array') {
+                        if (!$arg1_type->canCastToUnionType(
+                            StringType::instance()->asUnionType()
+                        )) {
+                            Issue::emit(
+                                Issue::ParamSpecial1,
+                                $context->getFile(),
+                                $context->getLineNumberStart(),
+                                2,
+                                'glue',
+                                (string)$arg2_type,
+                                (string)$method->getFQSEN(),
+                                'string',
+                                1,
+                                'array'
+                            );
+                        }
+                    } elseif ((string)$arg1_type == 'string') {
+                        if (!$arg2_type->canCastToUnionType(
+                            ArrayType::instance()->asUnionType()
+                        )) {
+                            Issue::emit(
+                                Issue::ParamSpecial1,
+                                $context->getFile(),
+                                $context->getLineNumberStart(),
+                                2,
+                                'pieces',
+                                (string)$arg2_type,
+                                (string)$method->getFQSEN(),
+                                'array',
+                                1,
+                                'string'
+                            );
+                        }
                     }
-                } elseif ((string)$arg1_type == 'string') {
-                    if (!$arg2_type->canCastToUnionType(
-                        ArrayType::instance()->asUnionType()
-                    )) {
-                        Issue::emit(
-                            Issue::ParamSpecial1,
-                            $context->getFile(),
-                            $context->getLineNumberStart(),
-                            2,
-                            'pieces',
-                            (string)$arg2_type,
-                            (string)$method->getFQSEN(),
-                            'array',
-                            1,
-                            'string'
-                        );
-                    }
+                    return;
                 }
-                return;
-            }
 
             // Any other arg counts we will let the regular
             // checks handle
-            break;
+                break;
             case 'array_udiff':
             case 'array_diff_uassoc':
             case 'array_uintersect_assoc':
             case 'array_intersect_ukey':
-            if ($argcount < 3) {
-                Issue::emit(
-                    Issue::ParamTooFewInternal,
-                    $context->getFile(),
-                    $context->getLineNumberStart(),
-                    $argcount,
-                    (string)$method->getFQSEN(),
-                    $method->getNumberOfRequiredParameters()
-                );
-
-                return;
-            }
-
-            self::analyzeNodeUnionTypeCast(
-                $arglist->children[$argcount - 1],
-                $context,
-                $code_base,
-                CallableType::instance()->asUnionType(),
-                function (UnionType $node_type) use ($context, $method) {
-                    // "The last argument to {$method->getFQSEN()} must be a callable"
-                    return Issue::fromType(Issue::ParamSpecial3)(
+                if ($argcount < 3) {
+                    Issue::emit(
+                        Issue::ParamTooFewInternal,
                         $context->getFile(),
-                        $context->getLineNumberStart(), [
-                            (string)$method->getFQSEN(),
-                            'callable'
-                        ]
+                        $context->getLineNumberStart(),
+                        $argcount,
+                        (string)$method->getFQSEN(),
+                        $method->getNumberOfRequiredParameters()
                     );
-                }
-            );
 
-            for ($i=0; $i < ($argcount - 1); $i++) {
+                    return;
+                }
+
                 self::analyzeNodeUnionTypeCast(
-                    $arglist->children[$i],
+                    $arglist->children[$argcount - 1],
                     $context,
                     $code_base,
                     CallableType::instance()->asUnionType(),
-                    function (UnionType $node_type) use ($context, $method, $i) {
+                    function (UnionType $node_type) use ($context, $method) {
+                    // "The last argument to {$method->getFQSEN()} must be a callable"
+                        return Issue::fromType(Issue::ParamSpecial3)(
+                        $context->getFile(),
+                        $context->getLineNumberStart(), [
+                            (string)$method->getFQSEN(),
+                            'callable'
+                        ]
+                        );
+                    }
+                );
+
+                for ($i=0; $i < ($argcount - 1); $i++) {
+                    self::analyzeNodeUnionTypeCast(
+                        $arglist->children[$i],
+                        $context,
+                        $code_base,
+                        CallableType::instance()->asUnionType(),
+                        function (UnionType $node_type) use ($context, $method, $i) {
                         // "arg#".($i+1)." is %s but {$method->getFQSEN()}() takes array"
-                        return Issue::fromType(Issue::ParamTypeMismatch)(
+                            return Issue::fromType(Issue::ParamTypeMismatch)(
                             $context->getFile(),
                             $context->getLineNumberStart(), [
                                 ($i+1),
@@ -547,72 +547,72 @@ class ArgumentType
                                 (string)$method->getFQSEN(),
                                 'array'
                             ]
-                        );
-                    }
-                );
-            }
-            return;
+                            );
+                        }
+                    );
+                }
+                return;
 
             case 'array_diff_uassoc':
             case 'array_uintersect_uassoc':
-            if ($argcount < 4) {
-                Issue::emit(
-                    Issue::ParamTooFewInternal,
-                    $context->getFile(),
-                    $context->getLineNumberStart(),
-                    $argcount,
-                    (string)$method->getFQSEN(),
-                    $method->getNumberOfRequiredParameters()
-                );
+                if ($argcount < 4) {
+                    Issue::emit(
+                        Issue::ParamTooFewInternal,
+                        $context->getFile(),
+                        $context->getLineNumberStart(),
+                        $argcount,
+                        (string)$method->getFQSEN(),
+                        $method->getNumberOfRequiredParameters()
+                    );
 
-                return;
-            }
+                    return;
+                }
 
             // The last 2 arguments must be a callable and there
             // can be a variable number of arrays before it
-            self::analyzeNodeUnionTypeCast(
-                $arglist->children[$argcount - 1],
-                $context,
-                $code_base,
-                CallableType::instance()->asUnionType(),
-                function (UnionType $node_type) use ($context, $method) {
-                    // "The last argument to {$method->getFQSEN()} must be a callable"
-                    return Issue::fromType(Issue::ParamSpecial3)(
-                        $context->getFile(),
-                        $context->getLineNumberStart(), [
-                            (string)$method->getFQSEN(),
-                            'callable'
-                        ]
-                    );
-                }
-            );
-
-            self::analyzeNodeUnionTypeCast(
-                $arglist->children[$argcount - 2],
-                $context,
-                $code_base,
-                CallableType::instance()->asUnionType(),
-                function (UnionType $node_type) use ($context, $method) {
-                    // "The second last argument to {$method->getFQSEN()} must be a callable"
-                    return Issue::fromType(Issue::ParamSpecial4)(
-                        $context->getFile(),
-                        $context->getLineNumberStart(), [
-                            (string)$method->getFQSEN(),
-                            'callable'
-                        ]
-                    );
-                }
-            );
-
-            for ($i=0; $i < ($argcount-2); $i++) {
                 self::analyzeNodeUnionTypeCast(
-                    $arglist->children[$i],
+                    $arglist->children[$argcount - 1],
                     $context,
                     $code_base,
-                    ArrayType::instance()->asUnionType(),
-                    function (UnionType $node_type) use ($context, $method, $i) {
+                    CallableType::instance()->asUnionType(),
+                    function (UnionType $node_type) use ($context, $method) {
+                    // "The last argument to {$method->getFQSEN()} must be a callable"
+                        return Issue::fromType(Issue::ParamSpecial3)(
+                        $context->getFile(),
+                        $context->getLineNumberStart(), [
+                            (string)$method->getFQSEN(),
+                            'callable'
+                        ]
+                        );
+                    }
+                );
+
+                self::analyzeNodeUnionTypeCast(
+                    $arglist->children[$argcount - 2],
+                    $context,
+                    $code_base,
+                    CallableType::instance()->asUnionType(),
+                    function (UnionType $node_type) use ($context, $method) {
+                    // "The second last argument to {$method->getFQSEN()} must be a callable"
+                        return Issue::fromType(Issue::ParamSpecial4)(
+                        $context->getFile(),
+                        $context->getLineNumberStart(), [
+                            (string)$method->getFQSEN(),
+                            'callable'
+                        ]
+                        );
+                    }
+                );
+
+                for ($i=0; $i < ($argcount-2); $i++) {
+                    self::analyzeNodeUnionTypeCast(
+                        $arglist->children[$i],
+                        $context,
+                        $code_base,
+                        ArrayType::instance()->asUnionType(),
+                        function (UnionType $node_type) use ($context, $method, $i) {
                         // "arg#".($i+1)." is %s but {$method->getFQSEN()}() takes array"
-                        return Issue::fromType(Issue::ParamTypeMismatch)(
+                            return Issue::fromType(Issue::ParamTypeMismatch)(
                             $context->getFile(),
                             $context->getLineNumberStart(), [
                                 ($i+1),
@@ -620,24 +620,24 @@ class ArgumentType
                                 (string)$method->getFQSEN(),
                                 'array'
                             ]
-                        );
-                    }
-                );
-            }
-            return;
+                            );
+                        }
+                    );
+                }
+                return;
 
             case 'strtok':
             // (string str, string token) or (string token)
-            if ($argcount == 1) {
-                // If we have just one arg it must be a string token
-                self::analyzeNodeUnionTypeCast(
-                    $arglist->children[0],
-                    $context,
-                    $code_base,
-                    ArrayType::instance()->asUnionType(),
-                    function (UnionType $node_type) use ($context, $method) {
+                if ($argcount == 1) {
+                    // If we have just one arg it must be a string token
+                    self::analyzeNodeUnionTypeCast(
+                        $arglist->children[0],
+                        $context,
+                        $code_base,
+                        ArrayType::instance()->asUnionType(),
+                        function (UnionType $node_type) use ($context, $method) {
                         // "arg#1(token) is %s but {$method->getFQSEN()}() takes string when passed only one arg"
-                        return Issue::fromType(Issue::ParamSpecial2)(
+                            return Issue::fromType(Issue::ParamSpecial2)(
                             $context->getFile(),
                             $context->getLineNumberStart(), [
                                 1,
@@ -646,24 +646,24 @@ class ArgumentType
                                 (string)$method->getFQSEN(),
                                 'string'
                             ]
-                        );
-                    }
-                );
-            }
+                            );
+                        }
+                    );
+                }
             // The arginfo check will handle the other case
-            break;
+                break;
             case 'min':
             case 'max':
-            if ($argcount == 1) {
-                // If we have just one arg it must be an array
-                if (!self::analyzeNodeUnionTypeCast(
-                    $arglist->children[0],
-                    $context,
-                    $code_base,
-                    ArrayType::instance()->asUnionType(),
-                    function (UnionType $node_type) use ($context, $method) {
+                if ($argcount == 1) {
+                    // If we have just one arg it must be an array
+                    if (!self::analyzeNodeUnionTypeCast(
+                        $arglist->children[0],
+                        $context,
+                        $code_base,
+                        ArrayType::instance()->asUnionType(),
+                        function (UnionType $node_type) use ($context, $method) {
                         // "arg#1(values) is %s but {$method->getFQSEN()}() takes array when passed only one arg"
-                        return Issue::fromType(Issue::ParamSpecial2)(
+                            return Issue::fromType(Issue::ParamSpecial2)(
                             $context->getFile(),
                             $context->getLineNumberStart(), [
                                 1,
@@ -672,16 +672,16 @@ class ArgumentType
                                 (string)$method->getFQSEN(),
                                 'array'
                             ]
-                        );
+                            );
+                        }
+                    )) {
+                        return;
                     }
-                )) {
-                    return;
                 }
-            }
             // The arginfo check will handle the other case
-            break;
+                break;
             default:
-            break;
+                break;
         }
     }
 }

--- a/src/Phan/Analyze/ArgumentVisitor.php
+++ b/src/Phan/Analyze/ArgumentVisitor.php
@@ -9,7 +9,8 @@ use \Phan\Language\Element\Variable;
 use \ast\Node;
 use \ast\Node\Decl;
 
-class ArgumentVisitor extends KindVisitorImplementation {
+class ArgumentVisitor extends KindVisitorImplementation
+{
 
     /**
      * @var CodeBase
@@ -50,7 +51,8 @@ class ArgumentVisitor extends KindVisitorImplementation {
      *
      * @return void
      */
-    public function visit(Node $node) {
+    public function visit(Node $node)
+    {
         // Nothing to do
     }
 
@@ -60,7 +62,8 @@ class ArgumentVisitor extends KindVisitorImplementation {
      *
      * @return void
      */
-    public function visitVar(Node $node) {
+    public function visitVar(Node $node)
+    {
         try {
             $variable = (new ContextNode(
                 $this->code_base,
@@ -79,7 +82,8 @@ class ArgumentVisitor extends KindVisitorImplementation {
      *
      * @return void
      */
-    public function visitStaticProp(Node $node) {
+    public function visitStaticProp(Node $node)
+    {
         $this->visitProp($node);
     }
 
@@ -89,9 +93,9 @@ class ArgumentVisitor extends KindVisitorImplementation {
      *
      * @return void
      */
-    public function visitProp(Node $node) {
+    public function visitProp(Node $node)
+    {
         try {
-
             // Only look at properties with names that aren't
             // variables or whatever
             if (!is_string($node->children['prop'])) {
@@ -116,7 +120,8 @@ class ArgumentVisitor extends KindVisitorImplementation {
      *
      * @return void
      */
-    public function visitClosure(Decl $node) {
+    public function visitClosure(Decl $node)
+    {
         try {
             $method = (new ContextNode(
                 $this->code_base,
@@ -136,12 +141,13 @@ class ArgumentVisitor extends KindVisitorImplementation {
      *
      * @return void
      */
-    public function visitCall(Node $node) {
+    public function visitCall(Node $node)
+    {
 
         $method_name = null;
         if (isset($node->children['method'])) {
             $method_name = $node->children['method'];
-        } else if (isset($node->children['expr'])) {
+        } elseif (isset($node->children['expr'])) {
             if ($node->children['expr']->kind == \ast\AST_NAME) {
                 $method_name = $node->children['expr']->children['name'];
             }
@@ -175,7 +181,8 @@ class ArgumentVisitor extends KindVisitorImplementation {
      *
      * @return void
      */
-    public function visitMethodCall(Node $node) {
+    public function visitMethodCall(Node $node)
+    {
         return $this->visitCall($node);
     }
 
@@ -185,8 +192,8 @@ class ArgumentVisitor extends KindVisitorImplementation {
      *
      * @return void
      */
-    public function visitStaticCall(Node $node) {
+    public function visitStaticCall(Node $node)
+    {
         return $this->visitCall($node);
     }
-
 }

--- a/src/Phan/Analyze/AssignmentVisitor.php
+++ b/src/Phan/Analyze/AssignmentVisitor.php
@@ -23,7 +23,8 @@ use \ast\Node;
 use \ast\Node\Decl;
 use Phan\Phan;
 
-class AssignmentVisitor extends KindVisitorImplementation {
+class AssignmentVisitor extends KindVisitorImplementation
+{
 
     /**
      * @var CodeBase
@@ -101,9 +102,12 @@ class AssignmentVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visit(Node $node) : Context {
-        assert(false,
-            "Unknown left side of assignment {$this->context}");
+    public function visit(Node $node) : Context
+    {
+        assert(
+            false,
+            "Unknown left side of assignment {$this->context}"
+        );
 
         return $this->visitVar($node);
     }
@@ -116,12 +120,13 @@ class AssignmentVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitList(Node $node) : Context {
+    public function visitList(Node $node) : Context
+    {
         // Figure out the type of elements in the list
         $element_type =
             $this->right_type->genericArrayElementTypes();
 
-        foreach($node->children ?? [] as $child_node) {
+        foreach ($node->children ?? [] as $child_node) {
             // Some times folks like to pass a null to
             // a list to throw the element away. I'm not
             // here to judge.
@@ -156,7 +161,8 @@ class AssignmentVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitDim(Node $node) : Context {
+    public function visitDim(Node $node) : Context
+    {
 
         // Make the right type a generic (i.e. int -> int[])
         $right_type =
@@ -172,12 +178,14 @@ class AssignmentVisitor extends KindVisitorImplementation {
             if ('GLOBALS' === $variable_name) {
                 $dim = $node->children['dim'];
 
-                if(is_string($dim)) {
+                if (is_string($dim)) {
                     // You're not going to believe this, but I just
                     // found a piece of code like $GLOBALS[mt_rand()].
                     // Super weird, right?
-                    assert(is_string($dim),
-                        "dim is not a string at {$this->context}");
+                    assert(
+                        is_string($dim),
+                        "dim is not a string at {$this->context}"
+                    );
 
                     $variable = new Variable(
                         $this->context,
@@ -214,7 +222,8 @@ class AssignmentVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitProp(Node $node) : Context {
+    public function visitProp(Node $node) : Context
+    {
 
         $property_name = $node->children['prop'];
 
@@ -223,8 +232,10 @@ class AssignmentVisitor extends KindVisitorImplementation {
             return $this->context;
         }
 
-        assert(is_string($property_name),
-            "Property must be string in context {$this->context}");
+        assert(
+            is_string($property_name),
+            "Property must be string in context {$this->context}"
+        );
 
         try {
             $class_list = (new ContextNode(
@@ -244,7 +255,6 @@ class AssignmentVisitor extends KindVisitorImplementation {
         }
 
         foreach ($class_list as $clazz) {
-
             // Check to see if this class has the property or
             // a setter
             if (!$clazz->hasPropertyWithName($this->code_base, $property_name)) {
@@ -300,7 +310,7 @@ class AssignmentVisitor extends KindVisitorImplementation {
             } catch (\Exception $exception) {
                 // swallow it
             }
-        } else if (!empty($class_list)) {
+        } elseif (!empty($class_list)) {
             Issue::emit(
                 Issue::UndeclaredProperty,
                 $this->context->getFile(),
@@ -323,7 +333,8 @@ class AssignmentVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitStaticProp(Node $node) : Context {
+    public function visitStaticProp(Node $node) : Context
+    {
         return $this->visitVar($node);
     }
 
@@ -335,7 +346,8 @@ class AssignmentVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitVar(Node $node) : Context {
+    public function visitVar(Node $node) : Context
+    {
         $variable_name = (new ContextNode(
             $this->code_base,
             $this->context,
@@ -401,5 +413,4 @@ class AssignmentVisitor extends KindVisitorImplementation {
 
         return $this->context;
     }
-
 }

--- a/src/Phan/Analyze/BinaryOperatorFlagVisitor.php
+++ b/src/Phan/Analyze/BinaryOperatorFlagVisitor.php
@@ -27,7 +27,8 @@ use \Phan\Language\Type\{
 use \Phan\Issue;
 use \ast\Node;
 
-class BinaryOperatorFlagVisitor extends FlagVisitorImplementation {
+class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
+{
 
     /**
      * @var CodeBase
@@ -54,7 +55,8 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation {
      * @param Node $node
      * A node to visit
      */
-    public function __invoke(Node $node) {
+    public function __invoke(Node $node)
+    {
         return (new Element($node))->acceptBinaryFlagVisitor($this);
     }
 
@@ -68,7 +70,8 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation {
      * @return UnionType
      * The resulting type(s) of the binary operation
      */
-    public function visit(Node $node) : UnionType {
+    public function visit(Node $node) : UnionType
+    {
         $left = UnionType::fromNode(
             $this->context,
             $this->code_base,
@@ -91,11 +94,11 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation {
             );
 
             return new UnionType();
-        } else if ($left->hasType(IntType::instance())
+        } elseif ($left->hasType(IntType::instance())
             && $right->hasType(IntType::instance())
         ) {
             return IntType::instance()->asUnionType();
-        } else if ($left->hasType(FloatType::instance())
+        } elseif ($left->hasType(FloatType::instance())
             && $right->hasType(FloatType::instance())
         ) {
             return FloatType::instance()->asUnionType();
@@ -114,7 +117,8 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation {
      * @return UnionType
      * The resulting type(s) of the binary operation
      */
-    public function visitBinaryBoolAnd(Node $node) : UnionType {
+    public function visitBinaryBoolAnd(Node $node) : UnionType
+    {
         return $this->visitBinaryBool($node);
     }
 
@@ -125,7 +129,8 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation {
      * @return UnionType
      * The resulting type(s) of the binary operation
      */
-    public function visitBinaryBoolXor(Node $node) : UnionType {
+    public function visitBinaryBoolXor(Node $node) : UnionType
+    {
         return $this->visitBinaryBool($node);
     }
 
@@ -136,7 +141,8 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation {
      * @return UnionType
      * The resulting type(s) of the binary operation
      */
-    public function visitBinaryBoolOr(Node $node) : UnionType {
+    public function visitBinaryBoolOr(Node $node) : UnionType
+    {
         return $this->visitBinaryBool($node);
     }
 
@@ -147,7 +153,8 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation {
      * @return UnionType
      * The resulting type(s) of the binary operation
      */
-    public function visitBinaryConcat(Node $node) : UnionType {
+    public function visitBinaryConcat(Node $node) : UnionType
+    {
         return StringType::instance()->asUnionType();
     }
 
@@ -158,47 +165,48 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation {
      * @return UnionType
      * The resulting type(s) of the binary operation
      */
-    private function visitBinaryOpCommon(Node $node) {
+    private function visitBinaryOpCommon(Node $node)
+    {
             $left = UnionType::fromNode(
                 $this->context,
                 $this->code_base,
                 $node->children['left']
             );
 
-        $right = UnionType::fromNode(
-            $this->context,
-            $this->code_base,
-            $node->children['right']
-        );
+            $right = UnionType::fromNode(
+                $this->context,
+                $this->code_base,
+                $node->children['right']
+            );
 
-        if (!$left->genericArrayElementTypes()->isEmpty()
+            if (!$left->genericArrayElementTypes()->isEmpty()
             && $left->nonGenericArrayTypes()->isEmpty()
             && !$right->canCastToUnionType(
                 ArrayType::instance()->asUnionType()
             )
-        ) {
-            Issue::emit(
-                Issue::TypeComparisonFromArray,
-                $this->context->getFile(),
-                $node->lineno ?? 0,
-                (string)$right
-            );
-        } else if (!$right->genericArrayElementTypes()->isEmpty()
+            ) {
+                Issue::emit(
+                    Issue::TypeComparisonFromArray,
+                    $this->context->getFile(),
+                    $node->lineno ?? 0,
+                    (string)$right
+                );
+            } elseif (!$right->genericArrayElementTypes()->isEmpty()
             && $right->nonGenericArrayTypes()->isEmpty()
             && !$left->canCastToUnionType(
                 ArrayType::instance()->asUnionType()
             )
-        ) {
-            // and the same for the left side
-            Issue::emit(
-                Issue::TypeComparisonToArray,
-                $this->context->getFile(),
-                $node->lineno ?? 0,
-                (string)$left
-            );
-        }
+            ) {
+                // and the same for the left side
+                Issue::emit(
+                    Issue::TypeComparisonToArray,
+                    $this->context->getFile(),
+                    $node->lineno ?? 0,
+                    (string)$left
+                );
+            }
 
-        return BoolType::instance()->asUnionType();
+            return BoolType::instance()->asUnionType();
     }
 
     /**
@@ -208,7 +216,8 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation {
      * @return UnionType
      * The resulting type(s) of the binary operation
      */
-    public function visitBinaryIsIdentical(Node $node) : UnionType {
+    public function visitBinaryIsIdentical(Node $node) : UnionType
+    {
         return $this->visitBinaryOpCommon($node);
     }
 
@@ -219,7 +228,8 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation {
      * @return UnionType
      * The resulting type(s) of the binary operation
      */
-    public function visitBinaryIsNotIdentical(Node $node) : UnionType {
+    public function visitBinaryIsNotIdentical(Node $node) : UnionType
+    {
         return $this->visitBinaryOpCommon($node);
     }
 
@@ -230,7 +240,8 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation {
      * @return UnionType
      * The resulting type(s) of the binary operation
      */
-    public function visitBinaryIsEqual(Node $node) : UnionType {
+    public function visitBinaryIsEqual(Node $node) : UnionType
+    {
         return $this->visitBinaryOpCommon($node);
     }
 
@@ -241,7 +252,8 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation {
      * @return UnionType
      * The resulting type(s) of the binary operation
      */
-    public function visitBinaryIsNotEqual(Node $node) : UnionType {
+    public function visitBinaryIsNotEqual(Node $node) : UnionType
+    {
         return $this->visitBinaryOpCommon($node);
     }
 
@@ -252,7 +264,8 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation {
      * @return UnionType
      * The resulting type(s) of the binary operation
      */
-    public function visitBinaryIsSmaller(Node $node) : UnionType {
+    public function visitBinaryIsSmaller(Node $node) : UnionType
+    {
         return $this->visitBinaryBool($node);
     }
 
@@ -263,7 +276,8 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation {
      * @return UnionType
      * The resulting type(s) of the binary operation
      */
-    public function visitBinaryIsSmallerOrEqual(Node $node) : UnionType {
+    public function visitBinaryIsSmallerOrEqual(Node $node) : UnionType
+    {
         return $this->visitBinaryBool($node);
     }
 
@@ -274,7 +288,8 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation {
      * @return UnionType
      * The resulting type(s) of the binary operation
      */
-    public function visitBinaryIsGreater(Node $node) : UnionType {
+    public function visitBinaryIsGreater(Node $node) : UnionType
+    {
         return $this->visitBinaryBool($node);
     }
 
@@ -285,7 +300,8 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation {
      * @return UnionType
      * The resulting type(s) of the binary operation
      */
-    public function visitBinaryIsGreaterOrEqual(Node $node) : UnionType {
+    public function visitBinaryIsGreaterOrEqual(Node $node) : UnionType
+    {
         return $this->visitBinaryBool($node);
     }
 
@@ -297,7 +313,8 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation {
      * @return UnionType
      * The resulting type(s) of the binary operation
      */
-    public function visitBinaryAdd(Node $node) : UnionType {
+    public function visitBinaryAdd(Node $node) : UnionType
+    {
         $left = UnionType::fromNode(
             $this->context,
             $this->code_base,
@@ -335,9 +352,10 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation {
             && empty($right->nonGenericArrayTypes())
         );
 
-        if($left_is_array
+        if ($left_is_array
             && !$right->canCastToUnionType(
-                ArrayType::instance()->asUnionType())
+                ArrayType::instance()->asUnionType()
+            )
         ) {
             Issue::emit(
                 Issue::TypeInvalidRightOperand,
@@ -345,7 +363,7 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation {
                 $node->lineno ?? 0
             );
             return new UnionType();
-        } else if($right_is_array
+        } elseif ($right_is_array
             && !$left->canCastToUnionType(ArrayType::instance()->asUnionType())
         ) {
             Issue::emit(
@@ -354,7 +372,7 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation {
                 $node->lineno ?? 0
             );
             return new UnionType();
-        } else if($left_is_array || $right_is_array) {
+        } elseif ($left_is_array || $right_is_array) {
             // If it is a '+' and we know one side is an array
             // and the other is unknown, assume array
             return ArrayType::instance()->asUnionType();
@@ -375,8 +393,8 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation {
      * @return UnionType
      * The resulting type(s) of the binary operation
      */
-    private function visitBinaryBool(Node $node) : UnionType {
+    private function visitBinaryBool(Node $node) : UnionType
+    {
         return $this->visitBinaryOpCommon($node);
     }
-
 }

--- a/src/Phan/Analyze/ConditionVisitor.php
+++ b/src/Phan/Analyze/ConditionVisitor.php
@@ -11,7 +11,8 @@ use \Phan\Language\Context;
 use \Phan\Language\UnionType;
 use \ast\Node;
 
-class ConditionVisitor extends KindVisitorImplementation {
+class ConditionVisitor extends KindVisitorImplementation
+{
 
     /**
      * @var CodeBase
@@ -54,7 +55,8 @@ class ConditionVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visit(Node $node) : Context {
+    public function visit(Node $node) : Context
+    {
         return $this->context;
     }
 
@@ -66,7 +68,8 @@ class ConditionVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitBinaryOp(Node $node) : Context {
+    public function visitBinaryOp(Node $node) : Context
+    {
         return $this->context;
     }
 
@@ -78,7 +81,8 @@ class ConditionVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitUnaryOp(Node $node) : Context {
+    public function visitUnaryOp(Node $node) : Context
+    {
         return $this->context;
     }
 
@@ -90,7 +94,8 @@ class ConditionVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitCoalesce(Node $node) : Context {
+    public function visitCoalesce(Node $node) : Context
+    {
         return $this->context;
     }
 
@@ -102,7 +107,8 @@ class ConditionVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitIsset(Node $node) : Context {
+    public function visitIsset(Node $node) : Context
+    {
         return $this->context;
 
         /*
@@ -152,7 +158,8 @@ class ConditionVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitInstanceof(Node $node) : Context {
+    public function visitInstanceof(Node $node) : Context
+    {
 
         // Only look at things of the form
         // `$variable instanceof ClassName`
@@ -201,8 +208,8 @@ class ConditionVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitEmpty(Node $node) : Context {
+    public function visitEmpty(Node $node) : Context
+    {
         return $this->context;
     }
-
 }

--- a/src/Phan/Analyze/ContextMergeVisitor.php
+++ b/src/Phan/Analyze/ContextMergeVisitor.php
@@ -12,7 +12,8 @@ use \Phan\Language\UnionType;
 use \Phan\Set;
 use \ast\Node;
 
-class ContextMergeVisitor extends KindVisitorImplementation {
+class ContextMergeVisitor extends KindVisitorImplementation
+{
 
     /**
      * @var CodeBase
@@ -68,7 +69,8 @@ class ContextMergeVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visit(Node $node) : Context {
+    public function visit(Node $node) : Context
+    {
         return end($this->child_context_list) ?: $this->context;
     }
 
@@ -80,20 +82,24 @@ class ContextMergeVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitIf(Node $node) : Context {
+    public function visitIf(Node $node) : Context
+    {
         // Get the list of scopes for each branch of the
         // conditional
         $scope_list = array_map(function (Context $context) {
             return $context->getScope();
         }, $this->child_context_list);
 
-        $has_else = array_reduce($node->children ?? [],
+        $has_else = array_reduce(
+            $node->children ?? [],
             function (bool $carry, $child_node) {
                 return $carry || (
                     $child_node instanceof Node
                     && empty($child_node->children['cond'])
                 );
-            }, false);
+            },
+            false
+        );
 
         // If we're not guaranteed to hit at least one
         // branch, mark the incoming scope as a possibility
@@ -119,15 +125,18 @@ class ContextMergeVisitor extends KindVisitorImplementation {
         // every branch
         $is_defined_on_all_branches =
             function (string $variable_name) use ($scope_list) {
-                return array_reduce($scope_list,
+                return array_reduce(
+                    $scope_list,
                     function (bool $has_variable, Scope $scope)
-                        use ($variable_name)
-                    {
+ use ($variable_name) {
+                    
                         return (
                             $has_variable &&
                             $scope->hasVariableWithName($variable_name)
                         );
-                    }, true);
+                    },
+                    true
+                );
             };
 
         // Get the intersection of all types for all versions of
@@ -144,7 +153,9 @@ class ContextMergeVisitor extends KindVisitorImplementation {
                         }
 
                         return $scope->getVariableWithName($variable_name);
-                    }, $scope_list));
+                    },
+                    $scope_list
+                ));
 
                 // Get the list of types for each version of the variable
                 $type_set_list = array_map(function (Variable $variable) : Set {

--- a/src/Phan/Analyze/ContextMergeVisitor.php
+++ b/src/Phan/Analyze/ContextMergeVisitor.php
@@ -128,7 +128,7 @@ class ContextMergeVisitor extends KindVisitorImplementation
                 return array_reduce(
                     $scope_list,
                     function (bool $has_variable, Scope $scope)
- use ($variable_name) {
+                    use ($variable_name) {
                     
                         return (
                             $has_variable &&

--- a/src/Phan/Analyze/DuplicateClassAnalyzer.php
+++ b/src/Phan/Analyze/DuplicateClassAnalyzer.php
@@ -6,7 +6,8 @@ use Phan\Issue;
 use Phan\Language\Element\Clazz;
 use Phan\Language\FQSEN;
 
-class DuplicateClassAnalyzer {
+class DuplicateClassAnalyzer
+{
 
     /**
      * Check to see if the given Clazz is a duplicate
@@ -66,5 +67,4 @@ class DuplicateClassAnalyzer {
 
         return;
     }
-
 }

--- a/src/Phan/Analyze/DuplicateFunctionAnalyzer.php
+++ b/src/Phan/Analyze/DuplicateFunctionAnalyzer.php
@@ -8,7 +8,8 @@ use \Phan\Language\FQSEN;
 use \Phan\Language\FQSEN\FullyQualifiedFunctionName;
 use \Phan\Language\FQSEN\FullyQualifiedMethodName;
 
-class DuplicateFunctionAnalyzer {
+class DuplicateFunctionAnalyzer
+{
 
     /**
      * Check to see if the given Clazz is a duplicate
@@ -58,5 +59,4 @@ class DuplicateFunctionAnalyzer {
             );
         }
     }
-
 }

--- a/src/Phan/Analyze/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analyze/ParameterTypesAnalyzer.php
@@ -8,7 +8,8 @@ use \Phan\Language\FQSEN;
 use \Phan\Language\FQSEN\FullyQualifiedFunctionName;
 use \Phan\Language\FQSEN\FullyQualifiedMethodName;
 
-class ParameterTypesAnalyzer {
+class ParameterTypesAnalyzer
+{
 
     /**
      * Check to see if the given Clazz is a duplicate
@@ -26,7 +27,6 @@ class ParameterTypesAnalyzer {
 
             // Look at each type in the parameter's Union Type
             foreach ($union_type->getTypeSet() as $type) {
-
                 // If its a native type or a reference to
                 // self, its OK
                 if ($type->isNativeType() || $type->isSelfType()) {
@@ -47,5 +47,4 @@ class ParameterTypesAnalyzer {
             }
         }
     }
-
 }

--- a/src/Phan/Analyze/ParentClassExistsAnalyzer.php
+++ b/src/Phan/Analyze/ParentClassExistsAnalyzer.php
@@ -6,7 +6,8 @@ use \Phan\Issue;
 use \Phan\Language\Element\Clazz;
 use \Phan\Language\FQSEN;
 
-class ParentClassExistsAnalyzer {
+class ParentClassExistsAnalyzer
+{
 
     /**
      * Check to see if the given Clazz is a duplicate

--- a/src/Phan/Analyze/ParentConstructorCalledAnalyzer.php
+++ b/src/Phan/Analyze/ParentConstructorCalledAnalyzer.php
@@ -8,7 +8,8 @@ use \Phan\Issue;
 use \Phan\Language\Element\Clazz;
 use \Phan\Language\FQSEN;
 
-class ParentConstructorCalledAnalyzer {
+class ParentConstructorCalledAnalyzer
+{
 
     /**
      * Check to see if the given Clazz is a duplicate
@@ -21,8 +22,10 @@ class ParentConstructorCalledAnalyzer {
     ) {
         // Only look at classes configured to require a call
         // to its parent constructor
-        if (!in_array($clazz->getName(),
-            Config::get()->parent_constructor_required)
+        if (!in_array(
+            $clazz->getName(),
+            Config::get()->parent_constructor_required
+        )
         ) {
             return;
         }

--- a/src/Phan/Analyze/ParseVisitor.php
+++ b/src/Phan/Analyze/ParseVisitor.php
@@ -45,7 +45,8 @@ use \ast\Node\Decl;
  * globally accessible structural elements and will return a
  * possibly new context as modified by the given node.
  */
-class ParseVisitor extends ScopeVisitor {
+class ParseVisitor extends ScopeVisitor
+{
 
     /**
      * @param Context $context
@@ -73,7 +74,8 @@ class ParseVisitor extends ScopeVisitor {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitClass(Decl $node) : Context {
+    public function visitClass(Decl $node) : Context
+    {
         if ($node->flags & \ast\flags\CLASS_ANONYMOUS) {
             $class_name = (new ContextNode(
                 $this->code_base,
@@ -90,8 +92,10 @@ class ParseVisitor extends ScopeVisitor {
             return $this->context;
         }
 
-        assert(!empty($class_name),
-            "Class must have name in {$this->context}");
+        assert(
+            !empty($class_name),
+            "Class must have name in {$this->context}"
+        );
 
         $class_fqsen =
             FullyQualifiedClassName::fromStringInContext(
@@ -101,7 +105,7 @@ class ParseVisitor extends ScopeVisitor {
 
         // Hunt for an available alternate ID if necessary
         $alternate_id = 0;
-        while($this->code_base->hasClassWithFQSEN($class_fqsen)) {
+        while ($this->code_base->hasClassWithFQSEN($class_fqsen)) {
             $class_fqsen = $class_fqsen->withAlternateId(++$alternate_id);
         }
 
@@ -126,12 +130,12 @@ class ParseVisitor extends ScopeVisitor {
         $this->code_base->addClass($clazz);
 
         // Look to see if we have a parent class
-        if(!empty($node->children['extends'])) {
+        if (!empty($node->children['extends'])) {
             $parent_class_name =
                 $node->children['extends']->children['name'];
 
             // Check to see if the name isn't fully qualified
-            if($node->children['extends']->flags & \ast\flags\NAME_NOT_FQ) {
+            if ($node->children['extends']->flags & \ast\flags\NAME_NOT_FQ) {
                 if ($this->context->hasNamespaceMapFor(
                     T_CLASS,
                     $parent_class_name
@@ -150,7 +154,7 @@ class ParseVisitor extends ScopeVisitor {
 
             // The name is fully qualified. Make sure it looks
             // like it is
-            if(0 !== strpos($parent_class_name, '\\')) {
+            if (0 !== strpos($parent_class_name, '\\')) {
                 $parent_class_name = '\\' . $parent_class_name;
             }
 
@@ -200,7 +204,8 @@ class ParseVisitor extends ScopeVisitor {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitUseTrait(Node $node) : Context {
+    public function visitUseTrait(Node $node) : Context
+    {
         // Bomb out if we're not in a class context
         $clazz = $this->getContextClass();
 
@@ -234,7 +239,8 @@ class ParseVisitor extends ScopeVisitor {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitMethod(Decl $node) : Context {
+    public function visitMethod(Decl $node) : Context
+    {
         // Bomb out if we're not in a class context
         $clazz = $this->getContextClass();
 
@@ -248,7 +254,7 @@ class ParseVisitor extends ScopeVisitor {
 
         // Hunt for an available alternate ID if necessary
         $alternate_id = 0;
-        while($this->code_base->hasMethod($method_fqsen)) {
+        while ($this->code_base->hasMethod($method_fqsen)) {
             $method_fqsen =
                 $method_fqsen->withAlternateId(++$alternate_id);
         }
@@ -258,9 +264,11 @@ class ParseVisitor extends ScopeVisitor {
 
         // Add $this to the scope of non-static methods
         if (!($node->flags & \ast\flags\MODIFIER_STATIC)) {
-            assert($clazz->getContext()->getScope()
+            assert(
+                $clazz->getContext()->getScope()
                 ->hasVariableWithName('this'),
-                "Classes must have a \$this variable.");
+                "Classes must have a \$this variable."
+            );
 
             $context = $context->withScopeVariable(
                 $clazz->getContext()->getScope()
@@ -281,13 +289,11 @@ class ParseVisitor extends ScopeVisitor {
 
         if ('__construct' === $method_name) {
             $clazz->setIsParentConstructorCalled(false);
-        }
-        else if ('__invoke' === $method_name) {
+        } elseif ('__invoke' === $method_name) {
             $clazz->getUnionType()->addType(
                 CallableType::instance()
             );
-        }
-        else if ('__toString' === $method_name
+        } elseif ('__toString' === $method_name
             && !$this->context->getIsStrictTypes()
         ) {
             $clazz->getUnionType()->addType(
@@ -320,7 +326,8 @@ class ParseVisitor extends ScopeVisitor {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitPropDecl(Node $node) : Context {
+    public function visitPropDecl(Node $node) : Context
+    {
         // Bomb out if we're not in a class context
         $clazz = $this->getContextClass();
 
@@ -330,7 +337,7 @@ class ParseVisitor extends ScopeVisitor {
             $this->context
         );
 
-        foreach($node->children ?? [] as $i => $child_node) {
+        foreach ($node->children ?? [] as $i => $child_node) {
             // Ignore children which are not property elements
             if (!$child_node
                 || $child_node->kind != \ast\AST_PROP_ELEM
@@ -368,20 +375,22 @@ class ParseVisitor extends ScopeVisitor {
 
             $property_name = $child_node->children['name'];
 
-            assert(is_string($property_name),
+            assert(
+                is_string($property_name),
                 'Property name must be a string. '
                 . 'Got '
                 . print_r($property_name, true)
                 . ' at '
-                . $this->context);
+                . $this->context
+            );
 
             $property =
                 new Property(
                     clone($this->context
                         ->withLineNumberStart($child_node->lineno ?? 0)),
                     is_string($child_node->children['name'])
-                        ? $child_node->children['name']
-                        : '_error_',
+                    ? $child_node->children['name']
+                    : '_error_',
                     $union_type,
                     $node->flags ?? 0
                 );
@@ -438,10 +447,11 @@ class ParseVisitor extends ScopeVisitor {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitClassConstDecl(Node $node) : Context {
+    public function visitClassConstDecl(Node $node) : Context
+    {
         $clazz = $this->getContextClass();
 
-        foreach($node->children ?? [] as $child_node) {
+        foreach ($node->children ?? [] as $child_node) {
             $name = $child_node->children['name'];
 
             $fqsen = FullyQualifiedClassConstantName::fromStringInContext(
@@ -487,7 +497,8 @@ class ParseVisitor extends ScopeVisitor {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitFuncDecl(Decl $node) : Context {
+    public function visitFuncDecl(Decl $node) : Context
+    {
         $function_name = (string)$node->name;
 
         // Hunt for an un-taken alternate ID
@@ -502,7 +513,7 @@ class ParseVisitor extends ScopeVisitor {
                 ->withNamespace($this->context->getNamespace())
                 ->withAlternateId($alternate_id++);
 
-        } while($this->code_base
+        } while ($this->code_base
             ->hasMethod($function_fqsen));
 
         $method = Method::fromNode(
@@ -541,13 +552,14 @@ class ParseVisitor extends ScopeVisitor {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitCall(Node $node) : Context {
+    public function visitCall(Node $node) : Context
+    {
         // If this is a call to a method that indicates that we
         // are treating the method in scope as a varargs method,
         // then set its optional args to something very high so
         // it can be called with anything.
         $expression = $node->children['expr'];
-        if($expression->kind === \ast\AST_NAME
+        if ($expression->kind === \ast\AST_NAME
             && $this->context->isMethodScope()
             && in_array($expression->children['name'], [
                 'func_get_args', 'func_get_arg', 'func_num_args'
@@ -570,20 +582,21 @@ class ParseVisitor extends ScopeVisitor {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitStaticCall(Node $node) : Context {
+    public function visitStaticCall(Node $node) : Context
+    {
         $call = $node->children['class'];
 
-        if($call->kind == \ast\AST_NAME) {
+        if ($call->kind == \ast\AST_NAME) {
             $func_name = strtolower($call->children['name']);
-            if($func_name == 'parent') {
+            if ($func_name == 'parent') {
                 // Make sure it is not a crazy dynamic parent method call
-                if(!($node->children['method'] instanceof Node)) {
+                if (!($node->children['method'] instanceof Node)) {
                     $meth = strtolower($node->children['method']);
 
-                    if($meth == '__construct') {
+                    if ($meth == '__construct') {
                         $clazz = $this->getContextClass();
                         $clazz->setIsParentConstructorCalled(true);
-					}
+                    }
                 }
             }
         }
@@ -601,7 +614,8 @@ class ParseVisitor extends ScopeVisitor {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitReturn(Node $node) : Context {
+    public function visitReturn(Node $node) : Context
+    {
         if (Config::get()->backward_compatibility_checks) {
             (new ContextNode(
                 $this->code_base,
@@ -620,12 +634,14 @@ class ParseVisitor extends ScopeVisitor {
         $method = null;
         if ($this->context->isClosureScope()) {
             $method = $this->context->getClosureInScope($this->code_base);
-        } else if ($this->context->isMethodScope()) {
+        } elseif ($this->context->isMethodScope()) {
             $method = $this->context->getMethodInScope($this->code_base);
         }
 
-        assert(!empty($method),
-            "We're supposed to be in either method or closure scope.");
+        assert(
+            !empty($method),
+            "We're supposed to be in either method or closure scope."
+        );
 
         // Mark the method as returning something
         $method->setHasReturn(true);
@@ -643,7 +659,8 @@ class ParseVisitor extends ScopeVisitor {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitPrint(Node $node) : Context {
+    public function visitPrint(Node $node) : Context
+    {
         return $this->visitReturn($node);
     }
 
@@ -657,7 +674,8 @@ class ParseVisitor extends ScopeVisitor {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitEcho(Node $node) : Context {
+    public function visitEcho(Node $node) : Context
+    {
         return $this->visitReturn($node);
     }
 
@@ -671,7 +689,8 @@ class ParseVisitor extends ScopeVisitor {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitMethodCall(Node $node) : Context {
+    public function visitMethodCall(Node $node) : Context
+    {
         return $this->visitReturn($node);
     }
 
@@ -685,7 +704,8 @@ class ParseVisitor extends ScopeVisitor {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitDeclare(Node $node) : Context {
+    public function visitDeclare(Node $node) : Context
+    {
         $declares = $node->children['declares'];
         $name = $declares->children[0]->children['name'];
         $value = $declares->children[0]->children['value'];
@@ -701,7 +721,8 @@ class ParseVisitor extends ScopeVisitor {
      * @return Clazz
      * Get the class on this scope or fail real hard
      */
-    private function getContextClass() : Clazz {
+    private function getContextClass() : Clazz
+    {
         return $this->context->getClassInScope($this->code_base);
     }
 }

--- a/src/Phan/Analyze/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analyze/PostOrderAnalysisVisitor.php
@@ -33,7 +33,8 @@ use \ast\Node;
 use \ast\Node\Decl;
 use Phan\Phan;
 
-class PostOrderAnalysisVisitor extends KindVisitorImplementation {
+class PostOrderAnalysisVisitor extends KindVisitorImplementation
+{
 
     /**
      * @var CodeBase
@@ -86,7 +87,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visit(Node $node) : Context {
+    public function visit(Node $node) : Context
+    {
         // Many nodes don't change the context and we
         // don't need to read them.
         return $this->context;
@@ -100,7 +102,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitAssign(Node $node) : Context {
+    public function visitAssign(Node $node) : Context
+    {
         // Get the type of the right side of the
         // assignment
         $right_type = UnionType::fromNode(
@@ -109,8 +112,10 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
             $node->children['expr']
         );
 
-        assert($node->children['var'] instanceof Node,
-            "Expected left side of assignment to be a var in {$this->context}");
+        assert(
+            $node->children['var'] instanceof Node,
+            "Expected left side of assignment to be a var in {$this->context}"
+        );
 
         // Handle the assignment based on the type of the
         // right side of the equation and the kind of item
@@ -159,7 +164,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitAssignRef(Node $node) : Context {
+    public function visitAssignRef(Node $node) : Context
+    {
         return $this->visitAssign($node);
     }
 
@@ -171,7 +177,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitList(Node $node) : Context {
+    public function visitList(Node $node) : Context
+    {
         return $this->context;
     }
 
@@ -183,7 +190,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitIfElem(Node $node) : Context {
+    public function visitIfElem(Node $node) : Context
+    {
         if (!isset($node->children['cond'])
             || !($node->children['cond'] instanceof Node)
         ) {
@@ -209,7 +217,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitWhile(Node $node) : Context {
+    public function visitWhile(Node $node) : Context
+    {
         return $this->visitIfElem($node);
     }
 
@@ -221,7 +230,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitSwitch(Node $node) : Context {
+    public function visitSwitch(Node $node) : Context
+    {
         return $this->visitIfElem($node);
     }
 
@@ -233,7 +243,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitSwitchCase(Node $node) : Context {
+    public function visitSwitchCase(Node $node) : Context
+    {
         return $this->visitIfElem($node);
     }
 
@@ -245,7 +256,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitExprList(Node $node) : Context {
+    public function visitExprList(Node $node) : Context
+    {
         return $this->visitIfElem($node);
     }
 
@@ -257,7 +269,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitDoWhile(Node $node) : Context {
+    public function visitDoWhile(Node $node) : Context
+    {
         return $this->context;
     }
 
@@ -271,7 +284,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitGlobal(Node $node) : Context {
+    public function visitGlobal(Node $node) : Context
+    {
         $variable = Variable::fromNodeInContext(
             $node->children['var'],
             $this->context,
@@ -294,7 +308,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitForeach(Node $node) : Context {
+    public function visitForeach(Node $node) : Context
+    {
         $expression_type = UnionType::fromNode(
             $this->context,
             $this->code_base,
@@ -323,7 +338,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitStatic(Node $node) : Context {
+    public function visitStatic(Node $node) : Context
+    {
         $variable = Variable::fromNodeInContext(
             $node->children['var'],
             $this->context,
@@ -358,7 +374,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitEcho(Node $node) : Context {
+    public function visitEcho(Node $node) : Context
+    {
         return $this->visitPrint($node);
     }
 
@@ -370,7 +387,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitPrint(Node $node) : Context {
+    public function visitPrint(Node $node) : Context
+    {
         $type = UnionType::fromNode(
             $this->context,
             $this->code_base,
@@ -399,7 +417,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitVar(Node $node) : Context {
+    public function visitVar(Node $node) : Context
+    {
         $this->analyzeNoOp($node, Issue::NoopVariable);
         return $this->context;
     }
@@ -412,7 +431,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitArray(Node $node) : Context {
+    public function visitArray(Node $node) : Context
+    {
         $this->analyzeNoOp($node, Issue::NoopArray);
         return $this->context;
     }
@@ -425,7 +445,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitConst(Node $node) : Context {
+    public function visitConst(Node $node) : Context
+    {
 
         try {
             $constant = (new ContextNode(
@@ -458,7 +479,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitClassConst(Node $node) : Context {
+    public function visitClassConst(Node $node) : Context
+    {
         try {
             $constant = (new ContextNode(
                 $this->code_base,
@@ -490,7 +512,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitClosure(Decl $node) : Context {
+    public function visitClosure(Decl $node) : Context
+    {
         $this->analyzeNoOp($node, Issue::NoopClosure);
         return $this->context;
     }
@@ -503,7 +526,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitReturn(Node $node) : Context {
+    public function visitReturn(Node $node) : Context
+    {
         // Don't check return types in traits
         if ($this->context->isInClassScope()) {
             $clazz = $this->context->getClassInScope($this->code_base);
@@ -522,12 +546,14 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
         $method = null;
         if ($this->context->isClosureScope()) {
             $method = $this->context->getClosureInScope($this->code_base);
-        } else if ($this->context->isMethodScope()) {
+        } elseif ($this->context->isMethodScope()) {
             $method = $this->context->getMethodInScope($this->code_base);
         }
 
-        assert(!empty($method),
-            "We're supposed to be in either method or closure scope.");
+        assert(
+            !empty($method),
+            "We're supposed to be in either method or closure scope."
+        );
 
         // Figure out what we intend to return
         $method_return_type = $method->getUnionType();
@@ -557,9 +583,9 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
 
         if (!$method->isReturnTypeUndefined()
             && !$expression_type->canCastToExpandedUnionType(
-                    $method_return_type,
-                    $this->code_base
-                )
+                $method_return_type,
+                $this->code_base
+            )
         ) {
             Issue::emit(
                 Issue::TypeMismatchReturn,
@@ -588,7 +614,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitPropDecl(Node $node) : Context {
+    public function visitPropDecl(Node $node) : Context
+    {
         return $this->context;
     }
 
@@ -600,7 +627,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitCall(Node $node) : Context {
+    public function visitCall(Node $node) : Context
+    {
         $expression = $node->children['expr'];
 
         (new ContextNode(
@@ -609,8 +637,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
             $node
         ))->analyzeBackwardCompatibility();
 
-        foreach($node->children['args']->children ?? [] as $arg_node) {
-            if($arg_node instanceof Node) {
+        foreach ($node->children['args']->children ?? [] as $arg_node) {
+            if ($arg_node instanceof Node) {
                 (new ContextNode(
                     $this->code_base,
                     $this->context,
@@ -626,7 +654,7 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
                 $expression
             ))->getVariableName();
 
-            if(empty($variable_name)) {
+            if (empty($variable_name)) {
                 return $this->context;
             }
 
@@ -669,9 +697,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
                     }
                 }
             }
-        } else if (
-            $expression->kind == \ast\AST_NAME
-        ){
+        } elseif ($expression->kind == \ast\AST_NAME
+        ) {
             try {
                 $method = (new ContextNode(
                     $this->code_base,
@@ -679,7 +706,7 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
                     $expression
                 ))->getFunction(
                     $expression->children['name']
-                        ?? $expression->children['method']
+                    ?? $expression->children['method']
                 );
             } catch (IssueException $exception) {
                 Phan::getIssueCollector()->collectIssue($exception->getIssueInstance());
@@ -692,8 +719,7 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
                 $method,
                 $node
             );
-        } else if (
-            $expression->kind == \ast\AST_CALL
+        } elseif ($expression->kind == \ast\AST_CALL
             || $expression->kind == \ast\AST_STATIC_CALL
             || $expression->kind == \ast\AST_NEW
             || $expression->kind == \ast\AST_METHOD_CALL
@@ -706,7 +732,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
 
             foreach ($class_list as $class) {
                 if (!$class->hasMethodWithName(
-                    $this->code_base, '__invoke'
+                    $this->code_base,
+                    '__invoke'
                 )) {
                     continue;
                 }
@@ -745,7 +772,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitNew(Node $node) : Context {
+    public function visitNew(Node $node) : Context
+    {
         try {
             $context_node = (new ContextNode(
                 $this->code_base,
@@ -754,7 +782,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
             ));
 
             $method = $context_node->getMethod(
-                '__construct', false
+                '__construct',
+                false
             );
 
             // Add a reference to each class this method
@@ -817,7 +846,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitInstanceof(Node $node) : Context {
+    public function visitInstanceof(Node $node) : Context
+    {
         try {
             $class_list = (new ContextNode(
                 $this->code_base,
@@ -844,7 +874,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitStaticCall(Node $node) : Context {
+    public function visitStaticCall(Node $node) : Context
+    {
 
         // Get the name of the method being called
         $method_name = $node->children['method'];
@@ -856,7 +887,7 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
 
         // Get the name of the static class being referenced
         $static_class = '';
-        if($node->children['class']->kind == \ast\AST_NAME) {
+        if ($node->children['class']->kind == \ast\AST_NAME) {
             $static_class = $node->children['class']->children['name'];
         }
 
@@ -885,8 +916,7 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
 
             // If the method isn't static and we're not calling
             // it on 'parent', we're in a bad spot.
-            if(!$method->isStatic() && 'parent' !== $static_class) {
-
+            if (!$method->isStatic() && 'parent' !== $static_class) {
                 $class_list = (new ContextNode(
                     $this->code_base,
                     $this->context,
@@ -915,8 +945,7 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
         } catch (IssueException $exception) {
             Phan::getIssueCollector()->collectIssue($exception->getIssueInstance());
 
-        }  catch (\Exception $exception) {
-
+        } catch (\Exception $exception) {
             // If we can't figure out the class for this method
             // call, cry YOLO and mark every method with that
             // name with a reference.
@@ -947,7 +976,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitMethod(Decl $node) : Context {
+    public function visitMethod(Decl $node) : Context
+    {
         $method =
             $this->context->getMethodInScope($this->code_base);
 
@@ -958,7 +988,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
             try {
                 $class = $method->getDefiningClass($this->code_base);
                 $has_interface_class = $class->isInterface();
-            } catch (\Exception $exception) {}
+            } catch (\Exception $exception) {
+            }
         }
 
         if (!$method->isAbstract()
@@ -990,7 +1021,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitFuncDecl(Decl $node) : Context {
+    public function visitFuncDecl(Decl $node) : Context
+    {
         return $this->visitMethod($node);
     }
 
@@ -1002,7 +1034,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitMethodCall(Node $node) : Context {
+    public function visitMethodCall(Node $node) : Context
+    {
         $method_name = $node->children['method'];
 
         if (!is_string($method_name)) {
@@ -1021,7 +1054,6 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
             Phan::getIssueCollector()->collectIssue($exception->getIssueInstance());
             return $this->context;
         } catch (NodeException $exception) {
-
             // If we can't figure out the class for this method
             // call, cry YOLO and mark every method with that
             // name with a reference.
@@ -1059,36 +1091,39 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitDim(Node $node) : Context {
+    public function visitDim(Node $node) : Context
+    {
         if (!Config::get()->backward_compatibility_checks) {
             return $this->context;
         }
 
-        if(!($node->children['expr'] instanceof Node
+        if (!($node->children['expr'] instanceof Node
             && ($node->children['expr']->children['name'] ?? null) instanceof Node)
         ) {
             return $this->context;
         }
 
         // check for $$var[]
-        if($node->children['expr']->kind == \ast\AST_VAR
+        if ($node->children['expr']->kind == \ast\AST_VAR
             && $node->children['expr']->children['name']->kind == \ast\AST_VAR
         ) {
             $temp = $node->children['expr']->children['name'];
             $depth = 1;
-            while($temp instanceof Node) {
-                assert(isset($temp->children['name']),
-                    "Expected to find a name at {$this->context}, something else found.");
+            while ($temp instanceof Node) {
+                assert(
+                    isset($temp->children['name']),
+                    "Expected to find a name at {$this->context}, something else found."
+                );
                 $temp = $temp->children['name'];
                 $depth++;
             }
-            $dollars = str_repeat('$',$depth);
+            $dollars = str_repeat('$', $depth);
             $ftemp = new \SplFileObject($this->context->getFile());
             $ftemp->seek($node->lineno-1);
             $line = $ftemp->current();
             unset($ftemp);
-            if(strpos($line,'{') === false
-                || strpos($line,'}') === false
+            if (strpos($line, '{') === false
+                || strpos($line, '}') === false
             ) {
                 Issue::emit(
                     Issue::CompatibleExpressionPHP7,
@@ -1099,7 +1134,7 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
             }
 
         // $foo->$bar['baz'];
-        } else if(!empty($node->children['expr']->children[1])
+        } elseif (!empty($node->children['expr']->children[1])
             && ($node->children['expr']->children[1] instanceof Node)
             && ($node->children['expr']->kind == \ast\AST_PROP)
             && ($node->children['expr']->children[0]->kind == \ast\AST_VAR)
@@ -1109,8 +1144,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
             $ftemp->seek($node->lineno-1);
             $line = $ftemp->current();
             unset($ftemp);
-            if(strpos($line,'{') === false
-                || strpos($line,'}') === false
+            if (strpos($line, '{') === false
+                || strpos($line, '}') === false
             ) {
                 Issue::emit(
                     Issue::CompatiblePHP7,
@@ -1123,7 +1158,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
         return $this->context;
     }
 
-    public function visitStaticProp(Node $node) : Context {
+    public function visitStaticProp(Node $node) : Context
+    {
         return $this->visitProp($node);
     }
 
@@ -1138,7 +1174,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitProp(Node $node) : Context {
+    public function visitProp(Node $node) : Context
+    {
         try {
             $property = (new ContextNode(
                 $this->code_base,
@@ -1199,8 +1236,7 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
                         $this->context,
                         $argument
                     ))->getOrCreateVariable();
-                } else if (
-                    $argument->kind == \ast\AST_STATIC_PROP
+                } elseif ($argument->kind == \ast\AST_STATIC_PROP
                     || $argument->kind == \ast\AST_PROP
                 ) {
                     $property_name = $argument->children['prop'];
@@ -1263,8 +1299,7 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
                         $this->context,
                         $argument
                     ))->getOrCreateVariable();
-                } else if (
-                    $argument->kind == \ast\AST_STATIC_PROP
+                } elseif ($argument->kind == \ast\AST_STATIC_PROP
                     || $argument->kind == \ast\AST_PROP
                 ) {
                     $property_name = $argument->children['prop'];
@@ -1335,7 +1370,9 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
             if ($parameter->getUnionType()->isEmpty()) {
                 $has_argument_parameter_mismatch = true;
                 $argument_type = UnionType::fromNode(
-                    $this->context, $this->code_base, $argument
+                    $this->context,
+                    $this->code_base,
+                    $argument
                 );
 
                 // If this isn't an internal function or method
@@ -1376,7 +1413,8 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
                             // parameter its mimicking
                             $method->getContext()->addScopeVariable(
                                 new PassByReferenceVariable(
-                                    $parameter, $variable
+                                    $parameter,
+                                    $variable
                                 )
                             );
                         }
@@ -1421,8 +1459,9 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
      *
      * @return null
      */
-    private function analyzeNoOp(Node $node, string $issue_type) {
-        if($this->parent_node instanceof Node &&
+    private function analyzeNoOp(Node $node, string $issue_type)
+    {
+        if ($this->parent_node instanceof Node &&
             $this->parent_node->kind == \ast\AST_STMT_LIST
         ) {
             Issue::emit(
@@ -1432,5 +1471,4 @@ class PostOrderAnalysisVisitor extends KindVisitorImplementation {
             );
         }
     }
-
 }

--- a/src/Phan/Analyze/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analyze/PreOrderAnalysisVisitor.php
@@ -28,7 +28,8 @@ use \Phan\Language\UnionType;
 use \ast\Node;
 use \ast\Node\Decl;
 
-class PreOrderAnalysisVisitor extends ScopeVisitor {
+class PreOrderAnalysisVisitor extends ScopeVisitor
+{
 
     /**
      * @param Context $context
@@ -52,7 +53,8 @@ class PreOrderAnalysisVisitor extends ScopeVisitor {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitClass(Decl $node) : Context {
+    public function visitClass(Decl $node) : Context
+    {
 
         if ($node->flags & \ast\flags\CLASS_ANONYMOUS) {
             $class_name =
@@ -89,8 +91,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor {
                 $class_fqsen
             );
 
-        } while(
-            $this->context->getProjectRelativePath()
+        } while ($this->context->getProjectRelativePath()
                 != $clazz->getContext()->getProjectRelativePath()
             || $this->context->getLineNumberStart() != $clazz->getContext()->getLineNumberStart()
         );
@@ -110,7 +111,8 @@ class PreOrderAnalysisVisitor extends ScopeVisitor {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitMethod(Decl $node) : Context {
+    public function visitMethod(Decl $node) : Context
+    {
         $method_name = (string)$node->name;
         $clazz = $this->getContextClass();
 
@@ -145,7 +147,8 @@ class PreOrderAnalysisVisitor extends ScopeVisitor {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitFuncDecl(Decl $node) : Context {
+    public function visitFuncDecl(Decl $node) : Context
+    {
         $function_name = (string)$node->name;
 
         try {
@@ -165,8 +168,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor {
         // Hunt for the alternate associated with the file we're
         // looking at currently in this context.
         foreach ($method->alternateGenerator($this->code_base)
-            as $i => $alternate_method
-        ) {
+ as $i => $alternate_method) {
             if ($alternate_method->getContext()->getProjectRelativePath()
                 === $this->context->getProjectRelativePath()
             ) {
@@ -195,7 +197,8 @@ class PreOrderAnalysisVisitor extends ScopeVisitor {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitClosure(Decl $node) : Context {
+    public function visitClosure(Decl $node) : Context
+    {
 
         $closure_fqsen =
             FullyQualifiedFunctionName::fromClosureInContext(
@@ -223,12 +226,12 @@ class PreOrderAnalysisVisitor extends ScopeVisitor {
         // Make the closure reachable by FQSEN from anywhere
         $this->code_base->addMethod($method);
 
-        if(!empty($node->children['uses'])
+        if (!empty($node->children['uses'])
             && $node->children['uses']->kind == \ast\AST_CLOSURE_USES
         ) {
             $uses = $node->children['uses'];
-            foreach($uses->children as $use) {
-                if($use->kind != \ast\AST_CLOSURE_VAR) {
+            foreach ($uses->children as $use) {
+                if ($use->kind != \ast\AST_CLOSURE_VAR) {
                     Issue::emit(
                         Issue::VariableUseClause,
                         $this->context->getFile(),
@@ -243,7 +246,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor {
                     $use->children['name']
                 ))->getVariableName();
 
-                if(empty($variable_name)) {
+                if (empty($variable_name)) {
                     continue;
                 }
 
@@ -322,9 +325,10 @@ class PreOrderAnalysisVisitor extends ScopeVisitor {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitForeach(Node $node) : Context {
-        if($node->children['value']->kind == \ast\AST_LIST) {
-            foreach($node->children['value']->children ?? [] as $child_node) {
+    public function visitForeach(Node $node) : Context
+    {
+        if ($node->children['value']->kind == \ast\AST_LIST) {
+            foreach ($node->children['value']->children ?? [] as $child_node) {
                 // for syntax like: foreach ([] as list(, $a));
                 if ($child_node === null) {
                     continue;
@@ -374,8 +378,8 @@ class PreOrderAnalysisVisitor extends ScopeVisitor {
         }
 
         // If there's a key, make a variable out of that too
-        if(!empty($node->children['key'])) {
-            if(($node->children['key'] instanceof \ast\Node)
+        if (!empty($node->children['key'])) {
+            if (($node->children['key'] instanceof \ast\Node)
                 && ($node->children['key']->kind == \ast\AST_LIST)
             ) {
                 throw new NodeException(
@@ -407,7 +411,8 @@ class PreOrderAnalysisVisitor extends ScopeVisitor {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitCatch(Node $node) : Context {
+    public function visitCatch(Node $node) : Context
+    {
         try {
             $union_type = UnionTypeVisitor::unionTypeFromClassNode(
                 $this->code_base,
@@ -461,7 +466,8 @@ class PreOrderAnalysisVisitor extends ScopeVisitor {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitIfElem(Node $node) : Context {
+    public function visitIfElem(Node $node) : Context
+    {
         // Clone the scope for each branch of a conditional.
         // They'll be merged upon existing all branches.
         $context = $this->context->withScope(
@@ -475,7 +481,8 @@ class PreOrderAnalysisVisitor extends ScopeVisitor {
             && ($node->children['cond'] instanceof Node)
         ) {
             return (new ConditionVisitor(
-                $this->code_base, $context
+                $this->code_base,
+                $context
             ))($node->children['cond']);
         }
 
@@ -486,7 +493,8 @@ class PreOrderAnalysisVisitor extends ScopeVisitor {
      * @return Clazz
      * Get the class on this scope or fail real hard
      */
-    private function getContextClass() : Clazz {
+    private function getContextClass() : Clazz
+    {
         return $this->context->getClassInScope($this->code_base);
     }
 }

--- a/src/Phan/Analyze/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analyze/PreOrderAnalysisVisitor.php
@@ -168,7 +168,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         // Hunt for the alternate associated with the file we're
         // looking at currently in this context.
         foreach ($method->alternateGenerator($this->code_base)
- as $i => $alternate_method) {
+        as $i => $alternate_method) {
             if ($alternate_method->getContext()->getProjectRelativePath()
                 === $this->context->getProjectRelativePath()
             ) {

--- a/src/Phan/Analyze/PropertyTypesAnalyzer.php
+++ b/src/Phan/Analyze/PropertyTypesAnalyzer.php
@@ -8,14 +8,16 @@ use Phan\Language\Element\Clazz;
 use Phan\Language\FQSEN;
 use Phan\Phan;
 
-class PropertyTypesAnalyzer {
+class PropertyTypesAnalyzer
+{
 
     /**
      * Check to see if the given Clazz is a duplicate
      *
      * @return null
      */
-    public static function analyzePropertyTypes(CodeBase $code_base, Clazz $clazz) {
+    public static function analyzePropertyTypes(CodeBase $code_base, Clazz $clazz)
+    {
         foreach ($clazz->getPropertyList($code_base) as $property) {
             try {
                 $union_type = $property->getUnionType();
@@ -26,7 +28,6 @@ class PropertyTypesAnalyzer {
 
             // Look at each type in the parameter's Union Type
             foreach ($union_type->getTypeSet() as $type) {
-
                 // If its a native type or a reference to
                 // self, its OK
                 if ($type->isNativeType() || $type->isSelfType()) {

--- a/src/Phan/Analyze/ReferenceCountsAnalyzer.php
+++ b/src/Phan/Analyze/ReferenceCountsAnalyzer.php
@@ -13,7 +13,8 @@ use Phan\Language\FQSEN;
 use Phan\Language\FQSEN\FullyQualifiedClassElement;
 use Phan\Language\FQSEN\FullyQualifiedMethodName;
 
-class ReferenceCountsAnalyzer {
+class ReferenceCountsAnalyzer
+{
 
     /**
      * Take a look at all globally accessible elements and see if
@@ -21,7 +22,8 @@ class ReferenceCountsAnalyzer {
      *
      * @return void
      */
-    public static function analyzeReferenceCounts(CodeBase $code_base) {
+    public static function analyzeReferenceCounts(CodeBase $code_base)
+    {
         // Check to see if dead code detection is enabled. Keep
         // in mind that the results here are just a guess and
         // we can't tell with certainty that anything is
@@ -39,17 +41,17 @@ class ReferenceCountsAnalyzer {
         );
 
         $i = 0;
-        $analyze_list = function($list, string $issue_type) use ($code_base, &$i, $total_count) {
+        $analyze_list = function ($list, string $issue_type) use ($code_base, &$i, $total_count) {
             foreach ($list as $name => $element) {
-                CLI::progress('dead code',  (++$i)/$total_count);
+                CLI::progress('dead code', (++$i)/$total_count);
                 self::analyzeElementReferenceCounts($code_base, $element, $issue_type);
             }
         };
 
-        $analyze_map = function($map, string $issue_type) use ($code_base, &$i, $total_count) {
+        $analyze_map = function ($map, string $issue_type) use ($code_base, &$i, $total_count) {
             foreach ($map as $fqsen_string => $list) {
                 foreach ($list as $name => $element) {
-                    CLI::progress('dead code',  (++$i)/$total_count);
+                    CLI::progress('dead code', (++$i)/$total_count);
 
                     // Don't worry about internal elements
                     if ($element->getContext()->isInternal()) {

--- a/src/Phan/Analyze/ScopeVisitor.php
+++ b/src/Phan/Analyze/ScopeVisitor.php
@@ -125,7 +125,7 @@ abstract class ScopeVisitor extends KindVisitorImplementation
         $context = $this->context;
 
         foreach ($this->aliasTargetMapFromUseNode($node)
-        as $alias => $map) {
+ as $alias => $map) {
             list($flags, $target) = $map;
             $context = $context->withNamespaceMap(
                 $node->flags ?? 0,

--- a/src/Phan/Analyze/ScopeVisitor.php
+++ b/src/Phan/Analyze/ScopeVisitor.php
@@ -10,7 +10,8 @@ use \Phan\Language\FQSEN\FullyQualifiedGlobalConstantName;
 use \Phan\Language\FQSEN\FullyQualifiedFunctionName;
 use \ast\Node;
 
-abstract class ScopeVisitor extends KindVisitorImplementation {
+abstract class ScopeVisitor extends KindVisitorImplementation
+{
 
     /**
      * @var CodeBase
@@ -51,7 +52,8 @@ abstract class ScopeVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visit(Node $node) : Context {
+    public function visit(Node $node) : Context
+    {
         // Many nodes don't change the context and we
         // don't need to read them.
         return $this->context;
@@ -67,7 +69,8 @@ abstract class ScopeVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitNamespace(Node $node) : Context {
+    public function visitNamespace(Node $node) : Context
+    {
         $namespace = '\\' . (string)$node->children['name'];
         return $this->context->withNamespace($namespace);
     }
@@ -83,7 +86,8 @@ abstract class ScopeVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitGroupUse(Node $node) : Context {
+    public function visitGroupUse(Node $node) : Context
+    {
         $children = $node->children ?? [];
 
         $prefix = array_shift($children);
@@ -91,13 +95,14 @@ abstract class ScopeVisitor extends KindVisitorImplementation {
         $context = $this->context;
 
         foreach ($this->aliasTargetMapFromUseNode(
-                $children['uses'],
-                $prefix
-            ) as $alias => $map
-        ) {
+            $children['uses'],
+            $prefix
+        ) as $alias => $map) {
             list($flags, $target) = $map;
             $context = $context->withNamespaceMap(
-                $flags, $alias, $target
+                $flags,
+                $alias,
+                $target
             );
         }
 
@@ -115,15 +120,17 @@ abstract class ScopeVisitor extends KindVisitorImplementation {
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitUse(Node $node) : Context {
+    public function visitUse(Node $node) : Context
+    {
         $context = $this->context;
 
         foreach ($this->aliasTargetMapFromUseNode($node)
-            as $alias => $map
-        ) {
+        as $alias => $map) {
             list($flags, $target) = $map;
             $context = $context->withNamespaceMap(
-                $node->flags ?? 0, $alias, $target
+                $node->flags ?? 0,
+                $alias,
+                $target
             );
         }
 
@@ -138,15 +145,17 @@ abstract class ScopeVisitor extends KindVisitorImplementation {
         Node $node,
         string $prefix = ''
     ) : array {
-        assert($node->kind == \ast\AST_USE,
-            'Method takes AST_USE nodes');
+        assert(
+            $node->kind == \ast\AST_USE,
+            'Method takes AST_USE nodes'
+        );
 
         $map = [];
-        foreach($node->children ?? [] as $child_node) {
+        foreach ($node->children ?? [] as $child_node) {
             $target = $child_node->children['name'];
 
-            if(empty($child_node->children['alias'])) {
-                if(($pos = strrpos($target, '\\'))!==false) {
+            if (empty($child_node->children['alias'])) {
+                if (($pos = strrpos($target, '\\'))!==false) {
                     $alias = substr($target, $pos + 1);
                 } else {
                     $alias = $target;
@@ -170,7 +179,7 @@ abstract class ScopeVisitor extends KindVisitorImplementation {
                     $prefix . '\\' . implode('\\', $parts),
                     $function_name
                 );
-            } else if ($target_node->flags == T_CONST) {
+            } elseif ($target_node->flags == T_CONST) {
                 $parts = explode('\\', $target);
                 $name = array_pop($parts);
                 $target = FullyQualifiedGlobalConstantName::make(

--- a/src/Phan/Bootstrap.php
+++ b/src/Phan/Bootstrap.php
@@ -23,14 +23,16 @@ foreach ([
 }
 
 // Customize assertions
-assert_options(ASSERT_ACTIVE,   true);
-assert_options(ASSERT_BAIL,     true);
-assert_options(ASSERT_WARNING,  false);
-assert_options(ASSERT_CALLBACK,
+assert_options(ASSERT_ACTIVE, true);
+assert_options(ASSERT_BAIL, true);
+assert_options(ASSERT_WARNING, false);
+assert_options(
+    ASSERT_CALLBACK,
     function (string $script, int $line, $expression, $message) {
         print "$script:$line ($expression) $message\n";
         debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-    });
+    }
+);
 
 // Print more of the backtrace than is done by default
 set_exception_handler(function (Throwable $throwable) {
@@ -40,7 +42,8 @@ set_exception_handler(function (Throwable $throwable) {
 /**
  * @suppress PhanUnreferencedMethod
  */
-function phan_error_handler($errno, $errstr, $errfile, $errline) {
+function phan_error_handler($errno, $errstr, $errfile, $errline)
+{
     print "$errfile:$errline [$errno] $errstr\n";
     debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
 }

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -93,13 +93,13 @@ class CLI
             switch ($key) {
                 case 'h':
                 case 'help':
-                $this->usage();
+                    $this->usage();
                     break;
                 case 'r':
                 case 'file-list-only':
                 // Mark it so that we don't load files through
                 // other mechanisms.
-                $this->file_list_only = true;
+                    $this->file_list_only = true;
 
                     // Empty out the file list
                     $this->file_list = [];

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -11,13 +11,15 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 
-class CLI {
+class CLI
+{
     private $output;
 
     /**
      * @return OutputInterface
      */
-    public function getOutput():OutputInterface {
+    public function getOutput():OutputInterface
+    {
         return $this->output;
     }
 
@@ -38,7 +40,8 @@ class CLI {
      * Create and read command line arguments, configuring
      * \Phan\Config as a side effect.
      */
-    public function __construct() {
+    public function __construct()
+    {
 
         global $argv;
 
@@ -47,7 +50,8 @@ class CLI {
         // Parse command line args
         // still available: g,j,k,n,t,u,v,w,z
         $opts = getopt(
-            "f:m:o:c:aeqbr:pid:s:3:y:l:xh::", [
+            "f:m:o:c:aeqbr:pid:s:3:y:l:xh::",
+            [
                 'backward-compatibility-checks',
                 'dead-code-detection',
                 'directory:',
@@ -85,123 +89,124 @@ class CLI {
         $mask = -1;
         $minimumSeverity = Issue::SEVERITY_LOW;
 
-        foreach($opts ?? [] as $key => $value) {
-            switch($key) {
-            case 'h':
-            case 'help':
+        foreach ($opts ?? [] as $key => $value) {
+            switch ($key) {
+                case 'h':
+                case 'help':
                 $this->usage();
-                break;
-            case 'r':
-            case 'file-list-only':
+                    break;
+                case 'r':
+                case 'file-list-only':
                 // Mark it so that we don't load files through
                 // other mechanisms.
                 $this->file_list_only = true;
 
-                // Empty out the file list
-                $this->file_list = [];
+                    // Empty out the file list
+                    $this->file_list = [];
 
-                // Intentionally fall through to load the
-                // file list
-            case 'f':
-            case 'file-list':
-                $file_list = is_array($value) ? $value : [$value];
-                foreach ($file_list as $file_name) {
-                    if(is_file($file_name) && is_readable($file_name)) {
-                        $this->file_list = array_merge(
-                            $this->file_list,
-                            file($file_name, FILE_IGNORE_NEW_LINES|FILE_SKIP_EMPTY_LINES)
-                        );
-                    } else {
-                        error_log("Unable to read file $file_name");
+                    // Intentionally fall through to load the
+                    // file list
+                case 'f':
+                case 'file-list':
+                    $file_list = is_array($value) ? $value : [$value];
+                    foreach ($file_list as $file_name) {
+                        if (is_file($file_name) && is_readable($file_name)) {
+                            $this->file_list = array_merge(
+                                $this->file_list,
+                                file($file_name, FILE_IGNORE_NEW_LINES|FILE_SKIP_EMPTY_LINES)
+                            );
+                        } else {
+                            error_log("Unable to read file $file_name");
+                        }
                     }
-                }
-                break;
-            case 'l':
-            case 'directory':
-                if (!$this->file_list_only) {
-                    $directory_list = is_array($value) ? $value : [$value];
-                    foreach ($directory_list as $directory_name) {
-                        $this->file_list = array_merge(
-                            $this->file_list,
-                            $this->directoryNameToFileList(
-                                $directory_name
+                    break;
+                case 'l':
+                case 'directory':
+                    if (!$this->file_list_only) {
+                        $directory_list = is_array($value) ? $value : [$value];
+                        foreach ($directory_list as $directory_name) {
+                            $this->file_list = array_merge(
+                                $this->file_list,
+                                $this->directoryNameToFileList(
+                                    $directory_name
+                                )
+                            );
+                        }
+                    }
+                    break;
+                case 'm':
+                case 'output-mode':
+                    if (!in_array($value, $factory->getTypes(), true)) {
+                        $this->usage(
+                            sprintf(
+                                'Unknown output mode "%s". Known values are [%s]',
+                                $value,
+                                implode(',', $factory->getTypes())
                             )
                         );
                     }
-                }
-                break;
-            case 'm':
-            case 'output-mode':
-                if (!in_array($value, $factory->getTypes(), true)) {
-                    $this->usage(
-                        sprintf(
-                            'Unknown output mode "%s". Known values are [%s]',
-                            $value,
-                            implode(',', $factory->getTypes())
-                        )
-                    );
-                }
 
-                $printerType = $value;
-                break;
-            case 'c':
-            case 'parent-constructor-required':
-                Config::get()->parent_constructor_required =
+                    $printerType = $value;
+                    break;
+                case 'c':
+                case 'parent-constructor-required':
+                    Config::get()->parent_constructor_required =
                     explode(',', $value);
-                break;
-            case 'q':
-            case 'quick':
-                Config::get()->quick_mode = true;
-                break;
-            case 'b':
-            case 'backward-compatibility-checks':
-                Config::get()->backward_compatibility_checks = true;
-                break;
-            case 'p':
-            case 'progress-bar':
-                Config::get()->progress_bar = true;
-                break;
-            case 'a':
-            case 'dump-ast':
-                Config::get()->dump_ast = true;
-                break;
-            case 'e':
-            case 'expand-file-list':
-                Config::get()->expand_file_list = true;
-                break;
-            case 'o':
-            case 'output':
-                $this->output = new StreamOutput(fopen($value, 'w'));
-                break;
-            case 'i':
-            case 'ignore-undeclared':
-                $mask ^= Issue::CATEGORY_UNDEFINED;
-                break;
-            case '3':
-            case 'exclude-directory-list':
-                Config::get()->exclude_analysis_directory_list =
+                    break;
+                case 'q':
+                case 'quick':
+                    Config::get()->quick_mode = true;
+                    break;
+                case 'b':
+                case 'backward-compatibility-checks':
+                    Config::get()->backward_compatibility_checks = true;
+                    break;
+                case 'p':
+                case 'progress-bar':
+                    Config::get()->progress_bar = true;
+                    break;
+                case 'a':
+                case 'dump-ast':
+                    Config::get()->dump_ast = true;
+                    break;
+                case 'e':
+                case 'expand-file-list':
+                    Config::get()->expand_file_list = true;
+                    break;
+                case 'o':
+                case 'output':
+                    $this->output = new StreamOutput(fopen($value, 'w'));
+                    break;
+                case 'i':
+                case 'ignore-undeclared':
+                    $mask ^= Issue::CATEGORY_UNDEFINED;
+                    break;
+                case '3':
+                case 'exclude-directory-list':
+                    Config::get()->exclude_analysis_directory_list =
                     explode(',', $value);
-                break;
-            case 's':
-            case 'state-file':
-                Config::get()->stored_state_file_path = $value;
-                break;
-            case 'y':
-            case 'minimum-severity':
-                $minimumSeverity = $value;
-                break;
-            case 'd':
-            case 'project-root-directory':
-                // We handle this flag before parsing options so
-                // that we can get the project root directory to
-                // base other config flags values on
-                break;
-            case 'x':
-            case 'dead-code-detection':
-                Config::get()->dead_code_detection = true;
-                break;
-            default:
-                $this->usage("Unknown option '-$key'"); break;
+                    break;
+                case 's':
+                case 'state-file':
+                    Config::get()->stored_state_file_path = $value;
+                    break;
+                case 'y':
+                case 'minimum-severity':
+                    $minimumSeverity = $value;
+                    break;
+                case 'd':
+                case 'project-root-directory':
+                    // We handle this flag before parsing options so
+                    // that we can get the project root directory to
+                    // base other config flags values on
+                    break;
+                case 'x':
+                case 'dead-code-detection':
+                    Config::get()->dead_code_detection = true;
+                    break;
+                default:
+                    $this->usage("Unknown option '-$key'");
+                    break;
             }
         }
 
@@ -217,8 +222,8 @@ class CLI {
         Phan::setIssueCollector($collector);
 
         $pruneargv = array();
-        foreach($opts ?? [] as $opt => $value) {
-            foreach($argv as $key => $chunk) {
+        foreach ($opts ?? [] as $opt => $value) {
+            foreach ($argv as $key => $chunk) {
                 $regex = '/^'. (isset($opt[1]) ? '--' : '-') . $opt . '/';
 
                 if ($chunk == $value
@@ -230,24 +235,27 @@ class CLI {
             }
         }
 
-        while($key = array_pop($pruneargv)) {
+        while ($key = array_pop($pruneargv)) {
             unset($argv[$key]);
         }
 
-        foreach($argv as $arg) if($arg[0]=='-') {
-            $this->usage("Unknown option '{$arg}'");
+        foreach ($argv as $arg) {
+            if ($arg[0]=='-') {
+                $this->usage("Unknown option '{$arg}'");
+            }
         }
 
         if (!$this->file_list_only) {
             // Merge in any remaining args on the CLI
             $this->file_list = array_merge(
                 $this->file_list,
-                array_slice($argv,1)
+                array_slice($argv, 1)
             );
 
             // Merge in any files given in the config
             $this->file_list = array_merge(
-                $this->file_list, Config::get()->file_list
+                $this->file_list,
+                Config::get()->file_list
             );
 
             // Merge in any directories given in the config
@@ -264,14 +272,16 @@ class CLI {
      * @return string[]
      * Get the set of files to analyze
      */
-    public function getFileList() : array {
+    public function getFileList() : array
+    {
         return $this->file_list;
     }
 
-    private function usage(string $msg='') {
+    private function usage(string $msg = '')
+    {
         global $argv;
 
-        if(!empty($msg)) {
+        if (!empty($msg)) {
             echo "$msg\n";
         }
 
@@ -371,7 +381,7 @@ EOB;
             );
 
             foreach (array_keys(iterator_to_array($iterator)) as $file_name) {
-                if(is_file($file_name) && is_readable($file_name)) {
+                if (is_file($file_name) && is_readable($file_name)) {
                     $file_list[] = $file_name;
                 } else {
                     error_log("Unable to read file $file_name");
@@ -415,14 +425,14 @@ EOB;
         // super fast
         if ($p < 1.0
             && rand(0, 1000) > (1000 * Config::get()->progress_bar_sample_rate
-        )) {
+            )) {
             return;
         }
 
         $memory = memory_get_usage()/1024/1024;
         $peak = memory_get_peak_usage()/1024/1024;
 
-        $padded_message = str_pad ($msg, 10, ' ', STR_PAD_LEFT);
+        $padded_message = str_pad($msg, 10, ' ', STR_PAD_LEFT);
 
         fwrite(STDERR, "$padded_message ");
         $current = (int)($p * 60);
@@ -438,7 +448,8 @@ EOB;
      * up the hierarchy and apply anything in there to
      * the configuration.
      */
-    private function maybeReadConfigFile() {
+    private function maybeReadConfigFile()
+    {
 
         // If the file doesn't exist here, try a directory up
         $config_file_name =
@@ -461,5 +472,4 @@ EOB;
             Config::get()->__set($key, $value);
         }
     }
-
 }

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -37,7 +37,8 @@ use \Phan\Language\UnionType;
  *  // Do stuff ...
  * ```
  */
-class CodeBase {
+class CodeBase
+{
     use \Phan\CodeBase\ClassMap;
     use \Phan\CodeBase\MethodMap;
     use \Phan\CodeBase\ConstantMap;
@@ -59,7 +60,8 @@ class CodeBase {
         $this->addFunctionsByNames($internal_function_name_list);
     }
 
-    public function __clone() {
+    public function __clone()
+    {
         $this->class_map = clone($this->class_map);
     }
 
@@ -67,17 +69,18 @@ class CodeBase {
      * @param string[] $function_name_list
      * A list of function names to load type information for
      */
-    private function addFunctionsByNames(array $function_name_list) {
+    private function addFunctionsByNames(array $function_name_list)
+    {
         foreach ($function_name_list as $i => $function_name) {
             foreach (Method::methodListFromFunctionName($this, $function_name)
-                as $method
-            ) {
+            as $method) {
                 $this->addMethod($method);
             }
         }
     }
 
-    public function store() {
+    public function store()
+    {
         if (!Database::isEnabled()) {
             return;
         }

--- a/src/Phan/CodeBase/ClassMap.php
+++ b/src/Phan/CodeBase/ClassMap.php
@@ -9,7 +9,8 @@ use \Phan\Language\FQSEN\FullyQualifiedClassName;
 use \Phan\Map;
 use \Phan\Model\Clazz as ClazzModel;
 
-trait ClassMap {
+trait ClassMap
+{
 
     /**
      * Implementing classes must support a mechanism for
@@ -27,7 +28,8 @@ trait ClassMap {
     /**
      * Initialize the map
      */
-    public function constructClassMap() {
+    public function constructClassMap()
+    {
         $this->class_map = new Map;
     }
 
@@ -38,7 +40,8 @@ trait ClassMap {
      * @return Map
      * A map from FQSEN to Clazz
      */
-    public function getClassMap() : Map {
+    public function getClassMap() : Map
+    {
         return $this->class_map;
     }
 
@@ -48,7 +51,8 @@ trait ClassMap {
      *
      * @return void
      */
-    private function setClassMap(Map $class_map) {
+    private function setClassMap(Map $class_map)
+    {
         $this->class_map = $class_map;
     }
 
@@ -82,7 +86,8 @@ trait ClassMap {
      * @return bool
      * True if the exlass exists else false
      */
-    public function hasClassWithFQSEN(FullyQualifiedClassName $fqsen) : bool {
+    public function hasClassWithFQSEN(FullyQualifiedClassName $fqsen) : bool
+    {
         // Check memory for the class
         if (!empty($this->class_map[$fqsen])) {
             return true;
@@ -106,13 +111,13 @@ trait ClassMap {
      *
      * @return null
      */
-    public function addClass(Clazz $class) {
+    public function addClass(Clazz $class)
+    {
         $this->class_map[$class->getFQSEN()]
             = $class;
 
         // For classes that aren't internal PHP classes
         if (!$class->getContext()->isInternal()) {
-
             // Associate the class with the file it was found in
             $this->getFileByPath($class->getContext()->getFile())
                 ->addClassFQSEN($class->getFQSEN());
@@ -125,7 +130,8 @@ trait ClassMap {
      *
      * @return null
      */
-    private function addClassesByNames(array $class_name_list) {
+    private function addClassesByNames(array $class_name_list)
+    {
         foreach ($class_name_list as $i => $class_name) {
             $clazz = Clazz::fromClassName($this, $class_name);
             $this->class_map[$clazz->getFQSEN()] = $clazz;
@@ -137,7 +143,8 @@ trait ClassMap {
      *
      * @return null
      */
-    protected function storeClassMap() {
+    protected function storeClassMap()
+    {
         if (!Database::isEnabled()) {
             return;
         }

--- a/src/Phan/CodeBase/ConstantMap.php
+++ b/src/Phan/CodeBase/ConstantMap.php
@@ -11,7 +11,8 @@ use \Phan\Language\FQSEN\FullyQualifiedConstantName;
 use \Phan\Language\FQSEN\FullyQualifiedGlobalConstantName;
 use \Phan\Model\Constant as ConstantModel;
 
-trait ConstantMap {
+trait ConstantMap
+{
 
     /**
      * Implementing classes must support a mechanism for
@@ -29,7 +30,8 @@ trait ConstantMap {
      * @return Constant[][]
      * A map from FQSEN to constant
      */
-    public function getConstantMap() : array {
+    public function getConstantMap() : array
+    {
         return $this->constant_map;
     }
 
@@ -37,7 +39,8 @@ trait ConstantMap {
      * @return Constant[]
      * A map from name to constant
      */
-    public function getConstantMapForScope(FQSEN $fqsen) : array {
+    public function getConstantMapForScope(FQSEN $fqsen) : array
+    {
         if (empty($this->constant_map[(string)$fqsen])) {
             return [];
         }
@@ -51,7 +54,8 @@ trait ConstantMap {
      *
      * @return null
      */
-    public function setConstantMap(array $constant_map) {
+    public function setConstantMap(array $constant_map)
+    {
         $this->constant_map = $constant_map;
     }
 
@@ -65,7 +69,8 @@ trait ConstantMap {
      *
      * @return bool
      */
-    public function hasConstant(FQSEN $fqsen = null, string $name) : bool {
+    public function hasConstant(FQSEN $fqsen = null, string $name) : bool
+    {
         return !empty($this->constant_map[(string)$fqsen][$name]);
     }
 
@@ -80,7 +85,8 @@ trait ConstantMap {
      * @return Constant
      * Get the constant with the given FQSEN
      */
-    public function getConstant(FQSEN $fqsen = null, string $name) : Constant {
+    public function getConstant(FQSEN $fqsen = null, string $name) : Constant
+    {
         return $this->constant_map[(string)$fqsen][$name];
     }
 
@@ -90,7 +96,8 @@ trait ConstantMap {
      *
      * @return null
      */
-    public function addConstant(Constant $constant) {
+    public function addConstant(Constant $constant)
+    {
         $this->addConstantInScope(
             $constant,
             $constant->getFQSEN()
@@ -119,7 +126,8 @@ trait ConstantMap {
      *
      * @return null
      */
-    protected function storeConstantMap() {
+    protected function storeConstantMap()
+    {
         if (!Database::isEnabled()) {
             return;
         }
@@ -142,7 +150,8 @@ trait ConstantMap {
     ) {
         // Remove it from the database
         if (Database::isEnabled()) {
-            ConstantModel::delete(Database::get(),
+            ConstantModel::delete(
+                Database::get(),
                 $scope . '|' .  $name
             );
         }
@@ -150,5 +159,4 @@ trait ConstantMap {
         // Remove it from memory
         unset($this->constant_map[$scope][$name]);
     }
-
 }

--- a/src/Phan/CodeBase/File.php
+++ b/src/Phan/CodeBase/File.php
@@ -16,7 +16,8 @@ use \Phan\Model\File as FileModel;
 /**
  * Information pertaining to PHP code files that we've read
  */
-class File {
+class File
+{
 
     /**
      * @var string
@@ -70,7 +71,8 @@ class File {
      * @return string
      * The file path
      */
-    public function getFilePath() : string {
+    public function getFilePath() : string
+    {
         return $this->file_path;
     }
 
@@ -79,7 +81,8 @@ class File {
      * The path of the file relative to the project
      * root directory
      */
-    public function getProjectRelativePath() : string {
+    public function getProjectRelativePath() : string
+    {
         return self::projectRelativePathFromCWDRelativePath(
             $this->file_path
         );
@@ -121,7 +124,8 @@ class File {
      * The time of the last known modification of this
      * file
      */
-    public function getModificationTime() : int {
+    public function getModificationTime() : int
+    {
         return $this->modification_time;
     }
 
@@ -130,7 +134,8 @@ class File {
      * True if the given file is up to date within this
      * code base, else false
      */
-    public function isParseUpToDate() : bool {
+    public function isParseUpToDate() : bool
+    {
         $real_path = realpath($this->file_path);
 
         // If the file no longer exists, its probably
@@ -150,7 +155,8 @@ class File {
      *
      * @return null
      */
-    public function setParseUpToDate() {
+    public function setParseUpToDate()
+    {
         $this->modification_time = filemtime(realpath($this->file_path));
 
         if (Database::isEnabled()) {
@@ -163,7 +169,8 @@ class File {
      * @return FQSEN[]
      * A list of class FQSENs associated with this file
      */
-    public function getClassFQSENList() : array {
+    public function getClassFQSENList() : array
+    {
         return $this->class_fqsen_list;
     }
 
@@ -173,7 +180,8 @@ class File {
      *
      * @return null
      */
-    public function setClassFQSENList(array $class_fqsen_list) {
+    public function setClassFQSENList(array $class_fqsen_list)
+    {
         $this->class_fqsen_list = $class_fqsen_list;
     }
 
@@ -183,7 +191,8 @@ class File {
      *
      * @return null
      */
-    public function addClassFQSEN(FQSEN $fqsen) {
+    public function addClassFQSEN(FQSEN $fqsen)
+    {
         $this->class_fqsen_list[] = $fqsen;
     }
 
@@ -191,7 +200,8 @@ class File {
      * Remove the class with the given FQSEN from our
      * list of associated classes
      */
-    public function flushClassWithFQSEN(FullyQualifiedClassName $fqsen) {
+    public function flushClassWithFQSEN(FullyQualifiedClassName $fqsen)
+    {
         unset($this->class_fqsen_list[(string)$fqsen]);
     }
 
@@ -199,7 +209,8 @@ class File {
      * @return FullyQualifiedMethodName[]|FullyQualifiedFunctionName[]
      * A list of method FQSENs associated with this file
      */
-    public function getMethodFQSENList() : array {
+    public function getMethodFQSENList() : array
+    {
         return $this->method_fqsen_list;
     }
 
@@ -209,7 +220,8 @@ class File {
      *
      * @return null
      */
-    public function setMethodFQSENList(array $method_fqsen_list) {
+    public function setMethodFQSENList(array $method_fqsen_list)
+    {
         $this->method_fqsen_list = $method_fqsen_list;
     }
 
@@ -219,7 +231,8 @@ class File {
      *
      * @return null
      */
-    public function addMethodFQSEN(FQSEN $fqsen) {
+    public function addMethodFQSEN(FQSEN $fqsen)
+    {
         $this->method_fqsen_list[(string)$fqsen] = $fqsen;
     }
 
@@ -227,7 +240,8 @@ class File {
      * Remove the method with the given FQSEN from our
      * list of associated methods
      */
-    public function flushMethodWithFQSEN(FQSEN $fqsen) {
+    public function flushMethodWithFQSEN(FQSEN $fqsen)
+    {
         unset($this->method_fqsen_list[(string)$fqsen]);
     }
 
@@ -235,7 +249,8 @@ class File {
      * @return FullyQualifiedPropertyName[]
      * A list of property FQSENs associated with this file
      */
-    public function getPropertyFQSENList() : array {
+    public function getPropertyFQSENList() : array
+    {
         return $this->property_fqsen_list;
     }
 
@@ -245,7 +260,8 @@ class File {
      *
      * @return null
      */
-    public function setPropertyFQSENList(array $property_fqsen_list) {
+    public function setPropertyFQSENList(array $property_fqsen_list)
+    {
         $this->property_fqsen_list = $property_fqsen_list;
     }
 
@@ -255,7 +271,8 @@ class File {
      *
      * @return null
      */
-    public function addPropertyFQSEN(FullyQualifiedPropertyName $fqsen) {
+    public function addPropertyFQSEN(FullyQualifiedPropertyName $fqsen)
+    {
         $this->property_fqsen_list[(string)$fqsen] = $fqsen;
     }
 
@@ -263,7 +280,8 @@ class File {
      * Remove the property with the given FQSEN from our
      * list of associated properties
      */
-    public function flushPropertyWithFQSEN(FullyQualifiedPropertyName $fqsen) {
+    public function flushPropertyWithFQSEN(FullyQualifiedPropertyName $fqsen)
+    {
         unset($this->property_fqsen_list[(string)$fqsen]);
     }
 
@@ -271,7 +289,8 @@ class File {
      * @return FullyQualifiedConstantName[]
      * A list of constant FQSENs associated with this file
      */
-    public function getConstantFQSENList() : array {
+    public function getConstantFQSENList() : array
+    {
         return $this->constant_fqsen_list;
     }
 
@@ -281,7 +300,8 @@ class File {
      *
      * @return null
      */
-    public function setConstantFQSENList(array $constant_fqsen_list) {
+    public function setConstantFQSENList(array $constant_fqsen_list)
+    {
         $this->constant_fqsen_list = $constant_fqsen_list;
     }
 
@@ -293,7 +313,8 @@ class File {
      *
      * @suppress PhanUnreferencedMethod
      */
-    public function addConstantFQSEN(FullyQualifiedConstantName $fqsen) {
+    public function addConstantFQSEN(FullyQualifiedConstantName $fqsen)
+    {
         $this->constant_fqsen_list[(string)$fqsen] = $fqsen;
     }
 
@@ -301,12 +322,13 @@ class File {
      * Remove the constant with the given FQSEN from our
      * list of associated constants
      */
-    public function flushConstantWithFQSEN(FQSEN $fqsen) {
+    public function flushConstantWithFQSEN(FQSEN $fqsen)
+    {
         unset($this->constant_fqsen_list[(string)$fqsen]);
     }
 
-    public function __toString() : string {
+    public function __toString() : string
+    {
         return $this->file_path;
     }
-
 }

--- a/src/Phan/CodeBase/File.php
+++ b/src/Phan/CodeBase/File.php
@@ -4,7 +4,10 @@ namespace Phan\CodeBase;
 use \Phan\Config;
 use \Phan\Database;
 use \Phan\Language\Context;
-use \Phan\Language\Element\{Clazz, Element, Method};
+use \Phan\Language\Element\{Clazz,
+    Element,
+    Method
+};
 use \Phan\Language\FQSEN;
 use \Phan\Language\FQSEN\FullyQualifiedClassName;
 use \Phan\Language\FQSEN\FullyQualifiedConstantName;

--- a/src/Phan/CodeBase/FileMap.php
+++ b/src/Phan/CodeBase/FileMap.php
@@ -18,7 +18,8 @@ use \Phan\Model\File as FileModel;
 /**
  * Information pertaining to PHP code files that we've read
  */
-trait FileMap {
+trait FileMap
+{
 
     /**
      * Implementing class must have a method for removing
@@ -136,11 +137,12 @@ trait FileMap {
         // Maps a structural element to a list of files that
         // depend on it
         $file_list_from_element =
-            function(TypedStructuralElement $element) : array {
+            function (TypedStructuralElement $element) : array {
                 return array_map(
-                    function(FileRef $file_ref) : string {
+                    function (FileRef $file_ref) : string {
                         return $file_ref->getFile();
-                    },  $element->getReferenceList()
+                    },
+                    $element->getReferenceList()
                 );
             };
 
@@ -149,10 +151,10 @@ trait FileMap {
             $dependency_file_list = array_merge(
                 $dependency_file_list,
                 $this->hasClassWithFQSEN($fqsen)
-                    ? $file_list_from_element(
+                ? $file_list_from_element(
                         $this->getClassByFQSEN($fqsen)
                     ) : []
-                );
+            );
         }
 
         // Get files that depend on constants defined in this file
@@ -192,10 +194,10 @@ trait FileMap {
             $dependency_file_list = array_merge(
                 $dependency_file_list,
                 $this->hasMethod($fqsen)
-                    ? $file_list_from_element(
+                ? $file_list_from_element(
                         $this->getMethod($fqsen)
                     ) : []
-                );
+            );
         }
 
         return $dependency_file_list;
@@ -273,7 +275,8 @@ trait FileMap {
      * True if the given file is up to date within this
      * code base, else false
      */
-    public function isParseUpToDateForFile(string $file_path) : bool {
+    public function isParseUpToDateForFile(string $file_path) : bool
+    {
         return $this->getFileByPath($file_path)
             ->isParseUpToDate();
     }
@@ -284,7 +287,8 @@ trait FileMap {
      *
      * @return null
      */
-    public function setParseUpToDateForFile(string $file_path) {
+    public function setParseUpToDateForFile(string $file_path)
+    {
         return $this->getFileByPath($file_path)
             ->setParseUpToDate();
     }
@@ -293,7 +297,8 @@ trait FileMap {
      * @return File[]
      * A map from file path to File
      */
-    protected function getFileMap() : array {
+    protected function getFileMap() : array
+    {
         return $this->file_map;
     }
 
@@ -303,7 +308,8 @@ trait FileMap {
      *
      * @return null
      */
-    protected function setFileMap(array $file_map) {
+    protected function setFileMap(array $file_map)
+    {
         $this->file_map = $file_map;
     }
 
@@ -314,9 +320,9 @@ trait FileMap {
      * @return File
      * An object tracking state for the given $file_path
      */
-    protected function getFileByPath(string $file_path) : File {
+    protected function getFileByPath(string $file_path) : File
+    {
         if (empty($this->file_map[$file_path])) {
-
             if (Database::isEnabled()) {
                 try {
                     $file_model =
@@ -344,7 +350,8 @@ trait FileMap {
      *
      * @return null
      */
-    public function storeFileMap() {
+    public function storeFileMap()
+    {
         if (!Database::isEnabled()) {
             return;
         }
@@ -353,5 +360,4 @@ trait FileMap {
             (new FileModel($file))->write(Database::get());
         }
     }
-
 }

--- a/src/Phan/CodeBase/GlobalVariableMap.php
+++ b/src/Phan/CodeBase/GlobalVariableMap.php
@@ -4,7 +4,8 @@ namespace Phan\CodeBase;
 use \Phan\Language\Element\Variable;
 use \Phan\Language\FQSEN;
 
-trait GlobalVariableMap {
+trait GlobalVariableMap
+{
 
     /**
      * @var Variable[]
@@ -16,7 +17,8 @@ trait GlobalVariableMap {
      * @return Variable[]
      * A map from name to global_variable
      */
-    public function getGlobalVariableMap() : array {
+    public function getGlobalVariableMap() : array
+    {
         return $this->global_variable_map;
     }
 
@@ -26,14 +28,16 @@ trait GlobalVariableMap {
      *
      * @return null
      */
-    public function setGlobalVariableMap(array $global_variable_map) {
+    public function setGlobalVariableMap(array $global_variable_map)
+    {
         $this->global_variable_map = $global_variable_map;
     }
 
     /**
      * @return bool
      */
-    public function hasGlobalVariableWithName(string $name) : bool {
+    public function hasGlobalVariableWithName(string $name) : bool
+    {
         return !empty($this->global_variable_map[$name]);
     }
 
@@ -41,7 +45,8 @@ trait GlobalVariableMap {
      * @return Variable
      * Get the global_variable with the given name
      */
-    public function getGlobalVariableByName(string $name) : Variable {
+    public function getGlobalVariableByName(string $name) : Variable
+    {
         return $this->global_variable_map[$name];
     }
 
@@ -51,9 +56,9 @@ trait GlobalVariableMap {
      *
      * @return null
      */
-    public function addGlobalVariable(Variable $global_variable) {
+    public function addGlobalVariable(Variable $global_variable)
+    {
         $this->global_variable_map[$global_variable->getName()] =
             $global_variable;
     }
-
 }

--- a/src/Phan/CodeBase/MethodMap.php
+++ b/src/Phan/CodeBase/MethodMap.php
@@ -13,7 +13,8 @@ use \Phan\Language\UnionType;
 use \Phan\Map;
 use \Phan\Model\Method as MethodModel;
 
-trait MethodMap {
+trait MethodMap
+{
 
     /**
      * Implementing classes must support a mechanism for
@@ -40,7 +41,8 @@ trait MethodMap {
      * @return Method[][]
      * A map from FQSEN to name to method
      */
-    public function getMethodMap() : array {
+    public function getMethodMap() : array
+    {
         return $this->method_map;
     }
 
@@ -64,7 +66,8 @@ trait MethodMap {
      *
      * @return null
      */
-    public function setMethodMap(array $method_map) {
+    public function setMethodMap(array $method_map)
+    {
         $this->method_map = $method_map;
     }
 
@@ -73,7 +76,8 @@ trait MethodMap {
      *
      * @return bool
      */
-    public function hasMethod($fqsen) : bool {
+    public function hasMethod($fqsen) : bool
+    {
         if ($fqsen instanceof FullyQualifiedMethodName) {
             return $this->hasMethodWithMethodFQSEN($fqsen);
         } else {
@@ -135,7 +139,8 @@ trait MethodMap {
                 UnionType::internalFunctionSignatureMap();
 
             $fqsen = FullyQualifiedFunctionName::make(
-                $scope, $name
+                $scope,
+                $name
             );
 
             if (!empty($function_signature_map[$name])) {
@@ -143,7 +148,9 @@ trait MethodMap {
 
                 // Add each method returned for the signature
                 foreach (Method::methodListFromSignature(
-                    $this, $fqsen, $signature
+                    $this,
+                    $fqsen,
+                    $signature
                 ) as $method) {
                     $this->addMethod($method);
                 }
@@ -171,7 +178,8 @@ trait MethodMap {
      * @return Method
      * Get the method with the given FQSEN
      */
-    public function getMethod($fqsen) : Method {
+    public function getMethod($fqsen) : Method
+    {
         if ($fqsen instanceof FullyQualifiedMethodName) {
             return $this->getMethodByMethodFQSEN($fqsen);
         } else {
@@ -186,7 +194,8 @@ trait MethodMap {
      * @return Method[]
      * All known methods with the given name
      */
-    public function getMethodListByName(string $name) : array {
+    public function getMethodListByName(string $name) : array
+    {
 
         // If we're doing dead code detection we'll have faster
         // access at the cost of being a bit more of a memory
@@ -271,15 +280,18 @@ trait MethodMap {
      *
      * @return null
      */
-    public function addMethod(Method $method) {
+    public function addMethod(Method $method)
+    {
         if ($method->getFQSEN() instanceof FullyQualifiedMethodName) {
             $this->addMethodWithMethodFQSEN(
                 $method,
                 $method->getFQSEN()
             );
         } else {
-            assert($method->getFQSEN() instanceof FullyQualifiedFunctionName,
-                "Method given must have FQSEN of type FullyQualifiedMethodName");
+            assert(
+                $method->getFQSEN() instanceof FullyQualifiedFunctionName,
+                "Method given must have FQSEN of type FullyQualifiedMethodName"
+            );
             $this->addMethodWithFunctionFQSEN(
                 $method,
                 $method->getFQSEN()
@@ -371,7 +383,8 @@ trait MethodMap {
      *
      * @return null
      */
-    protected function storeMethodMap() {
+    protected function storeMethodMap()
+    {
         if (!Database::isEnabled()) {
             return;
         }
@@ -395,12 +408,12 @@ trait MethodMap {
         string $name
     ) {
         if (Database::isEnabled()) {
-            MethodModel::delete(Database::get(),
+            MethodModel::delete(
+                Database::get(),
                 $scope . '|' .  $name
             );
         }
 
         unset($this->method_map[$scope][$name]);
     }
-
 }

--- a/src/Phan/CodeBase/PropertyMap.php
+++ b/src/Phan/CodeBase/PropertyMap.php
@@ -8,7 +8,8 @@ use \Phan\Language\FQSEN;
 use \Phan\Language\FQSEN\FullyQualifiedClassName;
 use \Phan\Model\Property as PropertyModel;
 
-trait PropertyMap {
+trait PropertyMap
+{
 
     /**
      * Implementing classes must support a mechanism for
@@ -26,7 +27,8 @@ trait PropertyMap {
      * @return Property[][]
      * A map from FQSEN to name to property
      */
-    public function getPropertyMap() : array {
+    public function getPropertyMap() : array
+    {
         return $this->property_map;
     }
 
@@ -34,7 +36,8 @@ trait PropertyMap {
      * @return Property[]
      * A map from name to property
      */
-    public function getPropertyMapForScope(FQSEN $fqsen) {
+    public function getPropertyMapForScope(FQSEN $fqsen)
+    {
         if (empty($this->property_map[(string)$fqsen])) {
             return [];
         }
@@ -48,14 +51,16 @@ trait PropertyMap {
      *
      * @return null
      */
-    public function setPropertyMap(array $property_map) {
+    public function setPropertyMap(array $property_map)
+    {
         $this->property_map = $property_map;
     }
 
     /**
      * @return bool
      */
-    public function hasProperty(FQSEN $fqsen, string $name) : bool {
+    public function hasProperty(FQSEN $fqsen, string $name) : bool
+    {
 
         if (!empty($this->property_map[(string)$fqsen][$name])) {
             return true;
@@ -64,7 +69,8 @@ trait PropertyMap {
         if (Database::isEnabled()) {
             // Otherwise, check the database
             try {
-                PropertyModel::read(Database::get(),
+                PropertyModel::read(
+                    Database::get(),
                     ((string)$fqsen) . '|' . $name
                 );
                 return true;
@@ -81,11 +87,13 @@ trait PropertyMap {
      * @return Property
      * Get the property with the given FQSEN
      */
-    public function getProperty(FQSEN $fqsen, string $name) : Property {
+    public function getProperty(FQSEN $fqsen, string $name) : Property
+    {
         if (Database::isEnabled()) {
             if (empty($this->property_map[(string)$fqsen][$name])) {
                 $this->property_map[(string)$fqsen][$name] =
-                    PropertyModel::read(Database::get(),
+                    PropertyModel::read(
+                        Database::get(),
                         ((string)$fqsen). '|' . $name
                     )
                     ->getProperty();
@@ -101,7 +109,8 @@ trait PropertyMap {
      *
      * @return null
      */
-    public function addProperty(Property $property) {
+    public function addProperty(Property $property)
+    {
         $this->addPropertyInScope(
             $property,
             $property->getFQSEN()->getFullyQualifiedClassName()
@@ -137,7 +146,8 @@ trait PropertyMap {
      *
      * @return null
      */
-    protected function storePropertyMap() {
+    protected function storePropertyMap()
+    {
         if (!Database::isEnabled()) {
             return;
         }
@@ -146,7 +156,9 @@ trait PropertyMap {
             foreach ($map as $name => $property) {
                 if (!$property->getContext()->isInternal()) {
                     (new PropertyModel(
-                        $property, $scope, $name
+                        $property,
+                        $scope,
+                        $name
                     ))->write(Database::get());
                 }
             }
@@ -162,7 +174,8 @@ trait PropertyMap {
     ) {
         // Remove it from the database
         if (Database::isEnabled()) {
-            PropertyModel::delete(Database::get(),
+            PropertyModel::delete(
+                Database::get(),
                 $scope . '|' . $name
             );
         }
@@ -170,5 +183,4 @@ trait PropertyMap {
         // Remove it from memory
         unset($this->property_map[$scope][$name]);
     }
-
 }

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -8,7 +8,8 @@ use \Phan\Issue;
  * See `./phan -h` for command line usage, or take a
  * look at \Phan\CLI.php for more details on CLI usage.
  */
-class Config {
+class Config
+{
 
     /**
      * @var string
@@ -131,14 +132,17 @@ class Config {
     /**
      * Disallow the constructor to force a singleton
      */
-    private function __construct() {}
+    private function __construct()
+    {
+    }
 
     /**
      * @return string
      * Get the root directory of the project that we're
      * scanning
      */
-    public function getProjectRootDirectory() : string {
+    public function getProjectRootDirectory() : string
+    {
         return $this->project_root_directory ?? getcwd();
     }
 
@@ -159,7 +163,8 @@ class Config {
      * @return Config
      * Get a Configuration singleton
      */
-    public static function get() : Config {
+    public static function get() : Config
+    {
         static $instance;
 
         if ($instance) {
@@ -170,11 +175,13 @@ class Config {
         return $instance;
     }
 
-    public function __get(string $name) {
+    public function __get(string $name)
+    {
         return $this->configuration[$name];
     }
 
-    public function __set(string $name, $value) {
+    public function __set(string $name, $value)
+    {
         $this->configuration[$name] = $value;
     }
 
@@ -184,7 +191,8 @@ class Config {
      *
      * @suppress PhanUnreferencedMethod
      */
-    public static function projectPath(string $relative_path) {
+    public static function projectPath(string $relative_path)
+    {
         return implode(DIRECTORY_SEPARATOR, [
             Config::get()->getProjectRootDirectory(),
             $relative_path

--- a/src/Phan/Database.php
+++ b/src/Phan/Database.php
@@ -8,15 +8,19 @@ use \SQLite3;
 /**
  * This class is the entry point into the static analyzer.
  */
-class Database extends SQLite3 {
+class Database extends SQLite3
+{
     use \Phan\Memoize;
 
-    public function __construct() {
-        assert(!is_dir(Config::get()->stored_state_file_path),
+    public function __construct()
+    {
+        assert(
+            !is_dir(Config::get()->stored_state_file_path),
             "State file '{Config::get()->stored_state_file_path}' cannot be a directory"
         );
 
-        assert(!file_exists(Config::get()->stored_state_file_path)
+        assert(
+            !file_exists(Config::get()->stored_state_file_path)
             || (
                 is_writable(Config::get()->stored_state_file_path)
                 && is_readable(Config::get()->stored_state_file_path)
@@ -34,14 +38,16 @@ class Database extends SQLite3 {
         $this->exec("PRAGMA page_size = 4096");
     }
 
-    public function __destruct() {
+    public function __destruct()
+    {
         $this->close();
     }
 
     /**
      * Get an open database to write to and read from
      */
-    public static function get() : Database {
+    public static function get() : Database
+    {
         static $instance = null;
 
         if (!$instance) {
@@ -61,8 +67,8 @@ class Database extends SQLite3 {
      * @return bool
      * True if the database is enabled
      */
-    public static function isEnabled() : bool {
+    public static function isEnabled() : bool
+    {
         return (bool)Config::get()->stored_state_file_path;
     }
-
 }

--- a/src/Phan/Database/Association.php
+++ b/src/Phan/Database/Association.php
@@ -3,7 +3,8 @@ namespace Phan\Database;
 
 use \Phan\Database;
 
-abstract class Association {
+abstract class Association
+{
 
     /**
      * @var Schema
@@ -76,5 +77,4 @@ abstract class Association {
         Database $database,
         $primary_key_value
     );
-
 }

--- a/src/Phan/Database/Column.php
+++ b/src/Phan/Database/Column.php
@@ -1,7 +1,8 @@
 <?php declare(strict_types=1);
 namespace Phan\Database;
 
-class Column {
+class Column
+{
 
     const TYPE_STRING = 'STRING';
     const TYPE_INT = 'INTEGER';
@@ -27,27 +28,33 @@ class Column {
         $this->is_unique = $is_unique;
     }
 
-    public function name() : string {
+    public function name() : string
+    {
         return $this->name;
     }
 
-    public function sqlType() : string {
+    public function sqlType() : string
+    {
         return $this->sql_type;
     }
 
-    public function isAutoIncrement() : bool {
+    public function isAutoIncrement() : bool
+    {
         return $this->is_auto_increment;
     }
 
-    public function isPrimaryKey() : bool {
+    public function isPrimaryKey() : bool
+    {
         return $this->is_primary_key;
     }
 
-    public function isUnique() : bool {
+    public function isUnique() : bool
+    {
         return $this->is_unique;
     }
 
-    public function __toString() : string {
+    public function __toString() : string
+    {
         $string = $this->name();
 
         $string .= " {$this->sqlType()}";
@@ -62,5 +69,4 @@ class Column {
 
         return $string;
     }
-
 }

--- a/src/Phan/Database/ListAssociation.php
+++ b/src/Phan/Database/ListAssociation.php
@@ -6,7 +6,8 @@ use \Phan\Database;
 /**
  * An association from a model to a list of strings
  */
-class ListAssociation extends Association {
+class ListAssociation extends Association
+{
     use \Phan\Memoize;
 
     /**
@@ -54,7 +55,8 @@ class ListAssociation extends Association {
      * @return Model
      * Read a model from the database with the given pk
      */
-    public function read(Database $database, ModelOne $model) {
+    public function read(Database $database, ModelOne $model)
+    {
         $read_closure = $this->read_closure;
 
         // Select all rows for this PK from the
@@ -91,7 +93,8 @@ class ListAssociation extends Association {
      *
      * @return null
      */
-    public function write(Database $database, ModelOne $model) {
+    public function write(Database $database, ModelOne $model)
+    {
         // Ensure that we've initialized this model
         $this->schema->initializeOnce($database);
 
@@ -101,7 +104,6 @@ class ListAssociation extends Association {
             $model->primaryKeyValue();
 
         foreach ($write_closure($model) as $key => $value) {
-
             // Write the association
             $query =
                 $this->schema->queryForInsert([
@@ -128,10 +130,10 @@ class ListAssociation extends Association {
         $this->schema->initializeOnce($database);
 
         $query = $this->schema->queryForDeleteColumnValue(
-            'source_pk', $primary_key_value
+            'source_pk',
+            $primary_key_value
         );
 
         $database->exec($query);
     }
-
 }

--- a/src/Phan/Database/Model.php
+++ b/src/Phan/Database/Model.php
@@ -7,7 +7,8 @@ use \Phan\Database;
  * Objects implementing this interface can be
  * read from and written to a SQLite3 database
  */
-abstract class Model {
+abstract class Model
+{
     use \Phan\Memoize;
 
     /**
@@ -20,8 +21,9 @@ abstract class Model {
      * @return Schema
      * Get the schema for this model
      */
-    public static function schema() : Schema {
-        return self::memoizeStatic(get_called_class(). '::' . __METHOD__, function() {
+    public static function schema() : Schema
+    {
+        return self::memoizeStatic(get_called_class(). '::' . __METHOD__, function () {
             return static::createSchema();
         });
     }
@@ -68,7 +70,8 @@ abstract class Model {
      *
      * @return null
      */
-    public function writeAssociationList(Database $database) {
+    public function writeAssociationList(Database $database)
+    {
         foreach (static::schema()->getAssociationList() as $key => $association) {
             $association->write(
                 $database,

--- a/src/Phan/Database/ModelListAssociation.php
+++ b/src/Phan/Database/ModelListAssociation.php
@@ -6,7 +6,8 @@ use \Phan\Database;
 /**
  * An association from a model to a list of strings
  */
-class ModelListAssociation extends Association {
+class ModelListAssociation extends Association
+{
     use \Phan\Memoize;
 
     /** @var string */
@@ -60,7 +61,8 @@ class ModelListAssociation extends Association {
      * @return Model
      * Read a model from the database with the given pk
      */
-    public function read(Database $database, ModelOne $model) {
+    public function read(Database $database, ModelOne $model)
+    {
         $read_closure = $this->read_closure;
 
         // Select all rows for this PK from the
@@ -101,7 +103,8 @@ class ModelListAssociation extends Association {
      *
      * @return null
      */
-    public function write(Database $database, ModelOne $model) {
+    public function write(Database $database, ModelOne $model)
+    {
         // Ensure that we've initialized this model
         $this->schema->initializeOnce($database);
 
@@ -110,7 +113,6 @@ class ModelListAssociation extends Association {
         $source_pk = $model->primaryKeyValue();
 
         foreach ($write_closure($model) as $key => $target) {
-
             // Write the target out
             $target->write($database);
 
@@ -140,10 +142,10 @@ class ModelListAssociation extends Association {
         $this->schema->initializeOnce($database);
 
         $query = $this->schema->queryForDeleteColumnValue(
-            'source_pk', $primary_key_value
+            'source_pk',
+            $primary_key_value
         );
 
         $database->exec($query);
     }
-
 }

--- a/src/Phan/Database/ModelOne.php
+++ b/src/Phan/Database/ModelOne.php
@@ -9,7 +9,8 @@ use \Phan\Exception\NotFoundException;
  * Objects implementing this interface can be
  * read from and written to a SQLite3 database
  */
-abstract class ModelOne extends Model implements ModelOneInterface {
+abstract class ModelOne extends Model implements ModelOneInterface
+{
 
     /**
      * @param Database $database
@@ -21,7 +22,8 @@ abstract class ModelOne extends Model implements ModelOneInterface {
      * @return Model
      * Read a model from the database with the given pk
      */
-    public static function read(Database $database, $primary_key_value) : Model {
+    public static function read(Database $database, $primary_key_value) : Model
+    {
         // Ensure that we've initialized this model
         static::schema()->initializeOnce($database);
 
@@ -52,7 +54,8 @@ abstract class ModelOne extends Model implements ModelOneInterface {
      *
      * @return null
      */
-    public function write(Database $database) {
+    public function write(Database $database)
+    {
         // Ensure that we've initialized this model
         static::schema()->initializeOnce($database);
 
@@ -92,5 +95,4 @@ abstract class ModelOne extends Model implements ModelOneInterface {
             $association->delete($database, $primary_key_value);
         }
     }
-
 }

--- a/src/Phan/Database/ModelOneInterface.php
+++ b/src/Phan/Database/ModelOneInterface.php
@@ -5,7 +5,8 @@ namespace Phan\Database;
  * Objects implementing this interface can be
  * read from and written to a SQLite3 database
  */
-interface ModelOneInterface {
+interface ModelOneInterface
+{
 
     /**
      * @return array

--- a/src/Phan/Database/Schema.php
+++ b/src/Phan/Database/Schema.php
@@ -7,7 +7,8 @@ use \SQLite3;
 /**
  * A schema for a persistent model
  */
-class Schema {
+class Schema
+{
     use \Phan\Memoize;
 
     /**
@@ -61,8 +62,10 @@ class Schema {
             }
         }
 
-        assert(!empty($this->primary_key_name),
-            "There must be a primary key column. None given for $table_name.");
+        assert(
+            !empty($this->primary_key_name),
+            "There must be a primary key column. None given for $table_name."
+        );
     }
 
     /**
@@ -70,7 +73,8 @@ class Schema {
      * A query to execute at table creation time, such as a query
      * to create a key.
      */
-    public function addCreateQuery(string $query) {
+    public function addCreateQuery(string $query)
+    {
         $this->create_query_list[] = $query;
     }
 
@@ -80,14 +84,16 @@ class Schema {
      *
      * @return null
      */
-    public function addAssociation(Association $model) {
+    public function addAssociation(Association $model)
+    {
         $this->association_list[] = $model;
     }
 
     /**
      * @return Association[]
      */
-    public function getAssociationList() : array {
+    public function getAssociationList() : array
+    {
         return $this->association_list;
     }
 
@@ -95,7 +101,8 @@ class Schema {
      * @return string
      * The name of the PK column
      */
-    public function primaryKeyName() : string {
+    public function primaryKeyName() : string
+    {
         return $this->primary_key_name;
     }
 
@@ -105,8 +112,9 @@ class Schema {
      *
      * @return null
      */
-    public function initializeOnce(Database $database) {
-        $this->memoize(__METHOD__, function() use ($database) {
+    public function initializeOnce(Database $database)
+    {
+        $this->memoize(__METHOD__, function () use ($database) {
             $query = $this->queryForCreateTable();
 
             // Make sure the table has been created
@@ -127,21 +135,24 @@ class Schema {
      * A query string that creates this table if it doesn't
      * yet exist
      */
-    public function queryForCreateTable() : string {
+    public function queryForCreateTable() : string
+    {
         $column_def_list = array_map(function (Column $column) {
             return (string)$column;
         }, $this->column_def_map);
 
 
         $has_autoincrement =
-            array_reduce($this->column_def_map,
+            array_reduce(
+                $this->column_def_map,
                 function (bool $carry, Column $column) {
                     return ($carry || $column->isAutoIncrement());
-                }, false);
+                },
+                false
+            );
 
         $primary_key_list = '';
         if (!$has_autoincrement) {
-
             // Get the list of primary keys for the table
             $primary_key_list =
                 array_map(function (Column $column) {
@@ -150,7 +161,7 @@ class Schema {
                     return $column->isPrimaryKey();
                 }));
 
-            $primary_key_list =
+                $primary_key_list =
                 ', PRIMARY KEY (' . implode(', ', $primary_key_list) . ')';
 
         }
@@ -170,7 +181,8 @@ class Schema {
      * @return string
      * A query for inserting a row for this schema
      */
-    public function queryForInsert(array $row_map) : string {
+    public function queryForInsert(array $row_map) : string
+    {
         return "REPLACE INTO {$this->table_name} "
             . '(' . implode(', ', $this->columnList($row_map)) . ')'
             . ' values '
@@ -178,7 +190,8 @@ class Schema {
             ;
     }
 
-    private function columnList(array $row_map) : array {
+    private function columnList(array $row_map) : array
+    {
         $list = [];
         foreach ($row_map as $name => $value) {
             $list[] = $name;
@@ -186,10 +199,10 @@ class Schema {
         return $list;
     }
 
-    private function valueList(array $row_map) : array {
+    private function valueList(array $row_map) : array
+    {
         $value_list = [];
         foreach ($row_map as $name => $value) {
-
             if (empty($this->column_def_map[$name])) {
                 print_r($this);
                 print "$name\n";
@@ -201,7 +214,7 @@ class Schema {
             if ($column_type == 'STRING') {
                 $value_list[] =
                     '"' . SQLite3::escapeString((string)$value) . '"';
-            } else if ($column_type == 'BOOL') {
+            } elseif ($column_type == 'BOOL') {
                 $value_list[] = ($value ? 1 : 0);
             } else {
                 $value_list[] = $value;
@@ -220,7 +233,8 @@ class Schema {
      * A query for getting all values for the row with the
      * given primary key
      */
-    public function queryForSelect($primary_key_value) : string {
+    public function queryForSelect($primary_key_value) : string
+    {
         return $this->queryForSelectColumnValue(
             $this->primaryKeyName(),
             $primary_key_value
@@ -235,7 +249,8 @@ class Schema {
      * A query for getting all values for the row with the
      * given primary key
      */
-    public function queryForSelectColumnValue(string $column, $value) : string {
+    public function queryForSelectColumnValue(string $column, $value) : string
+    {
 
         if ($this->column_def_map[$column]->sqlType() == 'STRING') {
             $value = '"' . SQLite3::escapeString((string)$value) . '"';
@@ -253,7 +268,8 @@ class Schema {
      * A query for deleting all values for the row with the
      * given primary key
      */
-    public function queryForDelete($primary_key_value) : string {
+    public function queryForDelete($primary_key_value) : string
+    {
         return $this->queryForDeleteColumnValue(
             $this->primaryKeyName(),
             $primary_key_value
@@ -268,7 +284,8 @@ class Schema {
      * A query for deleting all values for the row with the
      * given primary key
      */
-    public function queryForDeleteColumnValue(string $column, $value) : string {
+    public function queryForDeleteColumnValue(string $column, $value) : string
+    {
 
         if ($this->column_def_map[$column]->sqlType() == 'STRING') {
             $value = '"' . SQLite3::escapeString((string)$value) . '"';
@@ -277,5 +294,4 @@ class Schema {
         return "DELETE FROM {$this->table_name} "
             . "WHERE $column = $value";
     }
-
 }

--- a/src/Phan/Debug.php
+++ b/src/Phan/Debug.php
@@ -6,7 +6,8 @@ use \ast\Node;
 /**
  * Debug utilities
  */
-class Debug {
+class Debug
+{
 
     /**
      * Print a lil' something to the console to
@@ -14,7 +15,8 @@ class Debug {
      *
      * @suppress PhanUnreferencedMethod
      */
-    public static function mark() {
+    public static function mark()
+    {
         print "mark\n";
     }
 
@@ -28,7 +30,8 @@ class Debug {
      *
      * @suppress PhanUnreferencedMethod
      */
-    public static function printNode($node) {
+    public static function printNode($node)
+    {
         print self::nodeToString($node);
     }
 
@@ -37,7 +40,8 @@ class Debug {
      *
      * @suppress PhanUnreferencedMethod
      */
-    public static function printNodeName($node, $indent = 0) {
+    public static function printNodeName($node, $indent = 0)
+    {
         print str_repeat("\t", $indent);
         print self::nodeName($node);
         print "\n";
@@ -48,7 +52,8 @@ class Debug {
      *
      * @suppress PhanUnreferencedMethod
      */
-    public static function print(string $message, int $indent = 0) {
+    public static function print(string $message, int $indent = 0)
+    {
         print str_repeat("\t", $indent);
         print $message . "\n";
     }
@@ -57,7 +62,8 @@ class Debug {
      * @return string
      * The name of the node
      */
-    public static function nodeName($node) : string {
+    public static function nodeName($node) : string
+    {
         if (is_string($node)) {
             return 'string';
         }
@@ -138,7 +144,8 @@ class Debug {
      * Get a string representation of AST node flags such as
      * 'ASSIGN_DIV|TYPE_ARRAY'
      */
-    public static function astFlagDescription(int $flag) : string {
+    public static function astFlagDescription(int $flag) : string
+    {
         $flag_names = [];
         foreach (self::$AST_FLAG_ID_NAME_MAP as $id => $name) {
             if ($flag == $id) {
@@ -155,17 +162,20 @@ class Debug {
      *
      * @suppress PhanUnreferencedMethod
      */
-    public static function backtrace(int $levels=0) {
-       $bt = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, $levels+1);
-       foreach($bt as $level=>$context) {
-           if(!$level) continue;
-           echo "#".($level-1)." {$context['file']}:{$context['line']} {$context['class']} ";
-           if(!empty($context['type'])) {
-               echo $context['class'].$context['type'];
-           }
-           echo $context['function'];
-           echo "\n";
-       }
+    public static function backtrace(int $levels = 0)
+    {
+        $bt = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, $levels+1);
+        foreach ($bt as $level => $context) {
+            if (!$level) {
+                continue;
+            }
+            echo "#".($level-1)." {$context['file']}:{$context['line']} {$context['class']} ";
+            if (!empty($context['type'])) {
+                echo $context['class'].$context['type'];
+            }
+            echo $context['function'];
+            echo "\n";
+        }
     }
 
     /**
@@ -259,4 +269,3 @@ class Debug {
         \ast\flags\USE_NORMAL => 'USE_NORMAL',
     ];
 }
-

--- a/src/Phan/Exception/CodeBaseException.php
+++ b/src/Phan/Exception/CodeBaseException.php
@@ -4,7 +4,8 @@ namespace Phan\Exception;
 use \Phan\Debug;
 use \Phan\Language\FQSEN;
 
-class CodeBaseException extends \Exception {
+class CodeBaseException extends \Exception
+{
 
     /** @var FQSEN|null */
     private $missing_fqsen;
@@ -30,7 +31,8 @@ class CodeBaseException extends \Exception {
      *
      * @suppress PhanUnreferencedMethod
      */
-    public function hasFQSEN() : bool {
+    public function hasFQSEN() : bool
+    {
         return !empty($this->missing_fqsen);
     }
 
@@ -38,8 +40,8 @@ class CodeBaseException extends \Exception {
      * @return FQSEN
      * The missing FQSEN
      */
-    public function getFQSEN() : FQSEN {
+    public function getFQSEN() : FQSEN
+    {
         return $this->missing_fqsen;
     }
-
 }

--- a/src/Phan/Exception/IssueException.php
+++ b/src/Phan/Exception/IssueException.php
@@ -17,7 +17,8 @@ use \Phan\IssueInstance;
  * );
  * ```
  */
-class IssueException extends Exception {
+class IssueException extends Exception
+{
 
     /** @var IssueInstance */
     private $issue_instance;
@@ -35,11 +36,11 @@ class IssueException extends Exception {
     }
 
     /**
-     * @return IssueInstance 
+     * @return IssueInstance
      * The issue that was found
      */
-    public function getIssueInstance() : IssueInstance {
+    public function getIssueInstance() : IssueInstance
+    {
         return $this->issue_instance;
     }
-
 }

--- a/src/Phan/Exception/NodeException.php
+++ b/src/Phan/Exception/NodeException.php
@@ -4,7 +4,8 @@ namespace Phan\Exception;
 use \Phan\Debug;
 use \ast\Node;
 
-class NodeException extends \Exception {
+class NodeException extends \Exception
+{
 
     /**
      * @var Node
@@ -32,8 +33,8 @@ class NodeException extends \Exception {
      *
      * @suppress PhanUnreferencedMethod
      */
-    public function getNode() : Node {
+    public function getNode() : Node
+    {
         return $this->node;
     }
-
 }

--- a/src/Phan/Exception/NotFoundException.php
+++ b/src/Phan/Exception/NotFoundException.php
@@ -3,4 +3,6 @@ namespace Phan\Exception;
 
 use \Phan\Debug;
 
-class NotFoundException extends \Exception {}
+class NotFoundException extends \Exception
+{
+}

--- a/src/Phan/Exception/TypeException.php
+++ b/src/Phan/Exception/TypeException.php
@@ -1,4 +1,8 @@
 <?php declare(strict_types=1);
 namespace Phan\Exception;
+
 use \Phan\Debug;
-class TypeException extends \Exception {}
+
+class TypeException extends \Exception
+{
+}

--- a/src/Phan/Exception/UnanalyzableException.php
+++ b/src/Phan/Exception/UnanalyzableException.php
@@ -4,4 +4,6 @@ namespace Phan\Exception;
 use \Phan\Debug;
 use \ast\Node;
 
-class UnanalyzableException extends NodeException {}
+class UnanalyzableException extends NodeException
+{
+}

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -4,7 +4,8 @@ namespace Phan;
 /**
  * An issue emitted during the course of analysis
  */
-class Issue {
+class Issue
+{
 
     // Issue::CATEGORY_UNDEFINED
     const EmptyFile                 = 'PhanEmptyFile';
@@ -102,18 +103,18 @@ class Issue {
     const CompatibleExpressionPHP7  = 'PhanCompatibleExpressionPHP7';
     const CompatiblePHP7            = 'PhanCompatiblePHP7';
 
-	const CATEGORY_ACCESS            = 1<<1;
-	const CATEGORY_ANALYSIS          = 1<<2;
-	const CATEGORY_COMPATIBLE        = 1<<3;
-	const CATEGORY_CONTEXT           = 1<<4;
-	const CATEGORY_DEPRECATED        = 1<<5;
-	const CATEGORY_NOOP              = 1<<6;
-	const CATEGORY_PARAMETER         = 1<<7;
-	const CATEGORY_REDEFINE          = 1<<8;
-	const CATEGORY_STATIC            = 1<<9;
-	const CATEGORY_TYPE              = 1<<10;
-	const CATEGORY_UNDEFINED         = 1<<11;
-	const CATEGORY_VARIABLE          = 1<<12;
+    const CATEGORY_ACCESS            = 1<<1;
+    const CATEGORY_ANALYSIS          = 1<<2;
+    const CATEGORY_COMPATIBLE        = 1<<3;
+    const CATEGORY_CONTEXT           = 1<<4;
+    const CATEGORY_DEPRECATED        = 1<<5;
+    const CATEGORY_NOOP              = 1<<6;
+    const CATEGORY_PARAMETER         = 1<<7;
+    const CATEGORY_REDEFINE          = 1<<8;
+    const CATEGORY_STATIC            = 1<<9;
+    const CATEGORY_TYPE              = 1<<10;
+    const CATEGORY_UNDEFINED         = 1<<11;
+    const CATEGORY_VARIABLE          = 1<<12;
 
     const CATEGORY_NAME = [
         self::CATEGORY_ACCESS            => 'AccessError',
@@ -168,7 +169,8 @@ class Issue {
     /**
      * @return Issue[]
      */
-    public static function issueMap() {
+    public static function issueMap()
+    {
         static $error_map;
 
         if (!empty($error_map)) {
@@ -178,242 +180,458 @@ class Issue {
         $error_list = [
 
             // Issue::CATEGORY_UNDEFINED
-            new Issue(self::EmptyFile, self::CATEGORY_UNDEFINED, self::SEVERITY_LOW,
+            new Issue(
+                self::EmptyFile,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_LOW,
                 "Empty file %s"
             ),
-            new Issue(self::ParentlessClass, self::CATEGORY_UNDEFINED, self::SEVERITY_CRITICAL,
+            new Issue(
+                self::ParentlessClass,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_CRITICAL,
                 "Reference to parent of class %s that does not extend anything"
             ),
-            new Issue(self::UndeclaredClass, self::CATEGORY_UNDEFINED, self::SEVERITY_CRITICAL,
+            new Issue(
+                self::UndeclaredClass,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_CRITICAL,
                 "Reference to undeclared class %s"
             ),
-            new Issue(self::UndeclaredExtendedClass, self::CATEGORY_UNDEFINED, self::SEVERITY_CRITICAL,
+            new Issue(
+                self::UndeclaredExtendedClass,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_CRITICAL,
                 "Class extends undeclared class %s"
             ),
-            new Issue(self::UndeclaredInterface, self::CATEGORY_UNDEFINED, self::SEVERITY_CRITICAL,
+            new Issue(
+                self::UndeclaredInterface,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_CRITICAL,
                 "Class implements undeclared interface %s"
             ),
-            new Issue(self::UndeclaredTrait, self::CATEGORY_UNDEFINED, self::SEVERITY_CRITICAL,
+            new Issue(
+                self::UndeclaredTrait,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_CRITICAL,
                 "Class uses undeclared trait %s"
             ),
-            new Issue(self::UndeclaredClassCatch, self::CATEGORY_UNDEFINED, self::SEVERITY_CRITICAL,
+            new Issue(
+                self::UndeclaredClassCatch,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_CRITICAL,
                 "Catching undeclared class %s"
             ),
-            new Issue(self::UndeclaredClassConstant, self::CATEGORY_UNDEFINED, self::SEVERITY_CRITICAL,
+            new Issue(
+                self::UndeclaredClassConstant,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_CRITICAL,
                 "Reference to constant %s from undeclared class %s"
             ),
-            new Issue(self::UndeclaredClassInstanceof, self::CATEGORY_UNDEFINED, self::SEVERITY_CRITICAL,
+            new Issue(
+                self::UndeclaredClassInstanceof,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_CRITICAL,
                 "Checking instanceof against undeclared class %s"
             ),
-            new Issue(self::UndeclaredClassMethod, self::CATEGORY_UNDEFINED, self::SEVERITY_CRITICAL,
+            new Issue(
+                self::UndeclaredClassMethod,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_CRITICAL,
                 "Call to method %s from undeclared class %s"
             ),
-            new Issue(self::UndeclaredClassReference, self::CATEGORY_UNDEFINED, self::SEVERITY_NORMAL,
+            new Issue(
+                self::UndeclaredClassReference,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_NORMAL,
                 "Reference to undeclared class %s"
             ),
-            new Issue(self::UndeclaredConstant, self::CATEGORY_UNDEFINED, self::SEVERITY_NORMAL,
+            new Issue(
+                self::UndeclaredConstant,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_NORMAL,
                 "Reference to undeclared constant %s"
             ),
-            new Issue(self::UndeclaredFunction, self::CATEGORY_UNDEFINED, self::SEVERITY_CRITICAL,
+            new Issue(
+                self::UndeclaredFunction,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_CRITICAL,
                 "Call to undeclared function %s"
             ),
-            new Issue(self::UndeclaredMethod, self::CATEGORY_UNDEFINED, self::SEVERITY_NORMAL,
+            new Issue(
+                self::UndeclaredMethod,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_NORMAL,
                 "Call to undeclared method %s"
             ),
-            new Issue(self::UndeclaredStaticMethod, self::CATEGORY_UNDEFINED, self::SEVERITY_NORMAL,
+            new Issue(
+                self::UndeclaredStaticMethod,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_NORMAL,
                 "Static call to undeclared method %s"
             ),
-            new Issue(self::UndeclaredProperty, self::CATEGORY_UNDEFINED, self::SEVERITY_NORMAL,
+            new Issue(
+                self::UndeclaredProperty,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_NORMAL,
                 "Reference to undeclared property %s"
             ),
-            new Issue(self::UndeclaredStaticProperty, self::CATEGORY_UNDEFINED, self::SEVERITY_NORMAL,
+            new Issue(
+                self::UndeclaredStaticProperty,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_NORMAL,
                 "Static property '%s' on %s is undeclared"
             ),
-            new Issue(self::TraitParentReference, self::CATEGORY_UNDEFINED, self::SEVERITY_LOW,
+            new Issue(
+                self::TraitParentReference,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_LOW,
                 "Reference to parent from trait %s"
             ),
-            new Issue(self::UndeclaredVariable, self::CATEGORY_UNDEFINED, self::SEVERITY_LOW,
+            new Issue(
+                self::UndeclaredVariable,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_LOW,
                 "Variable \$%s is undeclared"
             ),
-            new Issue(self::UndeclaredTypeParameter, self::CATEGORY_UNDEFINED, self::SEVERITY_NORMAL,
+            new Issue(
+                self::UndeclaredTypeParameter,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_NORMAL,
                 "Parameter of undeclared type %s"
             ),
-            new Issue(self::UndeclaredTypeProperty, self::CATEGORY_UNDEFINED, self::SEVERITY_NORMAL,
+            new Issue(
+                self::UndeclaredTypeProperty,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_NORMAL,
                 "Property of undeclared type %s"
             ),
 
             // Issue::CATEGORY_ANALYSIS
-            new Issue(self::Unanalyzable, self::CATEGORY_UNDEFINED, self::SEVERITY_LOW,
+            new Issue(
+                self::Unanalyzable,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_LOW,
                 "Expression is unanalyzable or feature is unimplemented. Please create an issue at https://github.com/etsy/phan/issues/new."
             ),
 
             // Issue::CATEGORY_TYPE
-            new Issue(self::TypeMismatchProperty, self::CATEGORY_TYPE, self::SEVERITY_NORMAL,
+            new Issue(
+                self::TypeMismatchProperty,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
                 "Assigning %s to property but %s is %s"
             ),
-            new Issue(self::TypeMismatchDefault, self::CATEGORY_TYPE, self::SEVERITY_NORMAL,
+            new Issue(
+                self::TypeMismatchDefault,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
                 "Default value for %s \$%s can't be %s"
             ),
-            new Issue(self::TypeMismatchArgument, self::CATEGORY_TYPE, self::SEVERITY_NORMAL,
+            new Issue(
+                self::TypeMismatchArgument,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
                 "Argument %d (%s) is %s but %s() takes %s defined at %s:%d"
             ),
-            new Issue(self::TypeMismatchArgumentInternal, self::CATEGORY_TYPE, self::SEVERITY_NORMAL,
+            new Issue(
+                self::TypeMismatchArgumentInternal,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
                 "Argument %d (%s) is %s but %s() takes %s"
             ),
-            new Issue(self::TypeMismatchReturn, self::CATEGORY_TYPE, self::SEVERITY_NORMAL,
+            new Issue(
+                self::TypeMismatchReturn,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
                 "Returning type %s but %s() is declared to return %s"
             ),
-            new Issue(self::TypeMissingReturn, self::CATEGORY_TYPE, self::SEVERITY_NORMAL,
+            new Issue(
+                self::TypeMissingReturn,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
                 "Method %s is declared to return %s but has no return value"
             ),
-            new Issue(self::TypeMismatchForeach, self::CATEGORY_TYPE, self::SEVERITY_NORMAL,
+            new Issue(
+                self::TypeMismatchForeach,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
                 "%s passed to foreach instead of array"
             ),
-            new Issue(self::TypeArrayOperator, self::CATEGORY_TYPE, self::SEVERITY_NORMAL,
+            new Issue(
+                self::TypeArrayOperator,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
                 "Invalid array operator"
             ),
-            new Issue(self::TypeArraySuspicious, self::CATEGORY_TYPE, self::SEVERITY_NORMAL,
+            new Issue(
+                self::TypeArraySuspicious,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
                 "Suspicious array access to %s"
             ),
-            new Issue(self::TypeComparisonToArray, self::CATEGORY_TYPE, self::SEVERITY_NORMAL,
+            new Issue(
+                self::TypeComparisonToArray,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
                 "%s to array comparison"
             ),
-            new Issue(self::TypeComparisonFromArray, self::CATEGORY_TYPE, self::SEVERITY_NORMAL,
+            new Issue(
+                self::TypeComparisonFromArray,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
                 "array to %s comparison"
             ),
-            new Issue(self::TypeConversionFromArray, self::CATEGORY_TYPE, self::SEVERITY_NORMAL,
+            new Issue(
+                self::TypeConversionFromArray,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
                 "array to %s conversion"
             ),
-            new Issue(self::TypeInstantiateAbstract, self::CATEGORY_TYPE, self::SEVERITY_NORMAL,
+            new Issue(
+                self::TypeInstantiateAbstract,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
                 "Instantiation of abstract class %s"
             ),
-            new Issue(self::TypeInstantiateInterface, self::CATEGORY_TYPE, self::SEVERITY_NORMAL,
+            new Issue(
+                self::TypeInstantiateInterface,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
                 "Instantiation of interface %s"
             ),
-            new Issue(self::TypeInvalidRightOperand, self::CATEGORY_TYPE, self::SEVERITY_NORMAL,
+            new Issue(
+                self::TypeInvalidRightOperand,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
                 "Invalid operator: left operand is array and right is not"
             ),
-            new Issue(self::TypeInvalidLeftOperand, self::CATEGORY_TYPE, self::SEVERITY_NORMAL,
+            new Issue(
+                self::TypeInvalidLeftOperand,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
                 "Invalid operator: right operand is array and left is not"
             ),
-            new Issue(self::TypeParentConstructorCalled, self::CATEGORY_TYPE, self::SEVERITY_NORMAL,
+            new Issue(
+                self::TypeParentConstructorCalled,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
                 "Must call parent::__construct() from %s which extends %s"
             ),
-            new Issue(self::TypeNonVarPassByRef, self::CATEGORY_TYPE, self::SEVERITY_NORMAL,
+            new Issue(
+                self::TypeNonVarPassByRef,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
                 "Only variables can be passed by reference at argument %d of %s()"
             ),
-            new Issue(self::NonClassMethodCall, self::CATEGORY_TYPE, self::SEVERITY_CRITICAL,
+            new Issue(
+                self::NonClassMethodCall,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_CRITICAL,
                 "Call to method %s on non-class type %s"
             ),
 
             // Issue::CATEGORY_VARIABLE
-            new Issue(self::VariableUseClause, self::CATEGORY_VARIABLE, self::SEVERITY_CRITICAL,
+            new Issue(
+                self::VariableUseClause,
+                self::CATEGORY_VARIABLE,
+                self::SEVERITY_CRITICAL,
                 "Non-variables not allowed within use clause"
             ),
 
             // Issue::CATEGORY_STATIC
-            new Issue(self::StaticCallToNonStatic, self::CATEGORY_STATIC, self::SEVERITY_NORMAL,
+            new Issue(
+                self::StaticCallToNonStatic,
+                self::CATEGORY_STATIC,
+                self::SEVERITY_NORMAL,
                 "Static call to non-static method %s defined at %s:%d"
             ),
 
             // Issue::CATEGORY_CONTEXT
-            new Issue(self::ContextNotObject, self::CATEGORY_CONTEXT, self::SEVERITY_CRITICAL,
+            new Issue(
+                self::ContextNotObject,
+                self::CATEGORY_CONTEXT,
+                self::SEVERITY_CRITICAL,
                 "Cannot access %s when not in object context"
             ),
 
             // Issue::CATEGORY_DEPRECATED
-            new Issue(self::DeprecatedFunction, self::CATEGORY_DEPRECATED, self::SEVERITY_NORMAL,
+            new Issue(
+                self::DeprecatedFunction,
+                self::CATEGORY_DEPRECATED,
+                self::SEVERITY_NORMAL,
                 "Call to deprecated function %s() defined at %s:%d"
             ),
 
             // Issue::CATEGORY_PARAMETER
-            new Issue(self::ParamReqAfterOpt, self::CATEGORY_PARAMETER, self::SEVERITY_LOW,
+            new Issue(
+                self::ParamReqAfterOpt,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_LOW,
                 "Required argument follows optional"
             ),
-            new Issue(self::ParamTooMany, self::CATEGORY_PARAMETER, self::SEVERITY_LOW,
+            new Issue(
+                self::ParamTooMany,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_LOW,
                 "Call with %d arg(s) to %s() which only takes %d arg(s) defined at %s:%d"
             ),
-            new Issue(self::ParamTooManyInternal, self::CATEGORY_PARAMETER, self::SEVERITY_LOW,
+            new Issue(
+                self::ParamTooManyInternal,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_LOW,
                 "Call with %d arg(s) to %s() which only takes %d arg(s)"
             ),
-            new Issue(self::ParamTooFew, self::CATEGORY_PARAMETER, self::SEVERITY_NORMAL,
+            new Issue(
+                self::ParamTooFew,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_NORMAL,
                 "Call with %d arg(s) to %s() which requires %d arg(s) defined at %s:%d"
             ),
-            new Issue(self::ParamTooFewInternal, self::CATEGORY_PARAMETER, self::SEVERITY_NORMAL,
+            new Issue(
+                self::ParamTooFewInternal,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_NORMAL,
                 "Call with %d arg(s) to %s() which requires %d arg(s)"
             ),
-            new Issue(self::ParamSpecial1, self::CATEGORY_PARAMETER, self::SEVERITY_NORMAL,
+            new Issue(
+                self::ParamSpecial1,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_NORMAL,
                 "Argument %d (%s) is %s but %s() takes %s when argument %d is %s"
             ),
-            new Issue(self::ParamSpecial2, self::CATEGORY_PARAMETER, self::SEVERITY_NORMAL,
+            new Issue(
+                self::ParamSpecial2,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_NORMAL,
                 "Argument %d (%s) is %s but %s() takes %s when passed only one argument"
             ),
-            new Issue(self::ParamSpecial3, self::CATEGORY_PARAMETER, self::SEVERITY_NORMAL,
+            new Issue(
+                self::ParamSpecial3,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_NORMAL,
                 "The last argument to %s must be of type %s"
             ),
-            new Issue(self::ParamSpecial4, self::CATEGORY_PARAMETER, self::SEVERITY_NORMAL,
+            new Issue(
+                self::ParamSpecial4,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_NORMAL,
                 "The second to last argument to %s must be of type %s"
             ),
-            new Issue(self::ParamTypeMismatch, self::CATEGORY_PARAMETER, self::SEVERITY_NORMAL,
+            new Issue(
+                self::ParamTypeMismatch,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_NORMAL,
                 "Argument %d is %s but %s() takes %s"
             ),
 
             // Issue::CATEGORY_NOOP
-            new Issue(self::NoopProperty, self::CATEGORY_NOOP, self::SEVERITY_LOW,
+            new Issue(
+                self::NoopProperty,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_LOW,
                 "Unused property"
             ),
-            new Issue(self::NoopArray, self::CATEGORY_NOOP, self::SEVERITY_LOW,
+            new Issue(
+                self::NoopArray,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_LOW,
                 "Unused array"
             ),
-            new Issue(self::NoopConstant, self::CATEGORY_NOOP, self::SEVERITY_LOW,
+            new Issue(
+                self::NoopConstant,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_LOW,
                 "Unused constant"
             ),
-            new Issue(self::NoopClosure, self::CATEGORY_NOOP, self::SEVERITY_LOW,
+            new Issue(
+                self::NoopClosure,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_LOW,
                 "Unused closure"
             ),
-            new Issue(self::NoopVariable, self::CATEGORY_NOOP, self::SEVERITY_LOW,
+            new Issue(
+                self::NoopVariable,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_LOW,
                 "Unused variable"
             ),
-            new Issue(self::UnreferencedClass, self::CATEGORY_NOOP, self::SEVERITY_CRITICAL,
+            new Issue(
+                self::UnreferencedClass,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_CRITICAL,
                 "Possibly zero references to class %s"
             ),
-            new Issue(self::UnreferencedMethod, self::CATEGORY_NOOP, self::SEVERITY_CRITICAL,
+            new Issue(
+                self::UnreferencedMethod,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_CRITICAL,
                 "Possibly zero references to method %s"
             ),
-            new Issue(self::UnreferencedProperty, self::CATEGORY_NOOP, self::SEVERITY_CRITICAL,
+            new Issue(
+                self::UnreferencedProperty,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_CRITICAL,
                 "Possibly zero references to property %s"
             ),
-            new Issue(self::UnreferencedConstant, self::CATEGORY_NOOP, self::SEVERITY_CRITICAL,
+            new Issue(
+                self::UnreferencedConstant,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_CRITICAL,
                 "Possibly zero references to constant %s"
             ),
 
             // Issue::CATEGORY_REDEFINE
-            new Issue(self::RedefineClass, self::CATEGORY_REDEFINE, self::SEVERITY_NORMAL,
+            new Issue(
+                self::RedefineClass,
+                self::CATEGORY_REDEFINE,
+                self::SEVERITY_NORMAL,
                 "%s defined at %s:%d was previously defined as %s at %s:%d"
             ),
-            new Issue(self::RedefineClassInternal, self::CATEGORY_REDEFINE, self::SEVERITY_NORMAL,
+            new Issue(
+                self::RedefineClassInternal,
+                self::CATEGORY_REDEFINE,
+                self::SEVERITY_NORMAL,
                 "%s defined at %s:%d was previously defined as %s internally"
             ),
-            new Issue(self::RedefineFunction, self::CATEGORY_REDEFINE, self::SEVERITY_NORMAL,
+            new Issue(
+                self::RedefineFunction,
+                self::CATEGORY_REDEFINE,
+                self::SEVERITY_NORMAL,
                 "Function %s defined at %s:%d was previously defined at %s:%d"
             ),
-            new Issue(self::RedefineFunctionInternal, self::CATEGORY_REDEFINE, self::SEVERITY_NORMAL,
+            new Issue(
+                self::RedefineFunctionInternal,
+                self::CATEGORY_REDEFINE,
+                self::SEVERITY_NORMAL,
                 "Function %s defined at %s:%d was previously defined internally"
             ),
 
             // Issue::CATEGORY_ACCESS
-            new Issue(self::AccessPropertyProtected, self::CATEGORY_ACCESS, self::SEVERITY_CRITICAL,
+            new Issue(
+                self::AccessPropertyProtected,
+                self::CATEGORY_ACCESS,
+                self::SEVERITY_CRITICAL,
                 "Cannot access protected property %s"
             ),
-            new Issue(self::AccessPropertyPrivate, self::CATEGORY_ACCESS, self::SEVERITY_CRITICAL,
+            new Issue(
+                self::AccessPropertyPrivate,
+                self::CATEGORY_ACCESS,
+                self::SEVERITY_CRITICAL,
                 "Cannot access private property %s"
             ),
 
             // Issue::CATEGORY_COMPATIBLE
-            new Issue(self::CompatiblePHP7, self::CATEGORY_COMPATIBLE, self::SEVERITY_NORMAL,
+            new Issue(
+                self::CompatiblePHP7,
+                self::CATEGORY_COMPATIBLE,
+                self::SEVERITY_NORMAL,
                 "Expression may not be PHP 7 compatible"
             ),
-            new Issue(self::CompatibleExpressionPHP7, self::CATEGORY_COMPATIBLE, self::SEVERITY_NORMAL,
+            new Issue(
+                self::CompatibleExpressionPHP7,
+                self::CATEGORY_COMPATIBLE,
+                self::SEVERITY_NORMAL,
                 "%s expression may not be PHP 7 compatible"
             ),
 
@@ -430,14 +648,16 @@ class Issue {
     /**
      * @return string
      */
-    public function getType() : string {
+    public function getType() : string
+    {
         return $this->type;
     }
 
     /**
      * @return int
      */
-    public function getCategory() : int {
+    public function getCategory() : int
+    {
         return $this->category;
     }
 
@@ -445,21 +665,24 @@ class Issue {
      * @return string
      * The name of the category
      */
-    public static function getNameForCategory(int $category) : string {
+    public static function getNameForCategory(int $category) : string
+    {
         return self::CATEGORY_NAME[$category] ?? '';
     }
 
     /**
      * @return int
      */
-    public function getSeverity() : int {
+    public function getSeverity() : int
+    {
         return $this->severity;
     }
 
     /**
      * @return string
      */
-    public function getTemplate() : string {
+    public function getTemplate() : string
+    {
         return $this->template;
     }
 
@@ -482,11 +705,14 @@ class Issue {
     /**
      * return Issue
      */
-    public static function fromType(string $type) : Issue {
+    public static function fromType(string $type) : Issue
+    {
         $error_map = self::issueMap();
 
-        assert(!empty($error_map[$type]),
-            "Undefined error type $type");
+        assert(
+            !empty($error_map[$type]),
+            "Undefined error type $type"
+        );
 
         return $error_map[$type];
     }

--- a/src/Phan/IssueInstance.php
+++ b/src/Phan/IssueInstance.php
@@ -1,7 +1,8 @@
 <?php declare(strict_types=1);
 namespace Phan;
 
-class IssueInstance {
+class IssueInstance
+{
 
     /** @var Issue */
     private $issue;
@@ -36,28 +37,32 @@ class IssueInstance {
     /**
      * @return Issue
      */
-    public function getIssue() : Issue {
+    public function getIssue() : Issue
+    {
         return $this->issue;
     }
 
     /**
      * @return string
      */
-    public function getFile() : string {
+    public function getFile() : string
+    {
         return $this->file;
     }
 
     /**
      * @return int
      */
-    public function getLine() : int {
+    public function getLine() : int
+    {
         return $this->line;
     }
 
     /**
      * @return string
      */
-    public function getMessage() {
+    public function getMessage()
+    {
         return vsprintf($this->getIssue()->getTemplate(), $this->template_parameters);
     }
 }

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -16,7 +16,8 @@ use \Phan\Language\Scope;
  * An object representing the context in which any
  * structural element (such as a class or method) lives.
  */
-class Context extends FileRef implements \Serializable {
+class Context extends FileRef implements \Serializable
+{
 
     /**
      * @var string
@@ -69,7 +70,8 @@ class Context extends FileRef implements \Serializable {
     /**
      * Create a new context
      */
-    public function __construct() {
+    public function __construct()
+    {
         $this->namespace = '';
         $this->namespace_map = [];
         $this->class_fqsen = null;
@@ -85,7 +87,8 @@ class Context extends FileRef implements \Serializable {
      * @return Context
      * A clone of this context with the given value is returned
      */
-    public function withNamespace(string $namespace) : Context {
+    public function withNamespace(string $namespace) : Context
+    {
         $context = clone($this);
         $context->namespace = $namespace;
         return $context;
@@ -95,7 +98,8 @@ class Context extends FileRef implements \Serializable {
      * @return string
      * The namespace of the file
      */
-    public function getNamespace() : string {
+    public function getNamespace() : string
+    {
         return $this->namespace;
     }
 
@@ -103,7 +107,8 @@ class Context extends FileRef implements \Serializable {
      * @return bool
      * True if we have a mapped NS for the given named element
      */
-    public function hasNamespaceMapFor(int $flags, string $name) : bool {
+    public function hasNamespaceMapFor(int $flags, string $name) : bool
+    {
         return !empty($this->namespace_map[$flags][strtolower($name)]);
     }
 
@@ -112,7 +117,8 @@ class Context extends FileRef implements \Serializable {
      * The namespace mapped name for the given flags and name
      */
     public function getNamespaceMapFor(
-        int $flags, string $name
+        int $flags,
+        string $name
     ) : FullyQualifiedGlobalStructuralElement {
         $name = strtolower($name);
 
@@ -121,8 +127,10 @@ class Context extends FileRef implements \Serializable {
             "No namespace defined for $name"
         );
 
-        assert($this->namespace_map[$flags][$name] instanceof FQSEN,
-            "Namespace map for $flags $name was not an FQSEN");
+        assert(
+            $this->namespace_map[$flags][$name] instanceof FQSEN,
+            "Namespace map for $flags $name was not an FQSEN"
+        );
 
         return $this->namespace_map[$flags][$name];
     }
@@ -148,7 +156,8 @@ class Context extends FileRef implements \Serializable {
      * @return Context
      * A clone of this context with the given value is returned
      */
-    public function withClassFQSEN(FullyQualifiedClassName $fqsen) : Context {
+    public function withClassFQSEN(FullyQualifiedClassName $fqsen) : Context
+    {
         $context = clone($this);
         $context->class_fqsen = $fqsen;
         return $context;
@@ -158,7 +167,8 @@ class Context extends FileRef implements \Serializable {
      * @return bool
      * True if a class fqsen is defined within this context.
      */
-    public function hasClassFQSEN() : bool {
+    public function hasClassFQSEN() : bool
+    {
         return !empty($this->class_fqsen);
     }
 
@@ -167,7 +177,8 @@ class Context extends FileRef implements \Serializable {
      * A fully-qualified structural element name describing
      * the current class in scope.
      */
-    public function getClassFQSEN() : FullyQualifiedClassName {
+    public function getClassFQSEN() : FullyQualifiedClassName
+    {
         return $this->class_fqsen;
     }
 
@@ -176,7 +187,8 @@ class Context extends FileRef implements \Serializable {
      * True if this context is currently within a class
      * scope, else false.
      */
-    public function isInClassScope() : bool {
+    public function isInClassScope() : bool
+    {
         return !empty($this->class_fqsen);
     }
 
@@ -188,7 +200,8 @@ class Context extends FileRef implements \Serializable {
      * @return Context
      * A clone of this context with the given value is returned
      */
-    public function withMethodFQSEN(FQSEN $fqsen = null) : Context {
+    public function withMethodFQSEN(FQSEN $fqsen = null) : Context
+    {
         $context = clone($this);
         $context->method_fqsen = $fqsen;
         return $context;
@@ -199,7 +212,8 @@ class Context extends FileRef implements \Serializable {
      * A fully-qualified structural element name describing
      * the current function or method in scope.
      */
-    public function getMethodFQSEN() : FQSEN {
+    public function getMethodFQSEN() : FQSEN
+    {
         return $this->method_fqsen;
     }
 
@@ -211,7 +225,8 @@ class Context extends FileRef implements \Serializable {
      * @return Context
      * A clone of this context with the given value is returned
      */
-    public function withClosureFQSEN(FullyQualifiedFunctionName $fqsen = null) : Context {
+    public function withClosureFQSEN(FullyQualifiedFunctionName $fqsen = null) : Context
+    {
         $context = clone($this);
         $context->closure_fqsen = $fqsen;
         return $context;
@@ -222,7 +237,8 @@ class Context extends FileRef implements \Serializable {
      * A fully-qualified structural element name describing
      * the current closure in scope
      */
-    public function getClosureFQSEN() : FullyQualifiedFunctionName {
+    public function getClosureFQSEN() : FullyQualifiedFunctionName
+    {
         return $this->closure_fqsen;
     }
 
@@ -233,7 +249,8 @@ class Context extends FileRef implements \Serializable {
      * @return Context
      * This context with the given value is returned
      */
-    public function withStrictTypes(int $strict_types) : Context {
+    public function withStrictTypes(int $strict_types) : Context
+    {
         $this->strict_types = $strict_types;
         return $this;
     }
@@ -243,7 +260,8 @@ class Context extends FileRef implements \Serializable {
      * True if strict_types is set to 1 in this
      * context.
      */
-    public function getIsStrictTypes() : bool {
+    public function getIsStrictTypes() : bool
+    {
         return (1 === $this->strict_types);
     }
 
@@ -252,7 +270,8 @@ class Context extends FileRef implements \Serializable {
      * An object describing the contents of the current
      * scope.
      */
-    public function getScope() : Scope {
+    public function getScope() : Scope
+    {
         return $this->scope ?? new Scope();
     }
 
@@ -260,7 +279,8 @@ class Context extends FileRef implements \Serializable {
      * @return Context
      * A new context with the given scope
      */
-    public function withScope(Scope $scope) : Context {
+    public function withScope(Scope $scope) : Context
+    {
         $context = clone($this);
         $context->scope = $scope;
         return $context;
@@ -271,7 +291,8 @@ class Context extends FileRef implements \Serializable {
      *
      * @return void
      */
-    public function setScope(Scope $scope) {
+    public function setScope(Scope $scope)
+    {
         $this->scope = $scope;
     }
 
@@ -321,9 +342,12 @@ class Context extends FileRef implements \Serializable {
      * Thrown if we can't find the class in scope within the
      * given codebase.
      */
-    public function getClassInScope(CodeBase $code_base) : Clazz {
-        assert($this->isInClassScope(),
-            "Must be in class scope to get class");
+    public function getClassInScope(CodeBase $code_base) : Clazz
+    {
+        assert(
+            $this->isInClassScope(),
+            "Must be in class scope to get class"
+        );
 
         if (!$code_base->hasClassWithFQSEN($this->getClassFQSEN())) {
             throw new CodeBaseException(
@@ -341,7 +365,8 @@ class Context extends FileRef implements \Serializable {
      * @return bool
      * True if we're within a method scope
      */
-    public function isMethodScope() : bool {
+    public function isMethodScope() : bool
+    {
         return !empty($this->method_fqsen);
     }
 
@@ -352,9 +377,12 @@ class Context extends FileRef implements \Serializable {
      * @return Method
      * Get the method in this scope or fail real hard
      */
-    public function getMethodInScope(CodeBase $code_base) : Method {
-        assert($this->isMethodScope(),
-            "Must be in method scope to get method. Actually in {$this}");
+    public function getMethodInScope(CodeBase $code_base) : Method
+    {
+        assert(
+            $this->isMethodScope(),
+            "Must be in method scope to get method. Actually in {$this}"
+        );
 
         return $code_base->getMethod(
             $this->getMethodFQSEN()
@@ -368,7 +396,8 @@ class Context extends FileRef implements \Serializable {
      * @return bool
      * True if we're within a closure scope
      */
-    public function isClosureScope() : bool {
+    public function isClosureScope() : bool
+    {
         return !empty($this->closure_fqsen);
     }
 
@@ -376,16 +405,20 @@ class Context extends FileRef implements \Serializable {
      * @return Method
      * Get the closure in this scope or fail real hard
      */
-    public function getClosureInScope(CodeBase $code_base) : Method {
-        assert($this->isClosureScope(),
-            "Must be in closure scope to get closure. Actually in {$this}");
+    public function getClosureInScope(CodeBase $code_base) : Method
+    {
+        assert(
+            $this->isClosureScope(),
+            "Must be in closure scope to get closure. Actually in {$this}"
+        );
 
         return $code_base->getMethod(
             $this->getClosureFQSEN()
         );
     }
 
-    public function serialize() {
+    public function serialize()
+    {
 
         $serialized = parent::serialize();
 
@@ -399,7 +432,8 @@ class Context extends FileRef implements \Serializable {
         return $serialized;
     }
 
-    public function unserialize($serialized) {
+    public function unserialize($serialized)
+    {
         list($file_ref, $serialized) = explode('^', $serialized);
         parent::unserialize($file_ref);
 

--- a/src/Phan/Language/Element/Addressable.php
+++ b/src/Phan/Language/Element/Addressable.php
@@ -3,7 +3,8 @@ namespace Phan\Language\Element;
 
 use \Phan\Language\FQSEN;
 
-interface Addressable {
+interface Addressable
+{
 
     /**
      * @return FQSEN

--- a/src/Phan/Language/Element/AddressableImplementation.php
+++ b/src/Phan/Language/Element/AddressableImplementation.php
@@ -3,7 +3,8 @@ namespace Phan\Language\Element;
 
 use \Phan\Language\FQSEN;
 
-trait AddressableImplementation {
+trait AddressableImplementation
+{
 
     /**
      * @var FQSEN
@@ -24,7 +25,8 @@ trait AddressableImplementation {
      *
      * @return null
      */
-    public function setFQSEN(FQSEN $fqsen) {
+    public function setFQSEN(FQSEN $fqsen)
+    {
         $this->fqsen = $fqsen;
     }
 
@@ -38,7 +40,8 @@ trait AddressableImplementation {
      * @return bool
      * True if this is a public property
      */
-    public function isPublic() {
+    public function isPublic()
+    {
         return !(
             $this->isProtected() || $this->isPrivate()
         );
@@ -48,7 +51,8 @@ trait AddressableImplementation {
      * @return bool
      * True if this is a protected property
      */
-    public function isProtected() {
+    public function isProtected()
+    {
         return (bool)(
             $this->getFlags() & \ast\flags\MODIFIER_PROTECTED
         );
@@ -58,10 +62,10 @@ trait AddressableImplementation {
      * @return bool
      * True if this is a private property
      */
-    public function isPrivate() {
+    public function isPrivate()
+    {
         return (bool)(
             $this->getFlags() & \ast\flags\MODIFIER_PRIVATE
         );
     }
-
 }

--- a/src/Phan/Language/Element/ClassElement.php
+++ b/src/Phan/Language/Element/ClassElement.php
@@ -9,7 +9,8 @@ use \Phan\Language\FQSEN\FullyQualifiedClassElement;
 use \Phan\Language\FQSEN\FullyQualifiedClassName;
 use \Phan\Language\UnionType;
 
-abstract class ClassElement extends TypedStructuralElement {
+abstract class ClassElement extends TypedStructuralElement
+{
     /**
      * @return FQSEN
      * The fully-qualified structural element name of this
@@ -22,8 +23,8 @@ abstract class ClassElement extends TypedStructuralElement {
      * The FQSEN of the class that originally defined
      * this element
      */
-    public function getDefiningClassFQSEN(
-    ) : FullyQualifiedClassName {
+    public function getDefiningClassFQSEN() : FullyQualifiedClassName
+    {
         if ($this instanceof Addressable) {
             $fqsen = $this->getFQSEN();
             if ($fqsen instanceof FullyQualifiedClassElement) {
@@ -58,5 +59,4 @@ abstract class ClassElement extends TypedStructuralElement {
 
         return $code_base->getClassByFQSEN($class_fqsen);
     }
-
 }

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -16,7 +16,8 @@ use \Phan\Language\FQSEN\FullyQualifiedPropertyName;
 use \Phan\Language\Type;
 use \Phan\Language\UnionType;
 
-class Clazz extends TypedStructuralElement implements Addressable {
+class Clazz extends TypedStructuralElement implements Addressable
+{
     use AddressableImplementation;
     use \Phan\Memoize;
 
@@ -137,14 +138,14 @@ class Clazz extends TypedStructuralElement implements Addressable {
         // Build a set of flags based on the constitution
         // of the built-in class
         $flags = 0;
-        if($class->isFinal()) {
+        if ($class->isFinal()) {
             $flags = \ast\flags\CLASS_FINAL;
-        } else if($class->isInterface()) {
+        } elseif ($class->isInterface()) {
             $flags = \ast\flags\CLASS_INTERFACE;
-        } else if($class->isTrait()) {
+        } elseif ($class->isTrait()) {
             $flags = \ast\flags\CLASS_TRAIT;
         }
-        if($class->isAbstract()) {
+        if ($class->isAbstract()) {
             $flags |= \ast\flags\CLASS_ABSTRACT;
         }
 
@@ -160,8 +161,7 @@ class Clazz extends TypedStructuralElement implements Addressable {
 
         // If this class has a parent class, add it to the
         // class info
-        if(($parent_class = $class->getParentClass())) {
-
+        if (($parent_class = $class->getParentClass())) {
             $parent_class_fqsen =
                 FullyQualifiedClassName::fromFullyQualifiedString(
                     '\\' . $parent_class->getName()
@@ -170,7 +170,7 @@ class Clazz extends TypedStructuralElement implements Addressable {
             $clazz->setParentClassFQSEN($parent_class_fqsen);
         }
 
-        foreach($class->getDefaultProperties() as $name => $value) {
+        foreach ($class->getDefaultProperties() as $name => $value) {
             // TODO: whats going on here?
             $reflection_property =
                 new \ReflectionProperty($class->getName(), $name);
@@ -201,7 +201,7 @@ class Clazz extends TypedStructuralElement implements Addressable {
             );
         }
 
-        foreach($class->getConstants() as $name => $value) {
+        foreach ($class->getConstants() as $name => $value) {
             $clazz->addConstant(
                 $code_base,
                 new Constant(
@@ -213,7 +213,7 @@ class Clazz extends TypedStructuralElement implements Addressable {
             );
         }
 
-        foreach($class->getMethods() as $reflection_method) {
+        foreach ($class->getMethods() as $reflection_method) {
             $method_list =
                 Method::methodListFromReflectionClassAndMethod(
                     $context->withClassFQSEN($clazz->getFQSEN()),
@@ -236,7 +236,8 @@ class Clazz extends TypedStructuralElement implements Addressable {
      *
      * @return null
      */
-    public function setParentClassFQSEN(FullyQualifiedClassName $fqsen) {
+    public function setParentClassFQSEN(FullyQualifiedClassName $fqsen)
+    {
         $this->parent_class_fqsen = $fqsen;
 
         // Add the parent to the union type of this
@@ -250,7 +251,8 @@ class Clazz extends TypedStructuralElement implements Addressable {
      * @return bool
      * True if this class has a parent class
      */
-    public function hasParentClassFQSEN() : bool {
+    public function hasParentClassFQSEN() : bool
+    {
         return !empty($this->parent_class_fqsen);
     }
 
@@ -258,7 +260,8 @@ class Clazz extends TypedStructuralElement implements Addressable {
      * @return FQSEN
      * The parent class of this class if one exists
      */
-    public function getParentClassFQSEN() : FullyQualifiedClassName {
+    public function getParentClassFQSEN() : FullyQualifiedClassName
+    {
         return $this->parent_class_fqsen;
     }
 
@@ -269,7 +272,8 @@ class Clazz extends TypedStructuralElement implements Addressable {
      *
      * @return null
      */
-    public function addInterfaceClassFQSEN(FQSEN $fqsen) {
+    public function addInterfaceClassFQSEN(FQSEN $fqsen)
+    {
         $this->interface_fqsen_list[] = $fqsen;
 
         // Add the interface to the union type of this
@@ -283,7 +287,8 @@ class Clazz extends TypedStructuralElement implements Addressable {
      * @return FQSEN[]
      * Get the list of interfaces implemented by this class
      */
-    public function getInterfaceFQSENList() : array {
+    public function getInterfaceFQSENList() : array
+    {
         return $this->interface_fqsen_list;
     }
 
@@ -353,7 +358,6 @@ class Clazz extends TypedStructuralElement implements Addressable {
 
         // Check to see if we have the property
         if (!$code_base->hasProperty($this->getFQSEN(), $name)) {
-
             // If we don't have the property but do have a
             // __get method, then we can create the property
             if ($this->hasMethodWithName($code_base, '__get')) {
@@ -423,7 +427,8 @@ class Clazz extends TypedStructuralElement implements Addressable {
      * @return Property[]
      * The list of properties on this class
      */
-    public function getPropertyMap(CodeBase $code_base) : array {
+    public function getPropertyMap(CodeBase $code_base) : array
+    {
         return $code_base->getPropertyMapForScope(
             $this->getFQSEN()
         );
@@ -477,7 +482,8 @@ class Clazz extends TypedStructuralElement implements Addressable {
      * @return Constant[]
      * The constants associated with this class
      */
-    public function getConstantMap(CodeBase $code_base) : array {
+    public function getConstantMap(CodeBase $code_base) : array
+    {
         return $code_base->getConstantMapForScope(
             $this->getFQSEN()
         );
@@ -502,7 +508,8 @@ class Clazz extends TypedStructuralElement implements Addressable {
         }
 
         $code_base->addMethodInScope(
-            $method, $this->getFQSEN()
+            $method,
+            $this->getFQSEN()
         );
     }
 
@@ -573,7 +580,8 @@ class Clazz extends TypedStructuralElement implements Addressable {
      * @return Method[]
      * A list of methods on this class
      */
-    public function getMethodMap(CodeBase $code_base) : array {
+    public function getMethodMap(CodeBase $code_base) : array
+    {
         return $code_base->getMethodMapForScope(
             $this->getFQSEN()
         );
@@ -582,7 +590,8 @@ class Clazz extends TypedStructuralElement implements Addressable {
     /**
      * @return null
      */
-    public function addTraitFQSEN(FQSEN $fqsen) {
+    public function addTraitFQSEN(FQSEN $fqsen)
+    {
         $this->trait_fqsen_list[] = $fqsen;
 
         // Add the trait to the union type of this class
@@ -595,7 +604,8 @@ class Clazz extends TypedStructuralElement implements Addressable {
      * @return FQSEN[]
      * A list of FQSEN's for included traits
      */
-    public function getTraitFQSENList() : array {
+    public function getTraitFQSENList() : array
+    {
         return $this->trait_fqsen_list;
     }
 
@@ -603,14 +613,16 @@ class Clazz extends TypedStructuralElement implements Addressable {
      * @return bool
      * True if this class calls its parent constructor
      */
-    public function getIsParentConstructorCalled() : bool {
+    public function getIsParentConstructorCalled() : bool
+    {
         return $this->is_parent_constructor_called;
     }
 
     /**
      * @return null
      */
-    public function setIsParentConstructorCalled(bool $is_parent_constructor_called) {
+    public function setIsParentConstructorCalled(bool $is_parent_constructor_called)
+    {
         $this->is_parent_constructor_called =
             $is_parent_constructor_called;
     }
@@ -619,7 +631,8 @@ class Clazz extends TypedStructuralElement implements Addressable {
      * @return bool
      * True if this is a final class
      */
-    public function isFinal() : bool {
+    public function isFinal() : bool
+    {
         return (bool)(
             $this->getFlags() & \ast\flags\CLASS_FINAL
         );
@@ -629,7 +642,8 @@ class Clazz extends TypedStructuralElement implements Addressable {
      * @return bool
      * True if this is an abstract class
      */
-    public function isAbstract() : bool {
+    public function isAbstract() : bool
+    {
         return (bool)(
             $this->getFlags() & \ast\flags\CLASS_ABSTRACT
         );
@@ -639,7 +653,8 @@ class Clazz extends TypedStructuralElement implements Addressable {
      * @return bool
      * True if this is an interface
      */
-    public function isInterface() : bool {
+    public function isInterface() : bool
+    {
         return (bool)(
             $this->getFlags() & \ast\flags\CLASS_INTERFACE
         );
@@ -649,7 +664,8 @@ class Clazz extends TypedStructuralElement implements Addressable {
      * @return bool
      * True if this class is a trait
      */
-    public function isTrait() : bool {
+    public function isTrait() : bool
+    {
         return (bool)(
             $this->getFlags() & \ast\flags\CLASS_TRAIT
         );
@@ -658,7 +674,8 @@ class Clazz extends TypedStructuralElement implements Addressable {
     /**
      * @return FullyQualifiedClassName
      */
-    public function getFQSEN() : FQSEN {
+    public function getFQSEN() : FQSEN
+    {
         // Allow overrides
         if ($this->fqsen) {
             return $this->fqsen;
@@ -677,7 +694,8 @@ class Clazz extends TypedStructuralElement implements Addressable {
      *
      * @return FullyQualifiedClassName[]
      */
-    public function getNonParentAncestorFQSENList(CodeBase $code_base) {
+    public function getNonParentAncestorFQSENList(CodeBase $code_base)
+    {
         return array_merge(
             $this->getTraitFQSENList(),
             $this->getInterfaceFQSENList()
@@ -687,7 +705,8 @@ class Clazz extends TypedStructuralElement implements Addressable {
     /**
      * @return FullyQualifiedClassName[]
      */
-    public function getAncestorFQSENList(CodeBase $code_base) {
+    public function getAncestorFQSENList(CodeBase $code_base)
+    {
         $ancestor_list = $this->getNonParentAncestorFQSENList($code_base);
 
         if ($this->hasParentClassFQSEN()) {
@@ -704,7 +723,8 @@ class Clazz extends TypedStructuralElement implements Addressable {
      *
      * @return Clazz[]
      */
-    public function getAncestorClazzList(CodeBase $code_base) {
+    public function getAncestorClazzList(CodeBase $code_base)
+    {
         $ancestor_class_list = [];
         foreach ($this->getAncestorFQSENList($code_base) as $fqsen) {
             if ($code_base->hasClassWithFQSEN($fqsen)) {
@@ -721,8 +741,9 @@ class Clazz extends TypedStructuralElement implements Addressable {
      *
      * @return void
      */
-    public function analyzeMethodOverrides(CodeBase $code_base) {
-        return $this->memoize(__METHOD__, function() use ($code_base) {
+    public function analyzeMethodOverrides(CodeBase $code_base)
+    {
+        return $this->memoize(__METHOD__, function () use ($code_base) {
 
             // Get the list of ancestors of this class
             $ancestor_class_list = $this->getAncestorClazzList(
@@ -733,13 +754,16 @@ class Clazz extends TypedStructuralElement implements Addressable {
             // something. We're relying here on having copied
             // methods to subclasses.
             foreach ($this->getMethodMap($code_base) as $name => $method) {
-                $is_override = array_reduce($ancestor_class_list,
+                $is_override = array_reduce(
+                    $ancestor_class_list,
                     function (bool $carry, Clazz $class) use ($code_base, $name) {
                         return ($carry || $class->hasMethodWithName(
                             $code_base,
                             $name
                         ));
-                    }, false);
+                    },
+                    false
+                );
 
                 // Tell the method if its overriding something or not
                 $method->setIsOverride($is_override);
@@ -757,8 +781,9 @@ class Clazz extends TypedStructuralElement implements Addressable {
      *
      * @return null
      */
-    public function importAncestorClasses(CodeBase $code_base) {
-        $this->memoize(__METHOD__, function() use ($code_base) {
+    public function importAncestorClasses(CodeBase $code_base)
+    {
+        $this->memoize(__METHOD__, function () use ($code_base) {
             foreach ($this->getNonParentAncestorFQSENList($code_base) as $fqsen) {
                 if (!$code_base->hasClassWithFQSEN($fqsen)) {
                     continue;
@@ -785,8 +810,9 @@ class Clazz extends TypedStructuralElement implements Addressable {
      *
      * @return null
      */
-    public function importParentClass(CodeBase $code_base) {
-        $this->memoize(__METHOD__, function() use ($code_base) {
+    public function importParentClass(CodeBase $code_base)
+    {
+        $this->memoize(__METHOD__, function () use ($code_base) {
             if (!$this->hasParentClassFQSEN()) {
                 return;
             }
@@ -798,8 +824,10 @@ class Clazz extends TypedStructuralElement implements Addressable {
                 return;
             }
 
-            assert($code_base->hasClassWithFQSEN($this->getParentClassFQSEN()),
-                "Clazz {$this->getParentClassFQSEN()} should already have been proven to exist from {$this->getContext()}");
+            assert(
+                $code_base->hasClassWithFQSEN($this->getParentClassFQSEN()),
+                "Clazz {$this->getParentClassFQSEN()} should already have been proven to exist from {$this->getContext()}"
+            );
 
             // Get the parent class
             $parent = $code_base->getClassByFQSEN(
@@ -830,8 +858,9 @@ class Clazz extends TypedStructuralElement implements Addressable {
         CodeBase $code_base,
         Clazz $superclazz
     ) {
-        $this->memoize((string)$superclazz->getFQSEN(),
-            function() use ($code_base, $superclazz) {
+        $this->memoize(
+            (string)$superclazz->getFQSEN(),
+            function () use ($code_base, $superclazz) {
 
                 // Copy properties
                 foreach ($superclazz->getPropertyMap($code_base) as $property) {
@@ -847,7 +876,8 @@ class Clazz extends TypedStructuralElement implements Addressable {
                 foreach ($superclazz->getMethodMap($code_base) as $method) {
                     $this->addMethod($code_base, $method);
                 }
-            });
+            }
+        );
     }
 
     /**
@@ -861,8 +891,8 @@ class Clazz extends TypedStructuralElement implements Addressable {
 
         // A function that maps a list of elements to the
         // total reference count for all elements
-        $list_count = function(array $list) use ($code_base) {
-            return array_reduce($list, function(
+        $list_count = function (array $list) use ($code_base) {
+            return array_reduce($list, function (
                 int $count,
                 TypedStructuralElement $element
             ) use ($code_base) {
@@ -885,7 +915,8 @@ class Clazz extends TypedStructuralElement implements Addressable {
      * @return string
      * A string describing this class
      */
-    public function __toString() : string {
+    public function __toString() : string
+    {
         $string = '';
 
         if ($this->isFinal()) {
@@ -898,7 +929,7 @@ class Clazz extends TypedStructuralElement implements Addressable {
 
         if ($this->isInterface()) {
             $string .= 'Interface ';
-        } else if ($this->isTrait()) {
+        } elseif ($this->isTrait()) {
             $string .= 'Trait ';
         } else {
             $string .= 'Class ';

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -8,7 +8,8 @@ use \Phan\Language\UnionType;
 
 /**
  */
-class Comment {
+class Comment
+{
 
     // A legal type identifier
     const simple_type_regex =
@@ -120,43 +121,39 @@ class Comment {
         $return = null;
         $suppress_issue_list = [];
 
-        $lines = explode("\n",$comment);
+        $lines = explode("\n", $comment);
 
-        foreach($lines as $line) {
-
+        foreach ($lines as $line) {
             if (strpos($line, '@param') !== false) {
                 $parameter_list[] =
                     self::parameterFromCommentLine($context, $line);
-            }
-
-            else if (stripos($line, '@var') !== false) {
+            } elseif (stripos($line, '@var') !== false) {
                 $variable_list[] =
                     self::parameterFromCommentLine($context, $line);
-            }
-
-            else if (stripos($line, '@return') !== false) {
-                if(preg_match('/@return\s+(' . self::union_type_regex . '+)/', $line, $match)) {
-                    if(strpos($match[1],'\\')===0 && strpos($match[1],'\\',1)===false) {
-                        $return = trim($match[1],'\\');
+            } elseif (stripos($line, '@return') !== false) {
+                if (preg_match('/@return\s+(' . self::union_type_regex . '+)/', $line, $match)) {
+                    if (strpos($match[1], '\\')===0 && strpos($match[1], '\\', 1)===false) {
+                        $return = trim($match[1], '\\');
                     } else {
                         $return = $match[1];
                     }
 
                 }
-            } else if (stripos($line, '@suppress') !== false) {
+            } elseif (stripos($line, '@suppress') !== false) {
                 $suppress_issue_list[] =
                     self::suppressIssueFromCommentLine($line);
             }
 
-            if(($pos=stripos($line, '@deprecated')) !== false) {
-                if(preg_match('/@deprecated\b/', $line, $match)) {
+            if (($pos=stripos($line, '@deprecated')) !== false) {
+                if (preg_match('/@deprecated\b/', $line, $match)) {
                     $is_deprecated = true;
                 }
             }
         }
 
         $return_type = UnionType::fromStringInContext(
-            $return ?: '', $context
+            $return ?: '',
+            $context
         );
 
         return new Comment(
@@ -184,7 +181,7 @@ class Comment {
         string $line
     ) {
         $match = [];
-        if(preg_match('/@(param|var)\s+(' . self::union_type_regex . ')(\s+(\\$\S+))?/', $line, $match)) {
+        if (preg_match('/@(param|var)\s+(' . self::union_type_regex . ')(\s+(\\$\S+))?/', $line, $match)) {
             $type = null;
 
             $type = $match[2];
@@ -208,7 +205,8 @@ class Comment {
             }
 
             return new CommentParameter(
-                $variable_name, $union_type
+                $variable_name,
+                $union_type
             );
         }
 
@@ -225,7 +223,7 @@ class Comment {
     private static function suppressIssueFromCommentLine(
         string $line
     ) : string {
-        if(preg_match('/@suppress\s+([^\s]+)/', $line, $match)) {
+        if (preg_match('/@suppress\s+([^\s]+)/', $line, $match)) {
             return $match[1];
         }
 
@@ -237,7 +235,8 @@ class Comment {
      * Set to true if the comment contains a 'deprecated'
      * directive.
      */
-    public function isDeprecated() : bool {
+    public function isDeprecated() : bool
+    {
         return $this->is_deprecated;
     }
 
@@ -245,7 +244,8 @@ class Comment {
      * @return UnionType
      * A UnionType defined by a (at)return directive
      */
-    public function getReturnType() : UnionType {
+    public function getReturnType() : UnionType
+    {
         return $this->return;
     }
 
@@ -254,7 +254,8 @@ class Comment {
      * True if this doc block contains a (at)return
      * directive specifying a type.
      */
-    public function hasReturnUnionType() : bool {
+    public function hasReturnUnionType() : bool
+    {
         return !empty($this->return) && !$this->return->isEmpty();
     }
 
@@ -263,7 +264,8 @@ class Comment {
      *
      * @suppress PhanUnreferencedMethod
      */
-    public function getParameterList() : array {
+    public function getParameterList() : array
+    {
         return $this->parameter_list;
     }
 
@@ -271,7 +273,8 @@ class Comment {
      * @return string[]
      * A set of issie names like 'PhanUnreferencedMethod' to suppress
      */
-    public function getSuppressIssueList() : array {
+    public function getSuppressIssueList() : array
+    {
         return $this->suppress_issue_list;
     }
 
@@ -308,11 +311,13 @@ class Comment {
     /**
      * @return CommentParameter[]
      */
-    public function getVariableList() : array {
+    public function getVariableList() : array
+    {
         return $this->variable_list;
     }
 
-    public function __toString() : string {
+    public function __toString() : string
+    {
         $string = "/**\n";
 
         if ($this->is_deprecated) {
@@ -335,5 +340,4 @@ class Comment {
 
         return $string;
     }
-
 }

--- a/src/Phan/Language/Element/Comment/Parameter.php
+++ b/src/Phan/Language/Element/Comment/Parameter.php
@@ -4,7 +4,8 @@ namespace Phan\Language\Element\Comment;
 
 use \Phan\Language\UnionType;
 
-class Parameter {
+class Parameter
+{
 
     /**
      * @var string
@@ -37,7 +38,8 @@ class Parameter {
      * @return string
      * The name of the parameter
      */
-    public function getName() : string {
+    public function getName() : string
+    {
         return $this->name;
     }
 
@@ -45,11 +47,13 @@ class Parameter {
      * @return UnionType
      * The type of the parameter
      */
-    public function getUnionType() : UnionType {
+    public function getUnionType() : UnionType
+    {
         return $this->type;
     }
 
-    public function __toString() : string {
+    public function __toString() : string
+    {
         $string = '';
 
         if (!$this->type->isEmpty()) {
@@ -60,5 +64,4 @@ class Parameter {
 
         return $string;
     }
-
 }

--- a/src/Phan/Language/Element/Constant.php
+++ b/src/Phan/Language/Element/Constant.php
@@ -9,7 +9,8 @@ use \Phan\Language\FutureUnionType;
 use \Phan\Language\UnionType;
 use \ast\Node;
 
-class Constant extends ClassElement implements Addressable {
+class Constant extends ClassElement implements Addressable
+{
     use AddressableImplementation;
     use ElementFutureUnionType;
 
@@ -50,7 +51,8 @@ class Constant extends ClassElement implements Addressable {
      *
      * @return UnionType
      */
-    public function getUnionType() : UnionType {
+    public function getUnionType() : UnionType
+    {
         if (null !== ($union_type = $this->getFutureUnionType())) {
             $this->getUnionType()->addUnionType($union_type);
         }
@@ -63,7 +65,8 @@ class Constant extends ClassElement implements Addressable {
      * The fully-qualified structural element name of this
      * structural element
      */
-    public function getFQSEN() : FQSEN {
+    public function getFQSEN() : FQSEN
+    {
         // Get the stored FQSEN if it exists
         if ($this->fqsen) {
             return $this->fqsen;
@@ -82,7 +85,8 @@ class Constant extends ClassElement implements Addressable {
         }
     }
 
-    public function __toString() : string {
+    public function __toString() : string
+    {
         return 'const ' . $this->getName();
     }
 }

--- a/src/Phan/Language/Element/ElementFutureUnionType.php
+++ b/src/Phan/Language/Element/ElementFutureUnionType.php
@@ -5,7 +5,8 @@ use \Phan\Language\FutureUnionType;
 use \Phan\Language\Type\NullType;
 use \Phan\Language\UnionType;
 
-trait ElementFutureUnionType {
+trait ElementFutureUnionType
+{
 
     /**
      * @var FutureUnionType|null
@@ -40,7 +41,8 @@ trait ElementFutureUnionType {
      * on this object or null if there is no future
      * union type.
      */
-    public function getFutureUnionType() {
+    public function getFutureUnionType()
+    {
         if (empty($this->future_union_type)) {
             return null;
         }
@@ -61,5 +63,4 @@ trait ElementFutureUnionType {
 
         return $union_type;
     }
-
 }

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -285,7 +285,7 @@ class Method extends ClassElement implements Addressable
 
             // Load properties if defined
             foreach ($map['property_name_type_map'] ?? []
-            as $parameter_name => $parameter_type) {
+ as $parameter_name => $parameter_type) {
                 $flags = 0;
                 $is_optional = false;
 

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -14,7 +14,8 @@ use \Phan\Language\UnionType;
 use \ast\Node;
 use \ast\Node\Decl;
 
-class Method extends ClassElement implements Addressable {
+class Method extends ClassElement implements Addressable
+{
     use AddressableImplementation;
     use \Phan\Analyze\Analyzable;
     use \Phan\Memoize;
@@ -159,7 +160,8 @@ class Method extends ClassElement implements Addressable {
         $namespace = '\\' . implode('\\', $parts);
 
         $fqsen = FullyQualifiedFunctionName::make(
-            $namespace, $method_name
+            $namespace,
+            $method_name
         );
 
         $method = new Method(
@@ -264,7 +266,7 @@ class Method extends ClassElement implements Addressable {
         }
 
         $alternate_id = 0;
-        return array_map(function($map) use (
+        return array_map(function ($map) use (
             $method,
             &$alternate_id
         ) : Method {
@@ -283,8 +285,7 @@ class Method extends ClassElement implements Addressable {
 
             // Load properties if defined
             foreach ($map['property_name_type_map'] ?? []
-                as $parameter_name => $parameter_type
-            ) {
+            as $parameter_name => $parameter_type) {
                 $flags = 0;
                 $is_optional = false;
 
@@ -324,12 +325,14 @@ class Method extends ClassElement implements Addressable {
             }
 
             $alternate_method->setNumberOfRequiredParameters(
-                array_reduce($alternate_method->parameter_list,
-                    function(int $carry, Parameter $parameter) : int {
+                array_reduce(
+                    $alternate_method->parameter_list,
+                    function (int $carry, Parameter $parameter) : int {
                         return ($carry + (
                             $parameter->isOptional() ? 0 : 1
                         ));
-                    }, 0
+                    },
+                    0
                 )
             );
 
@@ -410,14 +413,17 @@ class Method extends ClassElement implements Addressable {
             $parameter_list,
             function (int $carry, Parameter $parameter) : int {
                 return ($carry + ($parameter->isRequired() ? 1 : 0));
-            }, 0)
-        );
+            },
+            0
+        ));
 
         $method->setNumberOfOptionalParameters(array_reduce(
-            $parameter_list, function (int $carry, Parameter $parameter) : int {
+            $parameter_list,
+            function (int $carry, Parameter $parameter) : int {
                 return ($carry + ($parameter->isOptional() ? 1 : 0));
-            }, 0)
-        );
+            },
+            0
+        ));
 
         // Check to see if the comment specifies that the
         // method is deprecated
@@ -425,7 +431,7 @@ class Method extends ClassElement implements Addressable {
         $method->setSuppressIssueList($comment->getSuppressIssueList());
 
         // Take a look at method return types
-        if($node->children['returnType'] !== null) {
+        if ($node->children['returnType'] !== null) {
             // Get the type of the parameter
             $union_type = UnionType::fromNode(
                 $context,
@@ -437,7 +443,6 @@ class Method extends ClassElement implements Addressable {
         }
 
         if ($comment->hasReturnUnionType()) {
-
             // See if we have a return type specified in the comment
             $union_type = $comment->getReturnType();
 
@@ -460,8 +465,7 @@ class Method extends ClassElement implements Addressable {
         }
 
         // Add params to local scope for user functions
-        if($context->getFile() != 'internal') {
-
+        if ($context->getFile() != 'internal') {
             $parameter_offset = 0;
             foreach ($method->getParameterList() as $i => $parameter) {
                 if ($parameter->getUnionType()->isEmpty()) {
@@ -497,7 +501,7 @@ class Method extends ClassElement implements Addressable {
                         if (!$default_type->isEqualTo(NullType::instance()->asUnionType())
                             && !$default_type->canCastToUnionType(
                                 $parameter->getUnionType()
-                        )) {
+                            )) {
                             Issue::emit(
                                 Issue::TypeMismatchDefault,
                                 $context->getFile(),
@@ -538,7 +542,8 @@ class Method extends ClassElement implements Addressable {
      * @return int
      * The number of optional parameters on this method
      */
-    public function getNumberOfOptionalParameters() : int {
+    public function getNumberOfOptionalParameters() : int
+    {
         return $this->number_of_optional_parameters;
     }
 
@@ -547,7 +552,8 @@ class Method extends ClassElement implements Addressable {
      *
      * @return null
      */
-    public function setNumberOfOptionalParameters(int $number) {
+    public function setNumberOfOptionalParameters(int $number)
+    {
         $this->number_of_optional_parameters = $number;
     }
 
@@ -555,7 +561,8 @@ class Method extends ClassElement implements Addressable {
      * @return int
      * The maximum number of parameters to this method
      */
-    public function getNumberOfParameters() : int {
+    public function getNumberOfParameters() : int
+    {
         return (
             $this->getNumberOfRequiredParameters()
             + $this->getNumberOfOptionalParameters()
@@ -566,7 +573,8 @@ class Method extends ClassElement implements Addressable {
      * @return int
      * The number of required parameters on this method
      */
-    public function getNumberOfRequiredParameters() : int {
+    public function getNumberOfRequiredParameters() : int
+    {
         return $this->number_of_required_parameters;
     }
     /**
@@ -575,7 +583,8 @@ class Method extends ClassElement implements Addressable {
      *
      * @return null
      */
-    public function setNumberOfRequiredParameters(int $number) {
+    public function setNumberOfRequiredParameters(int $number)
+    {
         $this->number_of_required_parameters = $number;
     }
 
@@ -583,7 +592,8 @@ class Method extends ClassElement implements Addressable {
      * @return Parameter[]
      * A list of parameters on the method
      */
-    public function getParameterList() {
+    public function getParameterList()
+    {
         return $this->parameter_list;
     }
 
@@ -593,7 +603,8 @@ class Method extends ClassElement implements Addressable {
      *
      * @return null
      */
-    public function setParameterList(array $parameter_list) {
+    public function setParameterList(array $parameter_list)
+    {
         $this->parameter_list = $parameter_list;
     }
 
@@ -601,7 +612,8 @@ class Method extends ClassElement implements Addressable {
      * @return bool
      * True if this is an abstract class
      */
-    public function isAbstract() : bool {
+    public function isAbstract() : bool
+    {
         return (bool)(
             $this->getFlags() & \ast\flags\MODIFIER_ABSTRACT
         );
@@ -611,7 +623,8 @@ class Method extends ClassElement implements Addressable {
      * @return bool
      * True if this is a static method
      */
-    public function isStatic() : bool {
+    public function isStatic() : bool
+    {
         return (bool)(
             $this->getFlags() & \ast\flags\MODIFIER_STATIC
         );
@@ -623,7 +636,8 @@ class Method extends ClassElement implements Addressable {
      * was defined (either in the signature itself or in the
      * docblock).
      */
-    public function isReturnTypeUndefined() : bool {
+    public function isReturnTypeUndefined() : bool
+    {
         return $this->is_return_type_undefined;
     }
 
@@ -644,7 +658,8 @@ class Method extends ClassElement implements Addressable {
      * @return bool
      * True if this method returns a value
      */
-    public function getHasReturn() : bool {
+    public function getHasReturn() : bool
+    {
         return $this->has_return;
     }
 
@@ -655,7 +670,8 @@ class Method extends ClassElement implements Addressable {
      *
      * @return void
      */
-    public function setHasReturn(bool $has_return) {
+    public function setHasReturn(bool $has_return)
+    {
         $this->has_return = $has_return;
     }
 
@@ -663,7 +679,8 @@ class Method extends ClassElement implements Addressable {
      * @return bool
      * True if this method overrides another method
      */
-    public function getIsOverride() : bool {
+    public function getIsOverride() : bool
+    {
         return $this->is_override;
     }
 
@@ -673,7 +690,8 @@ class Method extends ClassElement implements Addressable {
      *
      * @return void
      */
-    public function setIsOverride(bool $is_override) {
+    public function setIsOverride(bool $is_override)
+    {
         $this->is_override = $is_override;
     }
 
@@ -681,7 +699,8 @@ class Method extends ClassElement implements Addressable {
      * @return bool
      * True if this is a magic method
      */
-    public function getIsMagic() : bool {
+    public function getIsMagic() : bool
+    {
         return in_array($this->getName(), [
             '__get',
             '__set',
@@ -706,7 +725,8 @@ class Method extends ClassElement implements Addressable {
     /**
      * @return FullyQualifiedFunctionName|FullyQualifiedMethodName
      */
-    public function getFQSEN() : FQSEN {
+    public function getFQSEN() : FQSEN
+    {
         // Allow overrides
         if ($this->fqsen) {
             return $this->fqsen;
@@ -730,7 +750,8 @@ class Method extends ClassElement implements Addressable {
      * @return Method[]|\Generator
      * The set of all alternates to this method
      */
-    public function alternateGenerator(CodeBase $code_base) : \Generator {
+    public function alternateGenerator(CodeBase $code_base) : \Generator
+    {
         $alternate_id = 0;
         $fqsen = $this->getFQSEN();
 
@@ -744,7 +765,8 @@ class Method extends ClassElement implements Addressable {
      * @return string
      * A string representation of this method signature
      */
-    public function __toString() : string {
+    public function __toString() : string
+    {
         $string = '';
 
         $string .= 'function ' . $this->getName();

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -16,7 +16,8 @@ use \Phan\Language\UnionType;
 use \ast\Node;
 use \ast\Node\Decl;
 
-class Parameter extends Variable {
+class Parameter extends Variable
+{
 
     /**
      * @var UnionType
@@ -61,14 +62,16 @@ class Parameter extends Variable {
      *
      * @return null
      */
-    public function __clone() {
+    public function __clone()
+    {
         parent::__clone();
         $this->default_value_type = $this->default_value_type
             ? clone($this->default_value_type)
             : $this->default_value_type;
     }
 
-    public function setUnionType(UnionType $type) {
+    public function setUnionType(UnionType $type)
+    {
         parent::setUnionType($type);
     }
 
@@ -78,7 +81,8 @@ class Parameter extends Variable {
      *
      * @return void
      */
-    public function setDefaultValueType(UnionType $type) {
+    public function setDefaultValueType(UnionType $type)
+    {
         $this->default_value_type = $type;
     }
 
@@ -87,7 +91,8 @@ class Parameter extends Variable {
      * True if this parameter has a type for its
      * default value
      */
-    public function hasDefaultValue() : bool {
+    public function hasDefaultValue() : bool
+    {
         return !empty($this->default_value_type);
     }
 
@@ -96,7 +101,8 @@ class Parameter extends Variable {
      * The type of the default value for this parameter
      * if it exists
      */
-    public function getDefaultValueType() : UnionType {
+    public function getDefaultValueType() : UnionType
+    {
         return $this->default_value_type;
     }
 
@@ -126,8 +132,7 @@ class Parameter extends Variable {
                     $context->getFile(),
                     $node->lineno ?? 0
                 );
-            } else if (
-                $parameter->isOptional()
+            } elseif ($parameter->isOptional()
                 && !$is_optional_seen
                 && $parameter->getUnionType()->isEmpty()
             ) {
@@ -172,7 +177,6 @@ class Parameter extends Variable {
 
         // If there is a default value, store it and its type
         if (($default_node = $node->children['default']) !== null) {
-
             // We can't figure out default values during the
             // parsing phase, unfortunately
             if (!($default_node instanceof Node)
@@ -226,7 +230,8 @@ class Parameter extends Variable {
      * @return bool
      * True if this is an optional parameter
      */
-    public function isOptional() : bool {
+    public function isOptional() : bool
+    {
         return (
             $this->hasDefaultValue()
             || $this->isVariadic()
@@ -237,7 +242,8 @@ class Parameter extends Variable {
      * @return bool
      * True if this is a required parameter
      */
-    public function isRequired() : bool {
+    public function isRequired() : bool
+    {
         return !$this->isOptional();
     }
 
@@ -247,7 +253,8 @@ class Parameter extends Variable {
      * take an unlimited list of parameters and express
      * them as an array.
      */
-    public function isVariadic() : bool {
+    public function isVariadic() : bool
+    {
         return (bool)(
             $this->getFlags() & \ast\flags\PARAM_VARIADIC
         );
@@ -258,13 +265,15 @@ class Parameter extends Variable {
      * True if this parameter is pass-by-reference
      * i.e. prefixed with '&'.
      */
-    public function isPassByReference() : bool {
+    public function isPassByReference() : bool
+    {
         return (bool)(
             $this->getFlags() & \ast\flags\PARAM_REF
         );
     }
 
-    public function __toString() : string {
+    public function __toString() : string
+    {
         $string = '';
 
         if (!$this->getUnionType()->isEmpty()) {
@@ -287,5 +296,4 @@ class Parameter extends Variable {
 
         return $string;
     }
-
 }

--- a/src/Phan/Language/Element/PassByReferenceVariable.php
+++ b/src/Phan/Language/Element/PassByReferenceVariable.php
@@ -15,7 +15,8 @@ use \ast\Node;
  * pass-by-reference parameter so that its value can be
  * updated when re-analyzing the method.
  */
-class PassByReferenceVariable extends Variable {
+class PassByReferenceVariable extends Variable
+{
 
     /** @var Parameter */
     private $parameter;
@@ -31,40 +32,48 @@ class PassByReferenceVariable extends Variable {
         $this->variable = $variable;
     }
 
-    public function getName() : string {
+    public function getName() : string
+    {
         return $this->parameter->getName();
     }
 
-    public function getUnionType() : UnionType {
+    public function getUnionType() : UnionType
+    {
         return $this->variable->getUnionType();
     }
 
-    public function setUnionType(UnionType $type) {
+    public function setUnionType(UnionType $type)
+    {
         $this->variable->setUnionType($type);
     }
 
-    public function getFlags() : int {
+    public function getFlags() : int
+    {
         return $this->variable->getFlags();
     }
 
-    public function setFlags(int $flags) {
+    public function setFlags(int $flags)
+    {
         $this->variable->setFlags($flags);
     }
 
-    public function getContext() : Context {
+    public function getContext() : Context
+    {
         return $this->variable->getContext();
     }
 
-    public function isDeprecated() : bool {
+    public function isDeprecated() : bool
+    {
         return $this->variable->isDeprecated();
     }
 
-    public function setIsDeprecated(bool $is_deprecated) {
+    public function setIsDeprecated(bool $is_deprecated)
+    {
         $this->variable->setIsDeprecated($is_deprecated);
     }
 
-    public function isInternal() : bool {
+    public function isInternal() : bool
+    {
         return $this->variable->isInternal();
     }
-
 }

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -6,7 +6,8 @@ use \Phan\Language\FQSEN;
 use \Phan\Language\FQSEN\FullyQualifiedPropertyName;
 use \Phan\Language\UnionType;
 
-class Property extends ClassElement implements Addressable {
+class Property extends ClassElement implements Addressable
+{
     use AddressableImplementation;
     use ElementFutureUnionType;
 
@@ -41,14 +42,15 @@ class Property extends ClassElement implements Addressable {
         );
     }
 
-    public function __toString() : string {
+    public function __toString() : string
+    {
         $string = '';
 
         if ($this->isPublic()) {
             $string .= 'public ';
-        } else if ($this->isProtected()) {
+        } elseif ($this->isProtected()) {
             $string .= 'protected ';
-        } else if ($this->isPrivate()) {
+        } elseif ($this->isPrivate()) {
             $string .= 'private ';
         }
 
@@ -61,7 +63,8 @@ class Property extends ClassElement implements Addressable {
      * Override the default getter to fill in a future
      * union type if available.
      */
-    public function getUnionType() : UnionType {
+    public function getUnionType() : UnionType
+    {
         if (null !== ($union_type = $this->getFutureUnionType())) {
             $this->getUnionType()->addUnionType($union_type);
         }
@@ -74,7 +77,8 @@ class Property extends ClassElement implements Addressable {
      * The fully-qualified structural element name of this
      * structural element
      */
-    public function getFQSEN() : FQSEN {
+    public function getFQSEN() : FQSEN
+    {
         // Get the stored FQSEN if it exists
         if ($this->fqsen) {
             return $this->fqsen;
@@ -85,5 +89,4 @@ class Property extends ClassElement implements Addressable {
             $this->getContext()
         );
     }
-
 }

--- a/src/Phan/Language/Element/StructuralElement.php
+++ b/src/Phan/Language/Element/StructuralElement.php
@@ -7,7 +7,8 @@ use \Phan\Language\Context;
  * Any PHP structural element such as a property, constant
  * class, method, closure, ...
  */
-abstract class StructuralElement {
+abstract class StructuralElement
+{
 
     /**
      * @var Context
@@ -43,7 +44,8 @@ abstract class StructuralElement {
      *
      * @return null
      */
-    public function __clone() {
+    public function __clone()
+    {
         $this->context = $this->context
             ? clone($this->context)
             : $this->context;
@@ -53,7 +55,8 @@ abstract class StructuralElement {
      * @return Context
      * The context in which this structural element exists
      */
-    public function getContext() : Context {
+    public function getContext() : Context
+    {
         return $this->context;
     }
 
@@ -61,7 +64,8 @@ abstract class StructuralElement {
      * @return bool
      * True if this element is marked as deprecated
      */
-    public function isDeprecated() : bool {
+    public function isDeprecated() : bool
+    {
         return $this->is_deprecated;
     }
 
@@ -71,7 +75,8 @@ abstract class StructuralElement {
      *
      * @return null
      */
-    public function setIsDeprecated(bool $is_deprecated) {
+    public function setIsDeprecated(bool $is_deprecated)
+    {
         $this->is_deprecated = $is_deprecated;
     }
 
@@ -81,7 +86,8 @@ abstract class StructuralElement {
      *
      * @return void
      */
-    public function setSuppressIssueList(array $suppress_issue_list) {
+    public function setSuppressIssueList(array $suppress_issue_list)
+    {
         $this->suppress_issue_list = [];
         foreach ($suppress_issue_list as $i => $issue_name) {
             $this->suppress_issue_list[$issue_name] = $issue_name;
@@ -93,7 +99,8 @@ abstract class StructuralElement {
      * True if this element would like to suppress the given
      * issue name
      */
-    public function hasSuppressIssue(string $issue_name) : bool {
+    public function hasSuppressIssue(string $issue_name) : bool
+    {
         return isset($this->suppress_issue_list[$issue_name]);
     }
 
@@ -101,7 +108,8 @@ abstract class StructuralElement {
      * @return bool
      * True if this was an internal PHP object
      */
-    public function isInternal() : bool {
+    public function isInternal() : bool
+    {
         return 'internal' === $this->getContext()->getFile();
     }
 }

--- a/src/Phan/Language/Element/TypedStructuralElement.php
+++ b/src/Phan/Language/Element/TypedStructuralElement.php
@@ -14,7 +14,8 @@ use \Phan\Model\CalledBy;
  * addressable such as a class, method, closure, property,
  * constant, variable, ...
  */
-abstract class TypedStructuralElement extends StructuralElement {
+abstract class TypedStructuralElement extends StructuralElement
+{
 
     /**
      * @var string
@@ -80,7 +81,8 @@ abstract class TypedStructuralElement extends StructuralElement {
      *
      * @return null
      */
-    public function __clone() {
+    public function __clone()
+    {
         parent::__clone();
         $this->type = $this->type
             ? clone($this->type)
@@ -100,7 +102,8 @@ abstract class TypedStructuralElement extends StructuralElement {
      * @return string
      * The (not fully-qualified) name of this element.
      */
-    public function getName() : string {
+    public function getName() : string
+    {
         return $this->name;
     }
 
@@ -108,7 +111,8 @@ abstract class TypedStructuralElement extends StructuralElement {
      * @return UnionType
      * Get the type of this structural element
      */
-    public function getUnionType() : UnionType {
+    public function getUnionType() : UnionType
+    {
         return $this->type;
     }
 
@@ -118,14 +122,16 @@ abstract class TypedStructuralElement extends StructuralElement {
      *
      * @return null
      */
-    public function setUnionType(UnionType $type) {
+    public function setUnionType(UnionType $type)
+    {
         $this->type = $type;
     }
 
     /**
      * @return int
      */
-    public function getFlags() : int {
+    public function getFlags() : int
+    {
         return $this->flags;
     }
 
@@ -133,7 +139,8 @@ abstract class TypedStructuralElement extends StructuralElement {
      * @param int $flags
      * @return null
      */
-    public function setFlags(int $flags) {
+    public function setFlags(int $flags)
+    {
         $this->flags = $flags;
     }
 
@@ -144,7 +151,8 @@ abstract class TypedStructuralElement extends StructuralElement {
      *
      * @return void
      */
-    public function addReference(FileRef $file_ref) {
+    public function addReference(FileRef $file_ref)
+    {
         $this->reference_list[] = $file_ref;
 
         // If requested, save the reference to the
@@ -163,7 +171,8 @@ abstract class TypedStructuralElement extends StructuralElement {
      * @return FileRef[]
      * A list of references to this typed structural element.
      */
-    public function getReferenceList() : array {
+    public function getReferenceList() : array
+    {
         if (!empty($this->reference_list)) {
             return $this->reference_list;
         }
@@ -173,7 +182,7 @@ abstract class TypedStructuralElement extends StructuralElement {
         if (Database::isEnabled()) {
             if ($this instanceof Addressable) {
                 $this->reference_list = array_map(
-                    function(CalledBy $called_by) : FileRef {
+                    function (CalledBy $called_by) : FileRef {
                         return $called_by->getFileRef();
                     },
                     CalledBy::findManyByFQSEN(
@@ -200,5 +209,4 @@ abstract class TypedStructuralElement extends StructuralElement {
     ) : int {
         return count($this->reference_list);
     }
-
 }

--- a/src/Phan/Language/Element/Variable.php
+++ b/src/Phan/Language/Element/Variable.php
@@ -8,7 +8,8 @@ use \Phan\Language\Context;
 use \Phan\Language\UnionType;
 use \ast\Node;
 
-class Variable extends TypedStructuralElement {
+class Variable extends TypedStructuralElement
+{
 
     /**
      * @param \phan\Context $context
@@ -105,7 +106,8 @@ class Variable extends TypedStructuralElement {
         ]);
     }
 
-    public function __toString() : string {
+    public function __toString() : string
+    {
         $string = '';
 
         if (!$this->getUnionType()->isEmpty()) {
@@ -114,5 +116,4 @@ class Variable extends TypedStructuralElement {
 
         return "$string\${$this->getName()}";
     }
-
 }

--- a/src/Phan/Language/FQSEN.php
+++ b/src/Phan/Language/FQSEN.php
@@ -8,7 +8,8 @@ use \Phan\Language\UnionType;
 /**
  * A Fully-Qualified Name
  */
-interface FQSEN {
+interface FQSEN
+{
 
     /**
      * @param $fqsen_string

--- a/src/Phan/Language/FQSEN/AbstractFQSEN.php
+++ b/src/Phan/Language/FQSEN/AbstractFQSEN.php
@@ -9,7 +9,8 @@ use \Phan\Language\FQSEN;
 /**
  * A Fully-Qualified Name
  */
-abstract class AbstractFQSEN implements FQSEN {
+abstract class AbstractFQSEN implements FQSEN
+{
 
     /**
      * @var string
@@ -21,7 +22,8 @@ abstract class AbstractFQSEN implements FQSEN {
      * @param string $name
      * The name of this structural element
      */
-    protected function __construct(string $name) {
+    protected function __construct(string $name)
+    {
         $this->name = $name;
     }
 
@@ -56,7 +58,8 @@ abstract class AbstractFQSEN implements FQSEN {
      * The class associated with this FQSEN or
      * null if not defined
      */
-    public function getName() : string {
+    public function getName() : string
+    {
         return $this->name;
     }
 
@@ -65,7 +68,8 @@ abstract class AbstractFQSEN implements FQSEN {
      * The canonical representation of the name of the object. Functions
      * and Methods, for instance, lowercase their names.
      */
-    public static function canonicalName(string $name) : string {
+    public static function canonicalName(string $name) : string
+    {
         return $name;
     }
 
@@ -76,4 +80,3 @@ abstract class AbstractFQSEN implements FQSEN {
      */
     abstract public function __toString() : string;
 }
-

--- a/src/Phan/Language/FQSEN/Alternatives.php
+++ b/src/Phan/Language/FQSEN/Alternatives.php
@@ -10,7 +10,8 @@ use \Phan\Language\FQSEN;
  * `\Name\Space\class,1` or `\Name\Space\class::function,1`
  * or when composed as `\Name\Space\class,1::function,1`.
  */
-trait Alternatives {
+trait Alternatives
+{
 
     /**
      * Implementers must have a getName() method
@@ -36,7 +37,8 @@ trait Alternatives {
      * FQSEN or zero if none if this is not an
      * alternative.
      */
-    public function getAlternateId() : int {
+    public function getAlternateId() : int
+    {
         return $this->alternate_id;
     }
 
@@ -45,7 +47,8 @@ trait Alternatives {
      * Get the name of this element with its alternate id
      * attached
      */
-    public function getNameWithAlternateId() : string {
+    public function getNameWithAlternateId() : string
+    {
         if ($this->alternate_id) {
             return "{$this->getName()},{$this->alternate_id}";
         }
@@ -57,7 +60,8 @@ trait Alternatives {
      * @return bool
      * True if this is an alternate
      */
-    public function isAlternate() : bool {
+    public function isAlternate() : bool
+    {
         return (0 !== $this->alternate_id);
     }
 
@@ -74,7 +78,8 @@ trait Alternatives {
      * Get the canonical (non-alternate) FQSEN associated
      * with this FQSEN
      */
-    public function getCanonicalFQSEN() : FQSEN {
+    public function getCanonicalFQSEN() : FQSEN
+    {
         if ($this->alternate_id == 0) {
             return $this;
         }

--- a/src/Phan/Language/FQSEN/FullyQualifiedClassConstantName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedClassConstantName.php
@@ -4,17 +4,15 @@ namespace Phan\Language\FQSEN;
 /**
  * A Fully-Qualified Class Constant Name
  */
-class FullyQualifiedClassConstantName
-    extends FullyQualifiedClassElement
-    implements FullyQualifiedConstantName
+class FullyQualifiedClassConstantName extends FullyQualifiedClassElement implements FullyQualifiedConstantName
 {
 
     /**
      * @return int
      * The namespace map type such as T_CLASS or T_FUNCTION
      */
-    protected static function getNamespaceMapType() : int {
+    protected static function getNamespaceMapType() : int
+    {
         return T_CONST;
     }
-
 }

--- a/src/Phan/Language/FQSEN/FullyQualifiedClassElement.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedClassElement.php
@@ -7,7 +7,8 @@ use \Phan\Language\FQSEN;
 /**
  * A Fully-Qualified Class Name
  */
-abstract class FullyQualifiedClassElement extends AbstractFQSEN {
+abstract class FullyQualifiedClassElement extends AbstractFQSEN
+{
     use \Phan\Language\FQSEN\Alternatives;
     use \Phan\Memoize;
 
@@ -64,7 +65,7 @@ abstract class FullyQualifiedClassElement extends AbstractFQSEN {
         $key = self::toString($fully_qualified_class_name, $name, $alternate_id)
             . '|' . get_called_class();
 
-        return self::memoizeStatic($key, function() use (
+        return self::memoizeStatic($key, function () use (
             $fully_qualified_class_name,
             $name,
             $alternate_id
@@ -84,8 +85,10 @@ abstract class FullyQualifiedClassElement extends AbstractFQSEN {
     public static function fromFullyQualifiedString(
         string $fully_qualified_string
     ) {
-        assert(false !== strpos($fully_qualified_string, '::'),
-            "Fully qualified class element lacks '::' delimiter in $fully_qualified_string.");
+        assert(
+            false !== strpos($fully_qualified_string, '::'),
+            "Fully qualified class element lacks '::' delimiter in $fully_qualified_string."
+        );
 
         list(
             $fully_qualified_class_name_string,
@@ -99,16 +102,20 @@ abstract class FullyQualifiedClassElement extends AbstractFQSEN {
 
         // Make sure that we're actually getting a class
         // name reference back
-        assert($fully_qualified_class_name instanceof FullyQualifiedClassName,
-            "$fully_qualified_class_name must be an instanceof FullyQualifiedClassName from string $fully_qualified_string but got " . get_class($fully_qualified_class_name));
+        assert(
+            $fully_qualified_class_name instanceof FullyQualifiedClassName,
+            "$fully_qualified_class_name must be an instanceof FullyQualifiedClassName from string $fully_qualified_string but got " . get_class($fully_qualified_class_name)
+        );
 
         // Split off the alternate ID
         $parts = explode(',', $name_string);
         $name = $parts[0];
         $alternate_id = (int)($parts[1] ?? 0);
 
-        assert(is_int($alternate_id),
-            "Alternate must be an integer in $fully_qualified_string");
+        assert(
+            is_int($alternate_id),
+            "Alternate must be an integer in $fully_qualified_string"
+        );
 
         return static::make(
             $fully_qualified_class_name,
@@ -132,14 +139,17 @@ abstract class FullyQualifiedClassElement extends AbstractFQSEN {
     ) {
         // Test to see if we have a class defined
         if (false === strpos($fqsen_string, '::')) {
-
-            assert($context->isInClassScope(),
-                "Cannot reference class element without class name when not in class scope. Got $fqsen_string.");
+            assert(
+                $context->isInClassScope(),
+                "Cannot reference class element without class name when not in class scope. Got $fqsen_string."
+            );
 
             $fully_qualified_class_name = $context->getClassFQSEN();
         } else {
-            assert(false !== strpos($fqsen_string, '::'),
-                "Fully qualified class element lacks '::' delimiter in $fqsen_string.");
+            assert(
+                false !== strpos($fqsen_string, '::'),
+                "Fully qualified class element lacks '::' delimiter in $fqsen_string."
+            );
 
             list(
                 $class_name_string,
@@ -148,7 +158,8 @@ abstract class FullyQualifiedClassElement extends AbstractFQSEN {
 
             $fully_qualified_class_name =
                 FullyQualifiedClassName::fromStringInContext(
-                    $class_name_string, $context
+                    $class_name_string,
+                    $context
                 );
         }
 
@@ -157,8 +168,10 @@ abstract class FullyQualifiedClassElement extends AbstractFQSEN {
         $name = $parts[0];
         $alternate_id = (int)($parts[1] ?? 0);
 
-        assert(is_int($alternate_id),
-            "Alternate must be an integer in $fqsen_string");
+        assert(
+            is_int($alternate_id),
+            "Alternate must be an integer in $fqsen_string"
+        );
 
         return static::make(
             $fully_qualified_class_name,
@@ -172,8 +185,8 @@ abstract class FullyQualifiedClassElement extends AbstractFQSEN {
      * The fully qualified class name associated with this
      * class element.
      */
-    public function getFullyQualifiedClassName(
-    ) : FullyQualifiedClassName {
+    public function getFullyQualifiedClassName() : FullyQualifiedClassName
+    {
         return $this->fully_qualified_class_name;
     }
 
@@ -230,8 +243,9 @@ abstract class FullyQualifiedClassElement extends AbstractFQSEN {
      * A string representation of this fully-qualified
      * structural element name.
      */
-    public function __toString() : string {
-        $fqsen_string = $this->memoize(__METHOD__, function() {
+    public function __toString() : string
+    {
+        $fqsen_string = $this->memoize(__METHOD__, function () {
             return self::toString(
                 $this->getFullyQualifiedClassName(),
                 $this->getName(),
@@ -243,5 +257,4 @@ abstract class FullyQualifiedClassElement extends AbstractFQSEN {
 
         return $fqsen_string;
     }
-
 }

--- a/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
@@ -8,13 +8,15 @@ use \Phan\Language\UnionType;
 /**
  * A Fully-Qualified Class Name
  */
-class FullyQualifiedClassName extends FullyQualifiedGlobalStructuralElement {
+class FullyQualifiedClassName extends FullyQualifiedGlobalStructuralElement
+{
 
     /**
      * @return int
      * The namespace map type such as T_CLASS or T_FUNCTION
      */
-    protected static function getNamespaceMapType() : int {
+    protected static function getNamespaceMapType() : int
+    {
         return T_CLASS;
     }
 
@@ -23,7 +25,8 @@ class FullyQualifiedClassName extends FullyQualifiedGlobalStructuralElement {
      * The canonical representation of the name of the object. Functions
      * and Methods, for instance, lowercase their names.
      */
-    public static function canonicalName(string $name) : string {
+    public static function canonicalName(string $name) : string
+    {
         return strtolower($name);
     }
 
@@ -31,7 +34,8 @@ class FullyQualifiedClassName extends FullyQualifiedGlobalStructuralElement {
      * @return FullyQualifiedClassName
      * A fully qualified class name from the given type
      */
-    public static function fromType(Type $type) : FullyQualifiedClassName {
+    public static function fromType(Type $type) : FullyQualifiedClassName
+    {
         return self::fromFullyQualifiedString(
             (string)$type
         );
@@ -41,7 +45,8 @@ class FullyQualifiedClassName extends FullyQualifiedGlobalStructuralElement {
      * @return Type
      * The type of this class
      */
-    public function asType() : Type {
+    public function asType() : Type
+    {
         return Type::fromFullyQualifiedString(
             (string)$this
         );
@@ -51,7 +56,8 @@ class FullyQualifiedClassName extends FullyQualifiedGlobalStructuralElement {
      * @return UnionType
      * The union type of just this class type
      */
-    public function asUnionType() : UnionType {
+    public function asUnionType() : UnionType
+    {
         return $this->asType()->asUnionType();
     }
 }

--- a/src/Phan/Language/FQSEN/FullyQualifiedConstantName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedConstantName.php
@@ -6,4 +6,6 @@ use \Phan\Language\FQSEN;
 /**
  * A Fully-Qualified Constant Name
  */
-interface FullyQualifiedConstantName extends FQSEN {}
+interface FullyQualifiedConstantName extends FQSEN
+{
+}

--- a/src/Phan/Language/FQSEN/FullyQualifiedFunctionName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedFunctionName.php
@@ -6,13 +6,15 @@ use \Phan\Language\Context;
 /**
  * A Fully-Qualified Function Name
  */
-class FullyQualifiedFunctionName extends FullyQualifiedGlobalStructuralElement {
+class FullyQualifiedFunctionName extends FullyQualifiedGlobalStructuralElement
+{
 
     /**
      * @return int
      * The namespace map type such as T_CLASS or T_FUNCTION
      */
-    protected static function getNamespaceMapType() : int {
+    protected static function getNamespaceMapType() : int
+    {
         return T_FUNCTION;
     }
 
@@ -38,14 +40,18 @@ class FullyQualifiedFunctionName extends FullyQualifiedGlobalStructuralElement {
         $fqsen_string = $parts[0];
         $alternate_id = (int)($parts[1] ?? 0);
 
-        assert(is_int($alternate_id),
-            "Alternate must be an integer in $fqsen_string");
+        assert(
+            is_int($alternate_id),
+            "Alternate must be an integer in $fqsen_string"
+        );
 
         $parts = explode('\\', $fqsen_string);
         $name = array_pop($parts);
 
-        assert(!empty($name),
-            "The name cannot be empty in $fqsen_string");
+        assert(
+            !empty($name),
+            "The name cannot be empty in $fqsen_string"
+        );
 
         // Check for a name map
         if ($context->hasNamespaceMapFor(static::getNamespaceMapType(), $name)) {
@@ -79,5 +85,4 @@ class FullyQualifiedFunctionName extends FullyQualifiedGlobalStructuralElement {
             $context
         );
     }
-
 }

--- a/src/Phan/Language/FQSEN/FullyQualifiedGlobalConstantName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedGlobalConstantName.php
@@ -4,16 +4,14 @@ namespace Phan\Language\FQSEN;
 /**
  * A Fully-Qualified Constant Name
  */
-class FullyQualifiedGlobalConstantName
-    extends FullyQualifiedGlobalStructuralElement
-    implements FullyQualifiedConstantName
+class FullyQualifiedGlobalConstantName extends FullyQualifiedGlobalStructuralElement implements FullyQualifiedConstantName
 {
     /**
      * @return int
      * The namespace map type such as T_CLASS or T_FUNCTION
      */
-    protected static function getNamespaceMapType() : int {
+    protected static function getNamespaceMapType() : int
+    {
         return T_CONST;
     }
-
 }

--- a/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
@@ -9,7 +9,8 @@ use \Phan\Language\UnionType;
 /**
  * A Fully-Qualified Global Structural Element
  */
-abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN {
+abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
+{
     use \Phan\Language\FQSEN\Alternatives;
     use \Phan\Memoize;
 
@@ -35,14 +36,20 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN {
         string $name,
         int $alternate_id = 0
     ) {
-        assert(!empty($name),
-            "The name cannot be empty");
+        assert(
+            !empty($name),
+            "The name cannot be empty"
+        );
 
-        assert(!empty($namespace),
-            "The namespace cannot be empty");
+        assert(
+            !empty($namespace),
+            "The namespace cannot be empty"
+        );
 
-        assert($namespace[0] === '\\',
-            "The first character of a namespace must be \\, but got $namespace");
+        assert(
+            $namespace[0] === '\\',
+            "The first character of a namespace must be \\, but got $namespace"
+        );
 
         parent::__construct($name);
         $this->namespace = $namespace;
@@ -78,9 +85,9 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN {
             static::toString($namespace, $name, $alternate_id)
         ]);
 
-        return self::memoizeStatic($key, function()
-            use ($namespace, $name, $alternate_id)
-        {
+        return self::memoizeStatic($key, function ()
+ use ($namespace, $name, $alternate_id) {
+        
             return new static(
                 $namespace,
                 $name,
@@ -99,30 +106,38 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN {
 
         $key = get_called_class() . '|' . $fully_qualified_string;
 
-        return self::memoizeStatic($key, function()
-            use ($fully_qualified_string) {
+        return self::memoizeStatic($key, function ()
+ use ($fully_qualified_string) {
 
             // Split off the alternate_id
             $parts = explode(',', $fully_qualified_string);
             $fqsen_string = $parts[0];
             $alternate_id = (int)($parts[1] ?? 0);
 
-            assert(is_int($alternate_id),
-                "Alternate must be an integer in $fully_qualified_string");
+            assert(
+                is_int($alternate_id),
+                "Alternate must be an integer in $fully_qualified_string"
+            );
 
             $parts = explode('\\', $fqsen_string);
             $name = array_pop($parts);
 
-            assert(!empty($name),
-                "The name cannot be empty in the FQSEN '$fully_qualified_string'");
+            assert(
+                !empty($name),
+                "The name cannot be empty in the FQSEN '$fully_qualified_string'"
+            );
 
             $namespace = '\\' . implode('\\', array_filter($parts));
 
-            assert(!empty($namespace),
-                "The namespace cannot be empty in the FQSEN '$fully_qualified_string'");
+            assert(
+                !empty($namespace),
+                "The namespace cannot be empty in the FQSEN '$fully_qualified_string'"
+            );
 
-            assert($namespace[0] === '\\',
-                "The first character of the namespace '$namespace' must be \\");
+            assert(
+                $namespace[0] === '\\',
+                "The first character of the namespace '$namespace' must be \\"
+            );
 
             return static::make(
                 $namespace,
@@ -154,14 +169,18 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN {
         $fqsen_string = $parts[0];
         $alternate_id = (int)($parts[1] ?? 0);
 
-        assert(is_int($alternate_id),
-            "Alternate must be an integer in $fqsen_string");
+        assert(
+            is_int($alternate_id),
+            "Alternate must be an integer in $fqsen_string"
+        );
 
         $parts = explode('\\', $fqsen_string);
         $name = array_pop($parts);
 
-        assert(!empty($name),
-            "The name cannot be empty in $fqsen_string");
+        assert(
+            !empty($name),
+            "The name cannot be empty in $fqsen_string"
+        );
 
         // Check for a name map
         if ($context->hasNamespaceMapFor(static::getNamespaceMapType(), $name)) {
@@ -198,7 +217,8 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN {
      * The namespace associated with this FQSEN
      * or null if not defined
      */
-    public function getNamespace() : string {
+    public function getNamespace() : string
+    {
         return $this->namespace;
     }
 
@@ -238,7 +258,8 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN {
      * its always prefixed with a '\' and never ends in a
      * '\', and is the string "\" if there is no namespace.
      */
-    protected static function cleanNamespace(string $namespace) : string {
+    protected static function cleanNamespace(string $namespace) : string
+    {
         if (!$namespace
             || empty($namespace)
             || $namespace === '\\'
@@ -293,8 +314,9 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN {
      * A string representation of this fully-qualified
      * structural element name.
      */
-    public function __toString() : string {
-        return $this->memoize(__METHOD__, function() {
+    public function __toString() : string
+    {
+        return $this->memoize(__METHOD__, function () {
             return static::toString(
                 $this->getNamespace(),
                 $this->getName(),
@@ -302,5 +324,4 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN {
             );
         });
     }
-
 }

--- a/src/Phan/Language/FQSEN/FullyQualifiedMethodName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedMethodName.php
@@ -6,15 +6,16 @@ use \Phan\Language\Context;
 /**
  * A Fully-Qualified Method Name
  */
-class FullyQualifiedMethodName extends FullyQualifiedClassElement {
+class FullyQualifiedMethodName extends FullyQualifiedClassElement
+{
 
     /**
      * @return string
      * The canonical representation of the name of the object. Functions
      * and Methods, for instance, lowercase their names.
      */
-    public static function canonicalName(string $name) : string {
+    public static function canonicalName(string $name) : string
+    {
         return strtolower($name);
     }
-
 }

--- a/src/Phan/Language/FQSEN/FullyQualifiedPropertyName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedPropertyName.php
@@ -4,4 +4,6 @@ namespace Phan\Language\FQSEN;
 /**
  * A Fully-Qualified Property Name
  */
-class FullyQualifiedPropertyName extends FullyQualifiedClassElement {}
+class FullyQualifiedPropertyName extends FullyQualifiedClassElement
+{
+}

--- a/src/Phan/Language/FileRef.php
+++ b/src/Phan/Language/FileRef.php
@@ -8,7 +8,8 @@ use \Phan\Config;
  * An object representing the context in which any
  * structural element (such as a class or method) lives.
  */
-class FileRef implements \Serializable {
+class FileRef implements \Serializable
+{
 
     /**
      * @var string
@@ -35,7 +36,8 @@ class FileRef implements \Serializable {
      * @return Context
      * This context with the given value is returned
      */
-    public function withFile(string $file) : FileRef {
+    public function withFile(string $file) : FileRef
+    {
         $context = clone($this);
         $context->file = $file;
         return $context;
@@ -45,7 +47,8 @@ class FileRef implements \Serializable {
      * @return string
      * The path to the file in which the element is defined
      */
-    public function getFile() : string {
+    public function getFile() : string
+    {
         return $this->file;
     }
 
@@ -54,7 +57,8 @@ class FileRef implements \Serializable {
      * The path of the file relative to the project
      * root directory
      */
-    public function getProjectRelativePath() : string {
+    public function getProjectRelativePath() : string
+    {
         return File::projectRelativePathFromCWDRelativePath(
             $this->file
         );
@@ -64,7 +68,8 @@ class FileRef implements \Serializable {
      * @return bool
      * True if this object is internal to PHP
      */
-    public function isInternal() : bool {
+    public function isInternal() : bool
+    {
         return ('internal' === $this->getFile());
     }
 
@@ -75,7 +80,8 @@ class FileRef implements \Serializable {
      * @return Context
      * This context with the given value is returned
      */
-    public function withLineNumberStart(int $line_number) : FileRef {
+    public function withLineNumberStart(int $line_number) : FileRef
+    {
         $this->line_number_start = $line_number;
         return $this;
     }
@@ -84,7 +90,8 @@ class FileRef implements \Serializable {
      * @return int
      * The starting line number of the element within the file
      */
-    public function getLineNumberStart() : int {
+    public function getLineNumberStart() : int
+    {
         return $this->line_number_start;
     }
 
@@ -95,7 +102,8 @@ class FileRef implements \Serializable {
      * @return Context
      * This context with the given value is returned
      */
-    public function withLineNumberEnd(int $line_number) : FileRef {
+    public function withLineNumberEnd(int $line_number) : FileRef
+    {
         $this->line_number_end = $line_number;
         return $this;
     }
@@ -105,19 +113,21 @@ class FileRef implements \Serializable {
      *
      * @return string
      */
-    public function __toString() : string {
+    public function __toString() : string
+    {
         return $this->file . ':' . $this->line_number_start;
     }
 
-    public function serialize() {
+    public function serialize()
+    {
         return (string)$this;
     }
 
-    public function unserialize($serialized) {
+    public function unserialize($serialized)
+    {
         $map = explode(':', $serialized);
         $this->file = $map[0];
         $this->line_number_start = (int)$map[1];
         $this->line_number_end = (int)($map[2] ?? 0);
     }
-
 }

--- a/src/Phan/Language/FutureUnionType.php
+++ b/src/Phan/Language/FutureUnionType.php
@@ -12,7 +12,8 @@ use \ast\Node;
  * A FutureUnionType is a UnionType that is lazily loaded.
  * Call `get()` in order force the type to be figured.
  */
-class FutureUnionType {
+class FutureUnionType
+{
 
     /** @var CodeBase */
     private $code_base;
@@ -50,7 +51,8 @@ class FutureUnionType {
      * An exception is thrown if we are unable to determine
      * the type at the time this method is called
      */
-    public function get() : UnionType {
+    public function get() : UnionType
+    {
         return UnionType::fromNode(
             $this->context,
             $this->code_base,

--- a/src/Phan/Language/Scope.php
+++ b/src/Phan/Language/Scope.php
@@ -4,7 +4,8 @@ namespace Phan\Language;
 
 use \Phan\Language\Element\Variable;
 
-class Scope {
+class Scope
+{
 
     /**
      * @var Variable[]
@@ -23,7 +24,8 @@ class Scope {
      * True if a variable with the given name is defined
      * within this scope
      */
-    public function hasVariableWithName(string $name) : bool {
+    public function hasVariableWithName(string $name) : bool
+    {
         return (
             !empty($this->variable_map[$name])
             || !empty(self::$global_variable_map[$name])
@@ -33,7 +35,8 @@ class Scope {
     /**
      * @return Variable
      */
-    public function getVariableWithName(string $name) : Variable {
+    public function getVariableWithName(string $name) : Variable
+    {
         return $this->variable_map[$name]
             ?? self::$global_variable_map[$name];
     }
@@ -42,7 +45,8 @@ class Scope {
      * @return Variable[]
      * A map from name to Variable in this scope
      */
-    public function getVariableMap() : array {
+    public function getVariableMap() : array
+    {
         return array_merge(
             $this->variable_map,
             self::$global_variable_map
@@ -55,7 +59,8 @@ class Scope {
      *
      * @return Scope;
      */
-    public function withGlobalVariable(Variable $variable) : Scope {
+    public function withGlobalVariable(Variable $variable) : Scope
+    {
         self::$global_variable_map[$variable->getName()] =
             $variable;
 
@@ -68,7 +73,8 @@ class Scope {
      *
      * @return Scope;
      */
-    public function withVariable(Variable $variable) : Scope {
+    public function withVariable(Variable $variable) : Scope
+    {
         $scope = clone($this);
         $scope->addVariable($variable);
         return $scope;
@@ -77,7 +83,8 @@ class Scope {
     /**
      * @return void
      */
-    public function addVariable(Variable $variable) {
+    public function addVariable(Variable $variable)
+    {
         $this->variable_map[$variable->getName()] = $variable;
     }
 
@@ -85,8 +92,8 @@ class Scope {
      * @return string
      * A string representation of this scope
      */
-    public function __toString() : string {
+    public function __toString() : string
+    {
         return implode(',', $this->getVariableMap());
     }
-
 }

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -23,7 +23,8 @@ use \Phan\Language\Type\VoidType;
 use \Phan\Language\UnionType;
 use \ast\Node;
 
-class Type {
+class Type
+{
     use \Phan\Memoize;
 
     /**
@@ -67,20 +68,30 @@ class Type {
         string $namespace,
         string $name
     ) : Type {
-        assert($namespace && 0 === strpos($namespace, '\\'),
-            "Namespace must be fully qualified");
+        assert(
+            $namespace && 0 === strpos($namespace, '\\'),
+            "Namespace must be fully qualified"
+        );
 
-        assert(!empty($namespace),
-            "Namespace cannot be empty");
+        assert(
+            !empty($namespace),
+            "Namespace cannot be empty"
+        );
 
-        assert('\\' === $namespace[0],
-            "Namespace must be fully qualified");
+        assert(
+            '\\' === $namespace[0],
+            "Namespace must be fully qualified"
+        );
 
-        assert(!empty($name),
-            "Type name cannot be empty");
+        assert(
+            !empty($name),
+            "Type name cannot be empty"
+        );
 
-        assert(false === strpos($name, '|'),
-            "Type name '{$name}' may not contain a pipe.");
+        assert(
+            false === strpos($name, '|'),
+            "Type name '{$name}' may not contain a pipe."
+        );
 
         // Create a canonical representation of the
         // namespace and name
@@ -125,8 +136,9 @@ class Type {
     ) : Type {
         $namespace = trim($namespace);
 
-        return self::memoizeStatic($namespace . '\\' . $type_name,
-            function() use ($namespace, $type_name) : Type {
+        return self::memoizeStatic(
+            $namespace . '\\' . $type_name,
+            function () use ($namespace, $type_name) : Type {
                 // Only if we're in the root namespace can we
                 // canonicalize native types.
                 if ('\\' === $namespace) {
@@ -146,14 +158,16 @@ class Type {
 
                 // If we have a namespace, we're all set
                 return Type::make($namespace, $type_name);
-            });
+            }
+        );
     }
 
     /**
      * @return Type
      * Get a type for the given object
      */
-    public static function fromObject($object) : Type {
+    public static function fromObject($object) : Type
+    {
         return Type::fromInternalTypeName(gettype($object));
     }
 
@@ -178,32 +192,34 @@ class Type {
             self::canonicalNameFromName($type_name);
 
         switch ($type_name) {
-        case 'array':
-            return ArrayType::instance();
-        case 'bool':
-            return BoolType::instance();
-        case 'callable':
-            return CallableType::instance();
-        case 'float':
-            return FloatType::instance();
-        case 'int':
-            return IntType::instance();
-        case 'mixed':
-            return MixedType::instance();
-        case 'null':
-            return NullType::instance();
-        case 'object':
-            return ObjectType::instance();
-        case 'resource':
-            return ResourceType::instance();
-        case 'string':
-            return StringType::instance();
-        case 'void':
-            return VoidType::instance();
+            case 'array':
+                return ArrayType::instance();
+            case 'bool':
+                return BoolType::instance();
+            case 'callable':
+                return CallableType::instance();
+            case 'float':
+                return FloatType::instance();
+            case 'int':
+                return IntType::instance();
+            case 'mixed':
+                return MixedType::instance();
+            case 'null':
+                return NullType::instance();
+            case 'object':
+                return ObjectType::instance();
+            case 'resource':
+                return ResourceType::instance();
+            case 'string':
+                return StringType::instance();
+            case 'void':
+                return VoidType::instance();
         }
 
-        assert(false,
-            "No internal type with name $type_name");
+        assert(
+            false,
+            "No internal type with name $type_name"
+        );
     }
 
     /**
@@ -219,8 +235,10 @@ class Type {
     public static function fromFullyQualifiedString(
         string $fully_qualified_string
     ) : Type {
-        assert(!empty($fully_qualified_string),
-            "Type cannot be empty");
+        assert(
+            !empty($fully_qualified_string),
+            "Type cannot be empty"
+        );
 
         if (0 !== strpos($fully_qualified_string, '\\')) {
             return self::fromInternalTypeName($fully_qualified_string);
@@ -231,8 +249,10 @@ class Type {
                 $fully_qualified_string
             );
 
-        assert(!empty($namespace) && !empty($type_name),
-            "Type '$fully_qualified_string' was not fully qualified");
+        assert(
+            !empty($namespace) && !empty($type_name),
+            "Type '$fully_qualified_string' was not fully qualified"
+        );
 
         return self::fromNamespaceAndName(
             $namespace,
@@ -256,8 +276,10 @@ class Type {
         Context $context
     ) : Type {
 
-        assert($string !== '' ,
-            "Type cannot be empty in $context");
+        assert(
+            $string !== '',
+            "Type cannot be empty in $context"
+        );
 
         $namespace = null;
 
@@ -278,7 +300,7 @@ class Type {
         // If this is a generic array type, get the name of
         // the type of each element
         $non_generic_array_type_name = $type_name;
-        if($is_generic_array_type
+        if ($is_generic_array_type
            && false !== ($pos = strpos($type_name, '[]'))
         ) {
             $non_generic_array_type_name =
@@ -323,35 +345,35 @@ class Type {
             );
         }
 
-        if($is_generic_array_type
+        if ($is_generic_array_type
            && self::isNativeTypeString($type_name)
         ) {
             return self::fromInternalTypeName($type_name);
         } else {
             // Check to see if its a builtin type
             switch (self::canonicalNameFromName($type_name)) {
-            case 'array':
-                return \Phan\Language\Type\ArrayType::instance();
-            case 'bool':
-                return \Phan\Language\Type\BoolType::instance();
-            case 'callable':
-                return \Phan\Language\Type\CallableType::instance();
-            case 'float':
-                return \Phan\Language\Type\FloatType::instance();
-            case 'int':
-                return \Phan\Language\Type\IntType::instance();
-            case 'mixed':
-                return \Phan\Language\Type\MixedType::instance();
-            case 'null':
-                return \Phan\Language\Type\NullType::instance();
-            case 'object':
-                return \Phan\Language\Type\ObjectType::instance();
-            case 'resource':
-                return \Phan\Language\Type\ResourceType::instance();
-            case 'string':
-                return \Phan\Language\Type\StringType::instance();
-            case 'void':
-                return \Phan\Language\Type\VoidType::instance();
+                case 'array':
+                    return \Phan\Language\Type\ArrayType::instance();
+                case 'bool':
+                    return \Phan\Language\Type\BoolType::instance();
+                case 'callable':
+                    return \Phan\Language\Type\CallableType::instance();
+                case 'float':
+                    return \Phan\Language\Type\FloatType::instance();
+                case 'int':
+                    return \Phan\Language\Type\IntType::instance();
+                case 'mixed':
+                    return \Phan\Language\Type\MixedType::instance();
+                case 'null':
+                    return \Phan\Language\Type\NullType::instance();
+                case 'object':
+                    return \Phan\Language\Type\ObjectType::instance();
+                case 'resource':
+                    return \Phan\Language\Type\ResourceType::instance();
+                case 'string':
+                    return \Phan\Language\Type\StringType::instance();
+                case 'void':
+                    return \Phan\Language\Type\VoidType::instance();
             }
         }
 
@@ -364,8 +386,10 @@ class Type {
             // to see if this type is a reference to 'parent' and
             // dealing with it there. We don't want to have this
             // method be dependent on the code base
-            assert('parent' !== $non_generic_array_type_name,
-                __METHOD__ . " does not know how to handle the type name 'parent' in $context");
+            assert(
+                'parent' !== $non_generic_array_type_name,
+                __METHOD__ . " does not know how to handle the type name 'parent' in $context"
+            );
 
             return GenericArrayType::fromElementType(
                 static::fromFullyQualifiedString(
@@ -383,8 +407,10 @@ class Type {
             // to see if this type is a reference to 'parent' and
             // dealing with it there. We don't want to have this
             // method be dependent on the code base
-            assert('parent' !== $type_name,
-                __METHOD__ . " does not know how to handle the type name 'parent' in $context");
+            assert(
+                'parent' !== $type_name,
+                __METHOD__ . " does not know how to handle the type name 'parent' in $context"
+            );
 
             return static::fromFullyQualifiedString(
                 (string)$context->getClassFQSEN()
@@ -402,7 +428,8 @@ class Type {
      * @return UnionType
      * A UnionType representing this and only this type
      */
-    public function asUnionType() : UnionType {
+    public function asUnionType() : UnionType
+    {
         return new UnionType([$this]);
     }
 
@@ -411,7 +438,8 @@ class Type {
      * A fully-qualified structural element name derived
      * from this type
      */
-    public function asFQSEN() : FQSEN {
+    public function asFQSEN() : FQSEN
+    {
         return FullyQualifiedClassName::fromType($this);
     }
 
@@ -419,7 +447,8 @@ class Type {
      * @return string
      * The name associated with this type
      */
-    public function getName() : string {
+    public function getName() : string
+    {
         return $this->name;
     }
 
@@ -427,7 +456,8 @@ class Type {
      * @return bool
      * True if this namespace is defined
      */
-    public function hasNamespace() : bool {
+    public function hasNamespace() : bool
+    {
         return !empty($this->namespace);
     }
 
@@ -435,7 +465,8 @@ class Type {
      * @return string
      * The namespace associated with this type
      */
-    public function getNamespace() : string {
+    public function getNamespace() : string
+    {
         return $this->namespace;
     }
 
@@ -444,7 +475,8 @@ class Type {
      * True if this is a native type (like int, string, etc.)
      *
      */
-    public function isNativeType() : bool {
+    public function isNativeType() : bool
+    {
         return self::isNativeTypeString((string)$this);
     }
 
@@ -455,9 +487,11 @@ class Type {
      * @see \Phan\Deprecated\Util::is_native_type
      * Formerly `function is_native_type`
      */
-    private static function isNativeTypeString(string $type_name) : bool {
+    private static function isNativeTypeString(string $type_name) : bool
+    {
         return in_array(
-            str_replace('[]', '', $type_name), [
+            str_replace('[]', '', $type_name),
+            [
                 'int',
                 'float',
                 'bool',
@@ -481,7 +515,8 @@ class Type {
      * class context in which it exists such as 'static'
      * or 'self'.
      */
-    public function isSelfType() : bool {
+    public function isSelfType() : bool
+    {
         return self::isSelfTypeString((string)$this);
     }
 
@@ -509,7 +544,8 @@ class Type {
      * @see \Phan\Deprecated\Util::type_scalar
      * Formerly `function type_scalar`
      */
-    public function isScalar() : bool {
+    public function isScalar() : bool
+    {
         return in_array((string)$this, [
             'int',
             'float',
@@ -525,7 +561,8 @@ class Type {
      * True if this is a generic type such as 'int[]' or
      * 'string[]'.
      */
-    public function isGenericArray() : bool {
+    public function isGenericArray() : bool
+    {
         return self::isGenericArrayString($this->name);
     }
 
@@ -537,7 +574,8 @@ class Type {
      * True if this is a generic type such as 'int[]' or
      * 'string[]'.
      */
-    private static function isGenericArrayString(string $type_name) : bool {
+    private static function isGenericArrayString(string $type_name) : bool
+    {
         if (in_array($type_name, ['[]', 'array'])) {
             return false;
         }
@@ -549,13 +587,18 @@ class Type {
      * A variation of this type that is not generic.
      * i.e. 'int[]' becomes 'int'.
      */
-    public function genericArrayElementType() : Type {
-        assert($this->isGenericArray(),
-            "Cannot call genericArrayElementType on non-generic array");
+    public function genericArrayElementType() : Type
+    {
+        assert(
+            $this->isGenericArray(),
+            "Cannot call genericArrayElementType on non-generic array"
+        );
 
         if (($pos = strpos($this->name, '[]')) !== false) {
-            assert($this->name !== '[]' && $this->name !== 'array',
-                "Non-generic type '{$this->name}' requested to be non-generic");
+            assert(
+                $this->name !== '[]' && $this->name !== 'array',
+                "Non-generic type '{$this->name}' requested to be non-generic"
+            );
 
             return Type::make(
                 $this->getNamespace(),
@@ -571,7 +614,8 @@ class Type {
      * Get a new type which is the generic array version of
      * this type. For instance, 'int' will produce 'int[]'.
      */
-    public function asGenericArrayType() : Type {
+    public function asGenericArrayType() : Type
+    {
         if ($this->name == 'array'
             || $this->name == 'mixed'
             || strpos($this->name, '[]') !== false
@@ -599,12 +643,15 @@ class Type {
         CodeBase $code_base,
         int $recursion_depth = 0
     ) : UnionType {
-        return $this->memoize(__METHOD__, function() use(
-            $code_base, $recursion_depth
+        return $this->memoize(__METHOD__, function () use (
+            $code_base,
+            $recursion_depth
         ) : UnionType {
 
-            assert($recursion_depth < 10,
-                "Recursion has gotten out of hand for type $this");
+            assert(
+                $recursion_depth < 10,
+                "Recursion has gotten out of hand for type $this"
+            );
 
             if ($this->isNativeType()) {
                 return $this->asUnionType();
@@ -624,8 +671,8 @@ class Type {
 
             $union_type->addUnionType(
                 $this->isGenericArray()
-                    ?  $clazz->getUnionType()->asGenericArrayTypes()
-                    : $clazz->getUnionType()
+                ?  $clazz->getUnionType()->asGenericArrayTypes()
+                : $clazz->getUnionType()
             );
 
             // Resurse up the tree to include all types
@@ -652,7 +699,8 @@ class Type {
      * True if this Type can be cast to the given Type
      * cleanly
      */
-    public function canCastToType(Type $type) : bool {
+    public function canCastToType(Type $type) : bool
+    {
         if ($this === $type) {
             return true;
         }
@@ -660,83 +708,87 @@ class Type {
         $s = (string)$this;
         $d = (string)$type;
 
-        if($s[0]=='\\') {
-            $s = substr($s,1);
+        if ($s[0]=='\\') {
+            $s = substr($s, 1);
         }
 
-        if($d[0]=='\\') {
-            $d = substr($d,1);
+        if ($d[0]=='\\') {
+            $d = substr($d, 1);
         }
 
-        if($s===$d) {
+        if ($s===$d) {
             return true;
         }
 
-        if($s==='int' && $d==='float') {
+        if ($s==='int' && $d==='float') {
             return true; // int->float is ok
         }
 
-        if(($s==='array'
+        if (($s==='array'
             || $s==='string'
-            || (strpos($s,'[]')!==false))
+            || (strpos($s, '[]')!==false))
             && $d==='callable'
         ) {
             return true;
         }
 
-        if($s === 'object'
+        if ($s === 'object'
             && !$type->isScalar()
             && $d!=='array'
         ) {
             return true;
         }
 
-        if($d === 'object' &&
+        if ($d === 'object' &&
             !$this->isScalar()
             && $s!=='array'
         ) {
             return true;
         }
 
-        if(strpos($s,'[]') !== false
+        if (strpos($s, '[]') !== false
             && $d==='array'
         ) {
             return true;
         }
 
-        if(strpos($d,'[]') !== false
+        if (strpos($d, '[]') !== false
             && $s==='array'
         ) {
             return true;
         }
 
-        if($s === 'callable' && $d === 'closure') {
+        if ($s === 'callable' && $d === 'closure') {
             return true;
         }
 
-        if(($pos = strrpos($d, '\\')) !== false) {
+        if (($pos = strrpos($d, '\\')) !== false) {
             if ('\\' !== $this->getNamespace()) {
-                if(trim($this->getNamespace().'\\'.$s,
-                    '\\') == $d
+                if (trim(
+                    $this->getNamespace().'\\'.$s,
+                    '\\'
+                ) == $d
                 ) {
                     return true;
                 }
             } else {
-                if(substr($d, $pos+1) === $s) {
+                if (substr($d, $pos+1) === $s) {
                     return true; // Lazy hack, but...
                 }
             }
         }
 
-        if(($pos = strrpos($s,'\\')) !== false) {
+        if (($pos = strrpos($s, '\\')) !== false) {
             if ('\\' !== $type->getNamespace()) {
-                if(trim($type->getNamespace().'\\'.$d,
-                    '\\') == $s
+                if (trim(
+                    $type->getNamespace().'\\'.$d,
+                    '\\'
+                ) == $s
                 ) {
                     return true;
                 }
             } else {
-                if(substr($s, $pos+1) === $d) {
+                if (substr($s, $pos+1) === $d) {
                     return true; // Lazy hack, but...
                 }
             }
@@ -749,7 +801,8 @@ class Type {
      * @return string
      * A human readable representation of this type
      */
-    public function __toString() {
+    public function __toString()
+    {
         if (!$this->hasNamespace()) {
             return $this->name;
         }

--- a/src/Phan/Language/Type/ArrayType.php
+++ b/src/Phan/Language/Type/ArrayType.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
-class ArrayType extends NativeType {
+class ArrayType extends NativeType
+{
     const NAME = 'array';
 }

--- a/src/Phan/Language/Type/BoolType.php
+++ b/src/Phan/Language/Type/BoolType.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
-class BoolType extends ScalarType {
+class BoolType extends ScalarType
+{
     const NAME = 'bool';
 }

--- a/src/Phan/Language/Type/CallableType.php
+++ b/src/Phan/Language/Type/CallableType.php
@@ -3,7 +3,8 @@ namespace Phan\Language\Type;
 
 use \Phan\Language\FQSEN;
 
-class CallableType extends NativeType {
+class CallableType extends NativeType
+{
     const NAME = 'callable';
 
     /**
@@ -11,7 +12,8 @@ class CallableType extends NativeType {
      */
     private $fqsen;
 
-    public static function instanceWithClosureFQSEN(FQSEN $fqsen) {
+    public static function instanceWithClosureFQSEN(FQSEN $fqsen)
+    {
         $instance = self::instance();
         $instance->fqsen = $fqsen;
         return $instance;
@@ -20,7 +22,8 @@ class CallableType extends NativeType {
     /**
      * Override asFQSEN to return the closure's FQSEN
      */
-    public function asFQSEN() : FQSEN {
+    public function asFQSEN() : FQSEN
+    {
         if (!empty($this->fqsen)) {
             return $this->fqsen;
         }

--- a/src/Phan/Language/Type/FloatType.php
+++ b/src/Phan/Language/Type/FloatType.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
-class FloatType extends ScalarType {
+class FloatType extends ScalarType
+{
     const NAME = 'float';
 }

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -3,7 +3,8 @@ namespace Phan\Language\Type;
 
 use \Phan\Language\Type;
 
-class GenericArrayType extends ArrayType {
+class GenericArrayType extends ArrayType
+{
     const NAME = 'array';
 
     /**
@@ -16,7 +17,8 @@ class GenericArrayType extends ArrayType {
      * @param Type $type
      * The type of every element in this array
      */
-    protected function __construct(Type $type) {
+    protected function __construct(Type $type)
+    {
         parent::__construct('\\', self::NAME);
         $this->element_type = $type;
     }
@@ -28,7 +30,8 @@ class GenericArrayType extends ArrayType {
      * @return GenericArrayType
      * Get a type representing an array of the given type
      */
-    public static function fromElementType(Type $type) : GenericArrayType {
+    public static function fromElementType(Type $type) : GenericArrayType
+    {
 
         // Make sure we only ever create exactly one
         // object for any unique type
@@ -39,7 +42,8 @@ class GenericArrayType extends ArrayType {
         }
 
         if (!$canonical_object_map->contains($type)) {
-            $canonical_object_map->attach($type,
+            $canonical_object_map->attach(
+                $type,
                 new GenericArrayType($type)
             );
         }
@@ -47,7 +51,8 @@ class GenericArrayType extends ArrayType {
         return $canonical_object_map->offsetGet($type);
     }
 
-    public function isGenericArray() : bool {
+    public function isGenericArray() : bool
+    {
         return true;
     }
 
@@ -56,12 +61,14 @@ class GenericArrayType extends ArrayType {
      * A variation of this type that is not generic.
      * i.e. 'int[]' becomes 'int'.
      */
-    public function genericArrayElementType() : Type {
+    public function genericArrayElementType() : Type
+    {
         return $this->element_type;
     }
 
 
-    public function __toString() : string {
+    public function __toString() : string
+    {
         return "{$this->element_type}[]";
     }
 }

--- a/src/Phan/Language/Type/IntType.php
+++ b/src/Phan/Language/Type/IntType.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
-class IntType extends ScalarType {
+class IntType extends ScalarType
+{
     const NAME = 'int';
 }

--- a/src/Phan/Language/Type/MixedType.php
+++ b/src/Phan/Language/Type/MixedType.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
-class MixedType extends NativeType {
+class MixedType extends NativeType
+{
     const NAME = 'mixed';
 }

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -3,10 +3,12 @@ namespace Phan\Language\Type;
 
 use \Phan\Language\Type;
 
-abstract class NativeType extends Type {
+abstract class NativeType extends Type
+{
     const NAME = '';
 
-    public static function instance() {
+    public static function instance()
+    {
         static $instance = null;
 
         if (empty($instance)) {
@@ -16,18 +18,20 @@ abstract class NativeType extends Type {
         return $instance;
     }
 
-    public function isNativeType() : bool {
+    public function isNativeType() : bool
+    {
         return true;
     }
 
-    public function isSelfType() : bool {
+    public function isSelfType() : bool
+    {
         return false;
     }
 
-    public function __toString() : string {
+    public function __toString() : string
+    {
         // Native types can just use their
         // non-fully-qualified names
         return $this->name;
     }
-
 }

--- a/src/Phan/Language/Type/NullType.php
+++ b/src/Phan/Language/Type/NullType.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
-class NullType extends ScalarType {
+class NullType extends ScalarType
+{
     const NAME = 'null';
 }

--- a/src/Phan/Language/Type/ObjectType.php
+++ b/src/Phan/Language/Type/ObjectType.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
-class ObjectType extends NativeType {
+class ObjectType extends NativeType
+{
     const NAME = 'object';
 }

--- a/src/Phan/Language/Type/ResourceType.php
+++ b/src/Phan/Language/Type/ResourceType.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
-class ResourceType extends NativeType {
+class ResourceType extends NativeType
+{
     const NAME = 'resource';
 }

--- a/src/Phan/Language/Type/ScalarType.php
+++ b/src/Phan/Language/Type/ScalarType.php
@@ -1,8 +1,10 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
-abstract class ScalarType extends NativeType {
-    public function isScalar() : bool {
+abstract class ScalarType extends NativeType
+{
+    public function isScalar() : bool
+    {
         return true;
     }
 }

--- a/src/Phan/Language/Type/StringType.php
+++ b/src/Phan/Language/Type/StringType.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
-class StringType extends ScalarType {
+class StringType extends ScalarType
+{
     const NAME = 'string';
 }

--- a/src/Phan/Language/Type/VoidType.php
+++ b/src/Phan/Language/Type/VoidType.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
-class VoidType extends NativeType {
+class VoidType extends NativeType
+{
     const NAME = 'void';
 }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -502,7 +502,7 @@ class UnionType implements \Serializable
         // Iterate over each viable class type to see if any
         // have the constant we're looking for
         foreach ($this->nonNativeTypes()->getTypeSet()
- as $class_type) {
+        as $class_type) {
             // Get the class FQSEN
             $class_fqsen = $class_type->asFQSEN();
 

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -30,7 +30,8 @@ use \Phan\Language\Type\VoidType;
 use \Phan\Set;
 use \ast\Node;
 
-class UnionType implements \Serializable {
+class UnionType implements \Serializable
+{
     use \Phan\Memoize;
 
     /**
@@ -42,7 +43,8 @@ class UnionType implements \Serializable {
      * @param Type[]|\Iterator $type_list
      * An optional list of types represented by this union
      */
-    public function __construct($type_list = null) {
+    public function __construct($type_list = null)
+    {
         $this->type_set = new Set($type_list);
     }
 
@@ -52,7 +54,8 @@ class UnionType implements \Serializable {
      *
      * @return null
      */
-    public function __clone() {
+    public function __clone()
+    {
         $set  = new Set();
         $set->addAll($this->type_set);
         $this->type_set = $set;
@@ -77,7 +80,7 @@ class UnionType implements \Serializable {
         }
 
         return new UnionType(
-            array_map(function(string $type_name) {
+            array_map(function (string $type_name) {
                 return Type::fromFullyQualifiedString($type_name);
             }, explode('|', $fully_qualified_string))
         );
@@ -104,9 +107,11 @@ class UnionType implements \Serializable {
         }
 
         return new UnionType(
-            array_map(function(string $type_name) use ($context, $type_string) {
-                assert($type_name !== '',
-                    "Type cannot be empty. Type '$type_name' given as part of the union type '$type_string' in $context.");
+            array_map(function (string $type_name) use ($context, $type_string) {
+                assert(
+                    $type_name !== '',
+                    "Type cannot be empty. Type '$type_name' given as part of the union type '$type_string' in $context."
+                );
                 return Type::fromStringInContext(
                     $type_name,
                     $context
@@ -150,7 +155,7 @@ class UnionType implements \Serializable {
             $node,
             $should_catch_issue_exception
         );
-	}
+    }
 
     /**
      * A list of types for parameters associated with the
@@ -221,7 +226,8 @@ class UnionType implements \Serializable {
      * The set of simple types associated with this
      * union type.
      */
-    public function getTypeSet() {
+    public function getTypeSet()
+    {
         return $this->type_set;
     }
 
@@ -230,7 +236,8 @@ class UnionType implements \Serializable {
      *
      * @return void
      */
-    public function addType(Type $type) {
+    public function addType(Type $type)
+    {
         $this->type_set->attach($type);
     }
 
@@ -239,7 +246,8 @@ class UnionType implements \Serializable {
      * True if this union type contains the given named
      * type.
      */
-    public function hasType(Type $type) : bool {
+    public function hasType(Type $type) : bool
+    {
         return $this->type_set->contains($type);
     }
 
@@ -248,7 +256,8 @@ class UnionType implements \Serializable {
      *
      * @return null
      */
-    public function addUnionType(UnionType $union_type) {
+    public function addUnionType(UnionType $union_type)
+    {
         $this->type_set->addAll(
             $union_type->getTypeSet()
         );
@@ -260,7 +269,8 @@ class UnionType implements \Serializable {
      * class context in which it exists such as 'static'
      * or 'self'.
      */
-    public function hasSelfType() : bool {
+    public function hasSelfType() : bool
+    {
         return (false !==
             $this->type_set->find(function (Type $type) : bool {
                 return $type->isSelfType();
@@ -273,7 +283,8 @@ class UnionType implements \Serializable {
      * True if and only if this UnionType contains
      * the given type and no others.
      */
-    public function isType(Type $type) : bool {
+    public function isType(Type $type) : bool
+    {
         if ($this->typeCount() != 1) {
             return false;
         }
@@ -286,13 +297,14 @@ class UnionType implements \Serializable {
      * True if this UnionType is exclusively native
      * types
      */
-    public function isNativeType() : bool {
+    public function isNativeType() : bool
+    {
         if ($this->isEmpty()) {
             return false;
         }
 
         return (false ===
-            $this->type_set->find(function(Type $type) : bool {
+            $this->type_set->find(function (Type $type) : bool {
                 return !$type->isNativeType();
             })
         );
@@ -303,7 +315,8 @@ class UnionType implements \Serializable {
      * True iff this union contains the exact set of types
      * represented in the given union type.
      */
-    public function isEqualTo(UnionType $union_type) : bool {
+    public function isEqualTo(UnionType $union_type) : bool
+    {
         return ((string)$this === (string)$union_type);
     }
 
@@ -315,7 +328,8 @@ class UnionType implements \Serializable {
      * True if this union type contains any of the given
      * named types
      */
-    public function hasAnyType(array $type_list) : bool {
+    public function hasAnyType(array $type_list) : bool
+    {
         return $this->type_set->containsAny($type_list);
     }
 
@@ -323,7 +337,8 @@ class UnionType implements \Serializable {
      * @return int
      * The number of types in this union type
      */
-    public function typeCount() : int {
+    public function typeCount() : int
+    {
         return $this->type_set->count();
     }
 
@@ -331,7 +346,8 @@ class UnionType implements \Serializable {
      * @return bool
      * True if this Union has no types
      */
-    public function isEmpty() : bool {
+    public function isEmpty() : bool
+    {
         return ($this->typeCount() < 1);
     }
 
@@ -383,7 +399,7 @@ class UnionType implements \Serializable {
 
         // If either type is unknown, we can't call it
         // a success
-        if($this->isEmpty() || $target->isEmpty()) {
+        if ($this->isEmpty() || $target->isEmpty()) {
             return true;
         }
 
@@ -418,12 +434,12 @@ class UnionType implements \Serializable {
         // Check conversion on the cross product of all
         // type combinations and see if any can cast to
         // any.
-        foreach($this->getTypeSet() as $source_type) {
-            if(empty($source_type)) {
+        foreach ($this->getTypeSet() as $source_type) {
+            if (empty($source_type)) {
                 continue;
             }
-            foreach($target->getTypeSet() as $target_type) {
-                if(empty($target_type)) {
+            foreach ($target->getTypeSet() as $target_type) {
+                if (empty($target_type)) {
                     continue;
                 }
 
@@ -445,13 +461,14 @@ class UnionType implements \Serializable {
      * @see \Phan\Deprecated\Util::type_scalar
      * Formerly `function type_scalar`
      */
-    public function isScalar() : bool {
+    public function isScalar() : bool
+    {
         if ($this->isEmpty()) {
             return false;
         }
 
         return (false ===
-            $this->type_set->find(function(Type $type) : bool {
+            $this->type_set->find(function (Type $type) : bool {
                 return !$type->isScalar();
             })
         );
@@ -461,9 +478,10 @@ class UnionType implements \Serializable {
      * @return UnionType
      * Get the subset of types which are not native
      */
-    public function nonNativeTypes() : UnionType {
+    public function nonNativeTypes() : UnionType
+    {
         return new UnionType(
-            $this->type_set->filter(function(Type $type) {
+            $this->type_set->filter(function (Type $type) {
                 return !$type->isNativeType();
             })
         );
@@ -484,8 +502,7 @@ class UnionType implements \Serializable {
         // Iterate over each viable class type to see if any
         // have the constant we're looking for
         foreach ($this->nonNativeTypes()->getTypeSet()
-            as $class_type
-        ) {
+ as $class_type) {
             // Get the class FQSEN
             $class_fqsen = $class_type->asFQSEN();
 
@@ -510,7 +527,8 @@ class UnionType implements \Serializable {
      * @see \Phan\Deprecated\Pass2::nongenerics
      * Formerly `function nongenerics`
      */
-    public function nonGenericArrayTypes() : UnionType {
+    public function nonGenericArrayTypes() : UnionType
+    {
         return new UnionType(
             $this->type_set->filter(
                 function (Type $type) : bool {
@@ -524,13 +542,14 @@ class UnionType implements \Serializable {
      * @return bool
      * True if this is exclusively generic types
      */
-    public function isGenericArray() : bool {
+    public function isGenericArray() : bool
+    {
         if ($this->isEmpty()) {
             return false;
         }
 
         return (false ===
-            $this->type_set->find(function(Type $type) : bool {
+            $this->type_set->find(function (Type $type) : bool {
                 return !$type->isGenericArray();
             })
         );
@@ -542,7 +561,8 @@ class UnionType implements \Serializable {
      * @return UnionType
      * The subset of types in this
      */
-    public function genericArrayElementTypes() : UnionType {
+    public function genericArrayElementTypes() : UnionType
+    {
         // If array is in there, then it can be any type
         // Same for mixed
         if ($this->hasType(ArrayType::instance())
@@ -570,7 +590,8 @@ class UnionType implements \Serializable {
      * the generic array version of this type. For instance,
      * 'int|float' will produce 'int[]|float[]'.
      */
-    public function asGenericArrayTypes() : UnionType {
+    public function asGenericArrayTypes() : UnionType
+    {
         return new UnionType(
             $this->type_set->map(function (Type $type) : Type {
                 return $type->asGenericArrayType();
@@ -595,8 +616,10 @@ class UnionType implements \Serializable {
         CodeBase $code_base,
         int $recursion_depth = 0
     ) : UnionType {
-        assert($recursion_depth < 10,
-            "Recursion has gotten out of hand for type $this");
+        assert(
+            $recursion_depth < 10,
+            "Recursion has gotten out of hand for type $this"
+        );
 
         $union_type = new UnionType();
         foreach ($this->type_set as $type) {
@@ -618,7 +641,8 @@ class UnionType implements \Serializable {
      *
      * @see \Serializable
      */
-    public function serialize() : string {
+    public function serialize() : string
+    {
         return (string)$this;
     }
 
@@ -633,7 +657,8 @@ class UnionType implements \Serializable {
      *
      * @see \Serializable
      */
-    public function unserialize($serialized) {
+    public function unserialize($serialized)
+    {
         return self::fromFullyQualifiedString($serialized);
     }
 
@@ -642,7 +667,8 @@ class UnionType implements \Serializable {
      * A human-readable string representation of this union
      * type
      */
-    public function __toString() : string {
+    public function __toString() : string
+    {
         // Create a new array containing the string
         // representations of each type
         $type_name_list =
@@ -664,7 +690,8 @@ class UnionType implements \Serializable {
      *
      * @see \Phan\Language\Internal\FunctionSignatureMap
      */
-    public static function internalFunctionSignatureMap() {
+    public static function internalFunctionSignatureMap()
+    {
         static $map = false;
 
         if (!$map) {
@@ -673,5 +700,4 @@ class UnionType implements \Serializable {
 
         return $map;
     }
-
 }

--- a/src/Phan/Map.php
+++ b/src/Phan/Map.php
@@ -6,13 +6,15 @@ namespace Phan;
  * based on spl_object_hash, which I believe its the zval's
  * memory address.
  */
-class Map extends \SplObjectStorage {
+class Map extends \SplObjectStorage
+{
 
     /**
      * We redefine the key to be the actual key rather than
      * the index of the key
      */
-    public function key() {
+    public function key()
+    {
         return parent::current();
     }
 
@@ -20,8 +22,8 @@ class Map extends \SplObjectStorage {
      * We redefine the current value to the current value rather
      * than the current key
      */
-    public function current() {
+    public function current()
+    {
         return $this->offsetGet(parent::current());
     }
-
 }

--- a/src/Phan/Memoize.php
+++ b/src/Phan/Memoize.php
@@ -1,7 +1,8 @@
 <?php declare(strict_types=1);
 namespace Phan;
 
-trait Memoize {
+trait Memoize
+{
     use Profile;
 
     /**
@@ -25,7 +26,8 @@ trait Memoize {
      * @return mixed
      * The result of the given computation is returned
      */
-    protected function memoize(string $key, \Closure $fn) {
+    protected function memoize(string $key, \Closure $fn)
+    {
         if (!array_key_exists($key, $this->memoized_data)) {
             $this->memoized_data[$key] = $fn();
         }
@@ -48,7 +50,8 @@ trait Memoize {
      * @return mixed
      * The result of the given computation is returned
      */
-    protected static function memoizeStatic(string $key, \Closure $fn) {
+    protected static function memoizeStatic(string $key, \Closure $fn)
+    {
         static $memoized_data = [];
 
         if (!array_key_exists($key, $memoized_data)) {
@@ -63,7 +66,8 @@ trait Memoize {
      *
      * @return null
      */
-    protected function memoizeFlushAll() {
+    protected function memoizeFlushAll()
+    {
         $this->memoized_data = [];
     }
 }

--- a/src/Phan/Model/CalledBy.php
+++ b/src/Phan/Model/CalledBy.php
@@ -8,7 +8,8 @@ use \Phan\Database\Schema;
 use \Phan\Language\FQSEN;
 use \Phan\Language\FileRef;
 
-class CalledBy extends ModelOne {
+class CalledBy extends ModelOne
+{
 
     /**
      * @var string
@@ -47,7 +48,8 @@ class CalledBy extends ModelOne {
     }
     */
 
-    public function getFileRef() : FileRef {
+    public function getFileRef() : FileRef
+    {
         return $this->file_ref;
     }
 
@@ -58,12 +60,14 @@ class CalledBy extends ModelOne {
      *       instead.
      */
     public static function read(
-        Database $database, $primary_key_value
+        Database $database,
+        $primary_key_value
     ) : CalledBy {
         return parent::read($database, $primary_key_value);
     }
 
-    public static function createSchema() : Schema {
+    public static function createSchema() : Schema
+    {
         $schema = new Schema('CalledBy', [
             new Column('id', Column::TYPE_INT, true, true),
             new Column('fqsen_string', Column::TYPE_STRING),
@@ -109,7 +113,8 @@ class CalledBy extends ModelOne {
         static::schema()->initializeOnce($database);
 
         $query = static::schema()->queryForSelectColumnValue(
-            'fqsen_string', (string)$fqsen
+            'fqsen_string',
+            (string)$fqsen
         );
 
         $result = $database->query($query);
@@ -159,7 +164,8 @@ class CalledBy extends ModelOne {
      * @return string
      * The primary key of this model
      */
-    public function primaryKeyValue() : string {
+    public function primaryKeyValue() : string
+    {
         throw new \Exception("Unimplemented");
         return 'not implemented';
     }
@@ -169,7 +175,8 @@ class CalledBy extends ModelOne {
      * Get a map from column name to row values for
      * this instance
      */
-    public function toRow() : array {
+    public function toRow() : array
+    {
         return [
             'fqsen_string' => (string)$this->fqsen_string,
             'file_path' => $this->file_ref->getFile(),
@@ -184,7 +191,8 @@ class CalledBy extends ModelOne {
      * @return CalledBy
      * An instance of the model derived from row data
      */
-    public static function fromRow(array $row) : CalledBy {
+    public static function fromRow(array $row) : CalledBy
+    {
         return new CalledBy(
             $row['fqsen_string'],
             (new FileRef)
@@ -192,5 +200,4 @@ class CalledBy extends ModelOne {
                 ->withLineNumberStart((int)$row['line_number'])
         );
     }
-
 }

--- a/src/Phan/Model/Clazz.php
+++ b/src/Phan/Model/Clazz.php
@@ -9,7 +9,8 @@ use \Phan\Language\Element\Clazz as ClazzElement;
 use \Phan\Language\FQSEN\FullyQualifiedClassName;
 use \Phan\Language\UnionType;
 
-class Clazz extends ModelOne {
+class Clazz extends ModelOne
+{
 
     /**
      * @var ClazzElement
@@ -19,11 +20,13 @@ class Clazz extends ModelOne {
     /**
      * @param ClazzElement $clazz
      */
-    public function __construct(ClazzElement $clazz) {
+    public function __construct(ClazzElement $clazz)
+    {
         $this->clazz = $clazz;
     }
 
-    public function getClass() : ClazzElement {
+    public function getClass() : ClazzElement
+    {
         return $this->clazz;
     }
 
@@ -38,7 +41,8 @@ class Clazz extends ModelOne {
         return parent::read($database, $primary_key_value);
     }
 
-    public static function createSchema() : Schema {
+    public static function createSchema() : Schema
+    {
         return new Schema('Clazz', [
             new Column('fqsen', Column::TYPE_STRING, true),
             new Column('name', Column::TYPE_STRING),
@@ -57,7 +61,8 @@ class Clazz extends ModelOne {
      * @return string
      * The value of the primary key for this model
      */
-    public function primaryKeyValue() {
+    public function primaryKeyValue()
+    {
         return (string)$this->clazz->getFQSEN();
     }
 
@@ -66,7 +71,8 @@ class Clazz extends ModelOne {
      * Get a map from column name to row values for
      * this instance
      */
-    public function toRow() : array {
+    public function toRow() : array
+    {
 
         $parent_class_fqsen = $this->clazz->hasParentClassFQSEN()
             ? (string)$this->clazz->getParentClassFQSEN()
@@ -104,7 +110,8 @@ class Clazz extends ModelOne {
      * @return Model
      * An instance of the model derived from row data
      */
-    public static function fromRow(array $row) : Clazz {
+    public static function fromRow(array $row) : Clazz
+    {
         $parent_fqsen = $row['parent_class_fqsen']
             ? FullyQualifiedClassName::fromFullyQualifiedString($row['parent_class_fqsen'])
             : null;
@@ -135,5 +142,4 @@ class Clazz extends ModelOne {
 
         return new Clazz($clazz);
     }
-
 }

--- a/src/Phan/Model/Constant.php
+++ b/src/Phan/Model/Constant.php
@@ -9,7 +9,8 @@ use \Phan\Language\FQSEN\FullyQualifiedClassName;
 use \Phan\Language\FQSEN\FullyQualifiedConstantName;
 use \Phan\Language\UnionType;
 
-class Constant extends ModelOne {
+class Constant extends ModelOne
+{
 
     /**
      * @var ConstantElement
@@ -41,7 +42,8 @@ class Constant extends ModelOne {
         $this->scope_name = $scope_name;
     }
 
-    public static function createSchema() : Schema {
+    public static function createSchema() : Schema
+    {
         return new Schema('Constant', [
             new Column('scope_name', Column::TYPE_STRING, true),
             new Column('fqsen', Column::TYPE_STRING, true),
@@ -57,7 +59,8 @@ class Constant extends ModelOne {
      * @return string
      * The value of the primary key for this model
      */
-    public function primaryKeyValue() {
+    public function primaryKeyValue()
+    {
         return $this->scope . '|' . $this->scope_name;
     }
 
@@ -66,7 +69,8 @@ class Constant extends ModelOne {
      * Get a map from column name to row values for
      * this instance
      */
-    public function toRow() : array {
+    public function toRow() : array
+    {
         $row = [
             'scope_name' => $this->primaryKeyValue(),
             'fqsen' => (string)$this->constant->getFQSEN(),
@@ -87,7 +91,8 @@ class Constant extends ModelOne {
      * @return Constant
      * An instance of the model derived from row data
      */
-    public static function fromRow(array $row) : Constant {
+    public static function fromRow(array $row) : Constant
+    {
         list($scope, $name) = explode('|', $row['scope_name']);
 
         $constant = new Constant(new ConstantElement(
@@ -99,5 +104,4 @@ class Constant extends ModelOne {
 
         return $constant;
     }
-
 }

--- a/src/Phan/Model/File.php
+++ b/src/Phan/Model/File.php
@@ -16,7 +16,8 @@ use \Phan\Language\FQSEN\FullyQualifiedMethodName;
 use \Phan\Language\FQSEN\FullyQualifiedPropertyName;
 use \Phan\Language\UnionType;
 
-class File extends ModelOne {
+class File extends ModelOne
+{
 
     /**
      * @var CodeBaseFile
@@ -26,19 +27,23 @@ class File extends ModelOne {
     /**
      * @param CodeBaseFile $file
      */
-    public function __construct(CodeBaseFile $file) {
+    public function __construct(CodeBaseFile $file)
+    {
         $this->file = $file;
     }
 
-    public function getFile() : CodeBaseFile {
+    public function getFile() : CodeBaseFile
+    {
         return $this->file;
     }
 
-    public static function read(Database $database, $primary_key_value) : File {
+    public static function read(Database $database, $primary_key_value) : File
+    {
         return parent::read($database, $primary_key_value);
     }
 
-    public static function createSchema() : Schema {
+    public static function createSchema() : Schema
+    {
         $schema = new Schema('File', [
             new Column('file_path', Column::TYPE_STRING, true),
             new Column('modification_time', Column::TYPE_INT)
@@ -46,7 +51,8 @@ class File extends ModelOne {
 
         $schema->addAssociation(
             new ListAssociation(
-                'FileClassFQSEN', Column::TYPE_STRING,
+                'FileClassFQSEN',
+                Column::TYPE_STRING,
                 function (File $file, array $class_fqsen_string_list) {
                     $file->getFile()->setClassFQSENList(
                         array_map(function (string $fqsen_string) {
@@ -66,7 +72,8 @@ class File extends ModelOne {
 
         $schema->addAssociation(
             new ListAssociation(
-                'FileMethodFQSEN', Column::TYPE_STRING,
+                'FileMethodFQSEN',
+                Column::TYPE_STRING,
                 function (File $file, array $method_fqsen_string_list) {
                     $file->getFile()->setMethodFQSENList(
                         array_map(function (string $fqsen_string) {
@@ -92,7 +99,8 @@ class File extends ModelOne {
 
         $schema->addAssociation(
             new ListAssociation(
-                'FilePropertyFQSEN', Column::TYPE_STRING,
+                'FilePropertyFQSEN',
+                Column::TYPE_STRING,
                 function (File $file, array $fqsen_string_list) {
                     $file->getFile()->setPropertyFQSENList(
                         array_map(function (string $fqsen_string) {
@@ -118,7 +126,8 @@ class File extends ModelOne {
 
         $schema->addAssociation(
             new ListAssociation(
-                'FileConstantFQSEN', Column::TYPE_STRING,
+                'FileConstantFQSEN',
+                Column::TYPE_STRING,
                 function (File $file, array $fqsen_string_list) {
                     $file->getFile()->setConstantFQSENList(
                         array_map(function (string $fqsen_string) {
@@ -149,7 +158,8 @@ class File extends ModelOne {
      * @return string
      * The primary key of this model
      */
-    public function primaryKeyValue() : string {
+    public function primaryKeyValue() : string
+    {
         return $this->file->getFilePath();
     }
 
@@ -158,7 +168,8 @@ class File extends ModelOne {
      * Get a map from column name to row values for
      * this instance
      */
-    public function toRow() : array {
+    public function toRow() : array
+    {
         return [
             'file_path' => $this->file->getProjectRelativePath(),
             'modification_time' => $this->file->getModificationTime(),
@@ -172,11 +183,11 @@ class File extends ModelOne {
      * @return File
      * An instance of the model derived from row data
      */
-    public static function fromRow(array $row) : File {
+    public static function fromRow(array $row) : File
+    {
         return new File(new CodeBaseFile(
             $row['file_path'],
             (int)$row['modification_time']
         ));
     }
-
 }

--- a/src/Phan/Model/Method.php
+++ b/src/Phan/Model/Method.php
@@ -12,7 +12,8 @@ use \Phan\Language\FQSEN\FullyQualifiedClassName;
 use \Phan\Language\FQSEN\FullyQualifiedMethodName;
 use \Phan\Language\UnionType;
 
-class Method extends ModelOne {
+class Method extends ModelOne
+{
 
     /**
      * @var MethodElement
@@ -44,7 +45,8 @@ class Method extends ModelOne {
         $this->scope_name = $scope_name;
     }
 
-    public function getMethod() : MethodElement {
+    public function getMethod() : MethodElement
+    {
         return $this->method;
     }
 
@@ -63,7 +65,8 @@ class Method extends ModelOne {
      * @return Schema
      * The schema for this model
      */
-    public static function createSchema() : Schema {
+    public static function createSchema() : Schema
+    {
         $schema = new Schema('Method', [
             new Column('scope_name', Column::TYPE_STRING, true),
             new Column('fqsen', Column::TYPE_STRING),
@@ -107,7 +110,8 @@ class Method extends ModelOne {
      * @return string
      * The value of the primary key for this model
      */
-    public function primaryKeyValue() {
+    public function primaryKeyValue()
+    {
         return $this->scope . '|' . $this->scope_name;
     }
 
@@ -116,7 +120,8 @@ class Method extends ModelOne {
      * Get a map from column name to row values for
      * this instance
      */
-    public function toRow() : array {
+    public function toRow() : array
+    {
         return [
             'scope_name' => $this->primaryKeyValue(),
             'fqsen' => (string)$this->method->getFQSEN(),
@@ -139,7 +144,8 @@ class Method extends ModelOne {
      * @return Model
      * An instance of the model derived from row data
      */
-    public static function fromRow(array $row) : Method {
+    public static function fromRow(array $row) : Method
+    {
         list($scope, $name) = explode('|', $row['scope_name']);
 
         return new Method(new MethodElement(

--- a/src/Phan/Model/Parameter.php
+++ b/src/Phan/Model/Parameter.php
@@ -11,7 +11,8 @@ use \Phan\Language\FQSEN\FullyQualifiedFunctionName;
 use \Phan\Language\FQSEN\FullyQualifiedMethodName;
 use \Phan\Language\UnionType;
 
-class Parameter extends ModelOne {
+class Parameter extends ModelOne
+{
 
     /**
      * @var ParameterElement
@@ -39,7 +40,8 @@ class Parameter extends ModelOne {
         $this->primary_key_value = $primary_key_value;
     }
 
-    public static function createSchema() : Schema {
+    public static function createSchema() : Schema
+    {
         $schema = new Schema('Parameter', [
             new Column('id', Column::TYPE_INT, true, true),
             new Column('method_fqsen', Column::TYPE_STRING),
@@ -64,7 +66,8 @@ class Parameter extends ModelOne {
     /**
      * @return ParameterElement
      */
-    public function getParameter() : ParameterElement {
+    public function getParameter() : ParameterElement
+    {
         return $this->parameter;
     }
 
@@ -91,7 +94,8 @@ class Parameter extends ModelOne {
         static::schema()->initializeOnce($database);
 
         $query = static::schema()->queryForSelectColumnValue(
-            'method_fqsen', (string)$fqsen
+            'method_fqsen',
+            (string)$fqsen
         );
 
         $result = $database->query($query);
@@ -112,7 +116,8 @@ class Parameter extends ModelOne {
      * @return string
      * The value of the primary key for this model
      */
-    public function primaryKeyValue() {
+    public function primaryKeyValue()
+    {
         return (string)$this->primary_key_value;
     }
 
@@ -121,7 +126,8 @@ class Parameter extends ModelOne {
      * Get a map from column name to row values for
      * this instance
      */
-    public function toRow() : array {
+    public function toRow() : array
+    {
         return [
             'method_fqsen' => (string)$this->method_fqsen,
             'name' => (string)$this->parameter->getName(),
@@ -139,7 +145,8 @@ class Parameter extends ModelOne {
      * @return Model
      * An instance of the model derived from row data
      */
-    public static function fromRow(array $row) : Parameter {
+    public static function fromRow(array $row) : Parameter
+    {
         if (false === strpos($row['method_fqsen'], '::')) {
             $method_fqsen = FullyQualifiedMethodName::fromFullyQualifiedString(
                 $row['method_fqsen']
@@ -161,5 +168,4 @@ class Parameter extends ModelOne {
 
         return $parameter;
     }
-
 }

--- a/src/Phan/Model/Property.php
+++ b/src/Phan/Model/Property.php
@@ -10,7 +10,8 @@ use \Phan\Language\FQSEN\FullyQualifiedClassName;
 use \Phan\Language\FQSEN\FullyQualifiedPropertyName;
 use \Phan\Language\UnionType;
 
-class Property extends ModelOne {
+class Property extends ModelOne
+{
 
     /**
      * @var PropertyElement
@@ -43,7 +44,8 @@ class Property extends ModelOne {
         $this->scope_name = $scope_name;
     }
 
-    public static function createSchema() : Schema {
+    public static function createSchema() : Schema
+    {
         return new Schema('Property', [
             new Column('scope_name', Column::TYPE_STRING, true),
             new Column('fqsen', Column::TYPE_STRING),
@@ -58,7 +60,8 @@ class Property extends ModelOne {
     /**
      * @return PropertyElement
      */
-    public function getProperty() : PropertyElement {
+    public function getProperty() : PropertyElement
+    {
         return $this->property;
     }
 
@@ -77,7 +80,8 @@ class Property extends ModelOne {
      * @return string
      * The value of the primary key for this model
      */
-    public function primaryKeyValue() {
+    public function primaryKeyValue()
+    {
         return $this->scope . '|' . $this->scope_name;
     }
 
@@ -86,7 +90,8 @@ class Property extends ModelOne {
      * Get a map from column name to row values for
      * this instance
      */
-    public function toRow() : array {
+    public function toRow() : array
+    {
         return [
             'scope_name' => $this->primaryKeyValue(),
             'fqsen' => (string)$this->property->getFQSEN(),
@@ -105,7 +110,8 @@ class Property extends ModelOne {
      * @return Model
      * An instance of the model derived from row data
      */
-    public static function fromRow(array $row) : Property {
+    public static function fromRow(array $row) : Property
+    {
         list($scope, $name) = explode('|', $row['scope_name']);
 
         $property = new Property(new PropertyElement(
@@ -117,5 +123,4 @@ class Property extends ModelOne {
 
         return $property;
     }
-
 }

--- a/src/Phan/Output/BufferedPrinterInterface.php
+++ b/src/Phan/Output/BufferedPrinterInterface.php
@@ -1,9 +1,9 @@
 <?php declare(strict_types = 1);
 namespace Phan\Output;
 
-interface BufferedPrinterInterface extends IssuePrinterInterface {
+interface BufferedPrinterInterface extends IssuePrinterInterface
+{
 
     /** flush printer buffer */
     public function flush();
-
 }

--- a/src/Phan/Output/Collector/BufferingCollector.php
+++ b/src/Phan/Output/Collector/BufferingCollector.php
@@ -6,7 +6,8 @@ use Phan\Output\Filter\AnyFilter;
 use Phan\Output\IssueCollectorInterface;
 use Phan\Output\IssueFilterInterface;
 
-final class BufferingCollector implements IssueCollectorInterface {
+final class BufferingCollector implements IssueCollectorInterface
+{
 
     /** @var  IssueInstance[] */
     private $issues = [];
@@ -18,7 +19,8 @@ final class BufferingCollector implements IssueCollectorInterface {
      * BufferingCollector constructor.
      * @param IssueFilterInterface $filter
      */
-    public function __construct(IssueFilterInterface $filter = null) {
+    public function __construct(IssueFilterInterface $filter = null)
+    {
         $this->filter = $filter;
 
         if (null === $this->filter) {
@@ -30,7 +32,8 @@ final class BufferingCollector implements IssueCollectorInterface {
      * Collect issue
      * @param IssueInstance $issue
      */
-    public function collectIssue(IssueInstance $issue) {
+    public function collectIssue(IssueInstance $issue)
+    {
         if (!$this->filter->supports($issue)) {
             return;
         }
@@ -42,7 +45,8 @@ final class BufferingCollector implements IssueCollectorInterface {
      * @param IssueInstance $issue
      * @return string
      */
-    private function formatSortableKey(IssueInstance $issue) {
+    private function formatSortableKey(IssueInstance $issue)
+    {
 
         // This needs to be a sortable key so that output
         // is in the expected order
@@ -57,7 +61,8 @@ final class BufferingCollector implements IssueCollectorInterface {
     /**
      * @return IssueInstance[]
      */
-    public function getCollectedIssues():array {
+    public function getCollectedIssues():array
+    {
         ksort($this->issues);
         return array_values($this->issues);
     }

--- a/src/Phan/Output/Filter/AnyFilter.php
+++ b/src/Phan/Output/Filter/AnyFilter.php
@@ -4,13 +4,15 @@ namespace Phan\Output\Filter;
 use Phan\IssueInstance;
 use Phan\Output\IssueFilterInterface;
 
-final class AnyFilter implements IssueFilterInterface {
+final class AnyFilter implements IssueFilterInterface
+{
 
     /**
      * @param IssueInstance $issue
      * @return bool
      */
-    public function supports(IssueInstance $issue):bool {
+    public function supports(IssueInstance $issue):bool
+    {
         return true;
     }
 }

--- a/src/Phan/Output/Filter/CategoryIssueFilter.php
+++ b/src/Phan/Output/Filter/CategoryIssueFilter.php
@@ -5,7 +5,8 @@ namespace Phan\Output\Filter;
 use Phan\IssueInstance;
 use Phan\Output\IssueFilterInterface;
 
-final class CategoryIssueFilter implements IssueFilterInterface {
+final class CategoryIssueFilter implements IssueFilterInterface
+{
     /** @var  int */
     private $mask;
 
@@ -13,7 +14,8 @@ final class CategoryIssueFilter implements IssueFilterInterface {
      * CategoryIssueFilter constructor.
      * @param int $mask
      */
-    public function __construct(int $mask = -1) {
+    public function __construct(int $mask = -1)
+    {
         $this->mask = $mask;
     }
 
@@ -21,7 +23,8 @@ final class CategoryIssueFilter implements IssueFilterInterface {
      * @param IssueInstance $issue
      * @return bool
      */
-    public function supports(IssueInstance $issue) : bool {
+    public function supports(IssueInstance $issue) : bool
+    {
         return (bool)($issue->getIssue()->getCategory() & $this->mask);
     }
 }

--- a/src/Phan/Output/Filter/ChainedIssueFilter.php
+++ b/src/Phan/Output/Filter/ChainedIssueFilter.php
@@ -4,7 +4,8 @@ namespace Phan\Output\Filter;
 use Phan\IssueInstance;
 use Phan\Output\IssueFilterInterface;
 
-final class ChainedIssueFilter implements IssueFilterInterface {
+final class ChainedIssueFilter implements IssueFilterInterface
+{
 
     /** @var IssueFilterInterface[] */
     private $filters = [];
@@ -14,7 +15,8 @@ final class ChainedIssueFilter implements IssueFilterInterface {
      *
      * @param IssueFilterInterface[] $filters
      */
-    public function __construct(array $filters) {
+    public function __construct(array $filters)
+    {
         $this->filters = $filters;
     }
 
@@ -22,7 +24,8 @@ final class ChainedIssueFilter implements IssueFilterInterface {
      * @param IssueInstance $issue
      * @return bool
      */
-    public function supports(IssueInstance $issue):bool {
+    public function supports(IssueInstance $issue):bool
+    {
         foreach ($this->filters as $filter) {
             if (!$filter->supports($issue)) {
                 return false;

--- a/src/Phan/Output/Filter/FileIssueFilter.php
+++ b/src/Phan/Output/Filter/FileIssueFilter.php
@@ -1,12 +1,12 @@
 <?php declare(strict_types=1);
 namespace Phan\Output\Filter;
 
-
 use Phan\IssueInstance;
 use Phan\Output\IgnoredFilesFilterInterface;
 use Phan\Output\IssueFilterInterface;
 
-final class FileIssueFilter implements IssueFilterInterface {
+final class FileIssueFilter implements IssueFilterInterface
+{
 
     /** @var IgnoredFilesFilterInterface */
     private $ignoredFilesFilter;
@@ -26,7 +26,8 @@ final class FileIssueFilter implements IssueFilterInterface {
      * @param IssueInstance $issue
      * @return bool
      */
-    public function supports(IssueInstance $issue):bool {
+    public function supports(IssueInstance $issue):bool
+    {
         return !$this->ignoredFilesFilter->isFilenameIgnored($issue->getFile());
     }
 }

--- a/src/Phan/Output/Filter/MinimumSeverityFilter.php
+++ b/src/Phan/Output/Filter/MinimumSeverityFilter.php
@@ -5,7 +5,8 @@ use Phan\Issue;
 use Phan\IssueInstance;
 use Phan\Output\IssueFilterInterface;
 
-final class MinimumSeverityFilter implements IssueFilterInterface {
+final class MinimumSeverityFilter implements IssueFilterInterface
+{
 
     /** @var int */
     private $minimumSeverity;
@@ -14,7 +15,8 @@ final class MinimumSeverityFilter implements IssueFilterInterface {
      * MinimumSeverityFilter constructor.
      * @param $minimumSeverity
      */
-    public function __construct(int $minimumSeverity = Issue::SEVERITY_LOW) {
+    public function __construct(int $minimumSeverity = Issue::SEVERITY_LOW)
+    {
         $this->minimumSeverity = $minimumSeverity;
     }
 
@@ -23,7 +25,8 @@ final class MinimumSeverityFilter implements IssueFilterInterface {
      * @param IssueInstance $issue
      * @return bool
      */
-    public function supports(IssueInstance $issue):bool {
+    public function supports(IssueInstance $issue):bool
+    {
         return $issue->getIssue()->getSeverity() >= $this->minimumSeverity;
     }
 }

--- a/src/Phan/Output/IgnoredFilesFilterInterface.php
+++ b/src/Phan/Output/IgnoredFilesFilterInterface.php
@@ -1,12 +1,12 @@
 <?php declare(strict_types = 1);
 namespace Phan\Output;
 
-interface IgnoredFilesFilterInterface {
+interface IgnoredFilesFilterInterface
+{
 
     /**
      * @param string $filename
      * @return bool True if filename is ignored during analysis
      */
     public function isFilenameIgnored(string $filename):bool;
-
 }

--- a/src/Phan/Output/IssueCollectorInterface.php
+++ b/src/Phan/Output/IssueCollectorInterface.php
@@ -3,7 +3,8 @@ namespace Phan\Output;
 
 use Phan\IssueInstance;
 
-interface IssueCollectorInterface {
+interface IssueCollectorInterface
+{
 
     /**
      * Collect issue
@@ -15,5 +16,4 @@ interface IssueCollectorInterface {
      * @return IssueInstance[]
      */
     public function getCollectedIssues():array;
-
 }

--- a/src/Phan/Output/IssueFilterInterface.php
+++ b/src/Phan/Output/IssueFilterInterface.php
@@ -3,12 +3,12 @@ namespace Phan\Output;
 
 use Phan\IssueInstance;
 
-interface IssueFilterInterface {
+interface IssueFilterInterface
+{
 
     /**
      * @param IssueInstance $issue
      * @return bool
      */
     public function supports(IssueInstance $issue):bool;
-
 }

--- a/src/Phan/Output/IssuePrinterInterface.php
+++ b/src/Phan/Output/IssuePrinterInterface.php
@@ -4,7 +4,8 @@ namespace Phan\Output;
 use Phan\IssueInstance;
 use Symfony\Component\Console\Output\OutputInterface;
 
-interface IssuePrinterInterface {
+interface IssuePrinterInterface
+{
 
     /** @param IssueInstance $instance */
     public function print(IssueInstance $instance);
@@ -13,5 +14,4 @@ interface IssuePrinterInterface {
      * @param OutputInterface $output
      */
     public function configureOutput(OutputInterface $output);
-
 }

--- a/src/Phan/Output/Printer/CodeClimatePrinter.php
+++ b/src/Phan/Output/Printer/CodeClimatePrinter.php
@@ -6,7 +6,8 @@ use Phan\IssueInstance;
 use Phan\Output\BufferedPrinterInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class CodeClimatePrinter implements BufferedPrinterInterface {
+final class CodeClimatePrinter implements BufferedPrinterInterface
+{
 
     const CODECLIMATE_SEVERITY_INFO = 'info';
     const CODECLIMATE_SEVERITY_CRITICAL = 'critical';
@@ -19,7 +20,8 @@ final class CodeClimatePrinter implements BufferedPrinterInterface {
     private $messages = [];
 
     /** @param IssueInstance $instance */
-    public function print(IssueInstance $instance) {
+    public function print(IssueInstance $instance)
+    {
         $this->messages[] = [
             'type' => 'issue',
             'check_name' => $instance->getIssue()->getType(),
@@ -43,7 +45,8 @@ final class CodeClimatePrinter implements BufferedPrinterInterface {
      * @param int $rawSeverity
      * @return string
      */
-    private static function mapSeverity(int $rawSeverity):string {
+    private static function mapSeverity(int $rawSeverity):string
+    {
         $severity = self::CODECLIMATE_SEVERITY_INFO;
         switch ($rawSeverity) {
             case Issue::SEVERITY_CRITICAL:
@@ -58,7 +61,8 @@ final class CodeClimatePrinter implements BufferedPrinterInterface {
     }
 
     /** flush printer buffer */
-    public function flush() {
+    public function flush()
+    {
 
         // See https://github.com/codeclimate/spec/blob/master/SPEC.md#output
         // for details on the CodeClimate output format
@@ -74,7 +78,8 @@ final class CodeClimatePrinter implements BufferedPrinterInterface {
     /**
      * @param OutputInterface $output
      */
-    public function configureOutput(OutputInterface $output) {
+    public function configureOutput(OutputInterface $output)
+    {
         $this->output = $output;
     }
 }

--- a/src/Phan/Output/Printer/JSONPrinter.php
+++ b/src/Phan/Output/Printer/JSONPrinter.php
@@ -6,7 +6,8 @@ use Phan\IssueInstance;
 use Phan\Output\BufferedPrinterInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class JSONPrinter implements BufferedPrinterInterface {
+final class JSONPrinter implements BufferedPrinterInterface
+{
 
     /** @var  OutputInterface */
     private $output;
@@ -15,7 +16,8 @@ final class JSONPrinter implements BufferedPrinterInterface {
     private $messages = [];
 
     /** @param IssueInstance $instance */
-    public function print(IssueInstance $instance) {
+    public function print(IssueInstance $instance)
+    {
         $this->messages[] = [
             'type' => 'issue',
             'check_name' => $instance->getIssue()->getType(),
@@ -35,7 +37,8 @@ final class JSONPrinter implements BufferedPrinterInterface {
     }
 
     /** flush printer buffer */
-    public function flush() {
+    public function flush()
+    {
         $this->output->write(json_encode($this->messages, JSON_UNESCAPED_SLASHES, JSON_UNESCAPED_UNICODE));
         $this->messages = [];
     }
@@ -43,7 +46,8 @@ final class JSONPrinter implements BufferedPrinterInterface {
     /**
      * @param OutputInterface $output
      */
-    public function configureOutput(OutputInterface $output) {
+    public function configureOutput(OutputInterface $output)
+    {
         $this->output = $output;
     }
 }

--- a/src/Phan/Output/Printer/PlainTextPrinter.php
+++ b/src/Phan/Output/Printer/PlainTextPrinter.php
@@ -5,13 +5,15 @@ use Phan\IssueInstance;
 use Phan\Output\IssuePrinterInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class PlainTextPrinter implements IssuePrinterInterface {
+final class PlainTextPrinter implements IssuePrinterInterface
+{
 
     /** @var OutputInterface */
     private $output;
 
     /** @param IssueInstance $instance */
-    public function print(IssueInstance $instance) {
+    public function print(IssueInstance $instance)
+    {
         $issue = sprintf(
             '%s:%d %s %s',
             $instance->getFile(),
@@ -26,7 +28,8 @@ final class PlainTextPrinter implements IssuePrinterInterface {
     /**
      * @param OutputInterface $output
      */
-    public function configureOutput(OutputInterface $output) {
+    public function configureOutput(OutputInterface $output)
+    {
         $this->output = $output;
     }
 }

--- a/src/Phan/Output/PrinterFactory.php
+++ b/src/Phan/Output/PrinterFactory.php
@@ -10,16 +10,19 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Class PrinterFactory
  * Subject of future refactoring to be a bit more extensible
  */
-class PrinterFactory {
+class PrinterFactory
+{
 
     /**
      * @return string[]
      */
-    public function getTypes():array {
+    public function getTypes():array
+    {
         return ['text', 'json', 'codeclimate'];
     }
 
-    public function getPrinter($type, OutputInterface $output):IssuePrinterInterface {
+    public function getPrinter($type, OutputInterface $output):IssuePrinterInterface
+    {
         switch ($type) {
             case 'codeclimate':
                 $printer = new CodeClimatePrinter();

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -191,7 +191,7 @@ class Phan implements IgnoredFilesFilterInterface
         string $file_path
     ) : bool {
         foreach (Config::get()->exclude_analysis_directory_list
-        as $directory) {
+ as $directory) {
             if (0 === strpos($file_path, $directory)
                 || 0 === strpos($file_path, "./$directory")
             ) {

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -6,18 +6,24 @@ use Phan\Output\IgnoredFilesFilterInterface;
 use Phan\Output\IssueCollectorInterface;
 use Phan\Output\IssuePrinterInterface;
 
-class Phan implements IgnoredFilesFilterInterface {
+class Phan implements IgnoredFilesFilterInterface
+{
 
-    /** @var IssuePrinterInterface */
+    /**
+ * @var IssuePrinterInterface
+*/
     public static $printer;
 
-    /** @var IssueCollectorInterface */
+    /**
+ * @var IssueCollectorInterface
+*/
     private static $issueCollector;
 
     /**
      * @return IssueCollectorInterface
      */
-    public static function getIssueCollector() : IssueCollectorInterface {
+    public static function getIssueCollector() : IssueCollectorInterface
+    {
         return self::$issueCollector;
     }
 
@@ -92,7 +98,7 @@ class Phan implements IgnoredFilesFilterInterface {
 
         // Don't continue on to analysis if the user has
         // chosen to just dump the AST
-            if (Config::get()->dump_ast) {
+        if (Config::get()->dump_ast) {
             exit;
         }
 
@@ -185,10 +191,10 @@ class Phan implements IgnoredFilesFilterInterface {
         string $file_path
     ) : bool {
         foreach (Config::get()->exclude_analysis_directory_list
-                 as $directory
-        ) {
+        as $directory) {
             if (0 === strpos($file_path, $directory)
-                || 0 === strpos($file_path, "./$directory")) {
+                || 0 === strpos($file_path, "./$directory")
+            ) {
                 return true;
             }
         }
@@ -201,7 +207,8 @@ class Phan implements IgnoredFilesFilterInterface {
      *
      * @return void
      */
-    private static function display() {
+    private static function display()
+    {
         $collector = self::$issueCollector;
 
         if (Config::get()->progress_bar) {
@@ -233,7 +240,8 @@ class Phan implements IgnoredFilesFilterInterface {
      *
      * @return bool True if filename is ignored during analysis
      */
-    public function isFilenameIgnored(string $filename):bool {
+    public function isFilenameIgnored(string $filename):bool
+    {
         return self::isExcludedAnalysisFile($filename);
     }
 }

--- a/src/Phan/Profile.php
+++ b/src/Phan/Profile.php
@@ -1,7 +1,8 @@
 <?php declare(strict_types=1);
 namespace Phan;
 
-trait Profile {
+trait Profile
+{
 
     private static $label_delta_map = [];
 
@@ -17,7 +18,8 @@ trait Profile {
      * @param \Closure $closure
      * Any closure to measure how long it takes to run
      */
-    protected static function time(string $label, \Closure $closure) {
+    protected static function time(string $label, \Closure $closure)
+    {
 
         if (!Config::get()->profiler_enabled) {
             return $closure();
@@ -46,11 +48,12 @@ trait Profile {
     /**
      * Initialize the profiler
      */
-    private static function initialize() {
+    private static function initialize()
+    {
 
         // Create a shutdown function to emit the log when we're
         // all done
-        register_shutdown_function(function() {
+        register_shutdown_function(function () {
             $label_metric_map = [];
 
             // Compute whatever metric we care about
@@ -67,7 +70,7 @@ trait Profile {
 
 
             // Sort such that the highest metric value is on top
-            uasort($label_metric_map, function($a, $b) {
+            uasort($label_metric_map, function ($a, $b) {
                 return ($b[1] <=> $a[1]);
             });
 
@@ -82,5 +85,4 @@ trait Profile {
             }
         });
     }
-
 }

--- a/src/Phan/Set.php
+++ b/src/Phan/Set.php
@@ -5,13 +5,15 @@ namespace Phan;
  * A set of objects supporting union and
  * intersection
  */
-class Set extends \SplObjectStorage {
+class Set extends \SplObjectStorage
+{
 
     /**
      * @param \Iterator|array $elements
      * An optional set of items to add to the set
      */
-    public function __construct($element_iterator = null) {
+    public function __construct($element_iterator = null)
+    {
         foreach ($element_iterator ?? [] as $element) {
             $this->attach($element);
         }
@@ -21,7 +23,8 @@ class Set extends \SplObjectStorage {
      * @return array
      * An array of all elements in the set is returned
      */
-    public function toArray() : array {
+    public function toArray() : array
+    {
         return iterator_to_array($this);
     }
 
@@ -33,7 +36,8 @@ class Set extends \SplObjectStorage {
      * A new set which contains only items in this
      * Set and the given Set
      */
-    public function intersect(Set $other) : Set {
+    public function intersect(Set $other) : Set
+    {
         $set = new Set();
         foreach ($this as $element) {
             if ($other->contains($element)) {
@@ -51,7 +55,8 @@ class Set extends \SplObjectStorage {
      * A new Set containing only the elements that appear in
      * all parameters
      */
-    public static function intersectAll(array $set_list) : Set {
+    public static function intersectAll(array $set_list) : Set
+    {
         if (empty($set_list)) {
             return new Set();
         }
@@ -74,7 +79,8 @@ class Set extends \SplObjectStorage {
      *
      * @suppress PhanUnreferencedMethod
      */
-    public function union(Set $other) : Set {
+    public function union(Set $other) : Set
+    {
         $set = new Set();
         $set->addAll($this);
         $set->addAll($other);
@@ -85,7 +91,8 @@ class Set extends \SplObjectStorage {
      * @return bool
      * True if this set contains any elements in the given list
      */
-    public function containsAny(array $element_list) : bool {
+    public function containsAny(array $element_list) : bool
+    {
         foreach ($element_list as $element) {
             if ($this->contains($element)) {
                 return true;
@@ -105,7 +112,8 @@ class Set extends \SplObjectStorage {
      * A new set for which all elements when passed to the given
      * closure return true
      */
-    public function filter(\Closure $closure) {
+    public function filter(\Closure $closure)
+    {
         $set = new Set();
         foreach ($this as $element) {
             if ($closure($element)) {
@@ -123,7 +131,8 @@ class Set extends \SplObjectStorage {
      * @return Set
      * A new set containing the mapped values
      */
-    public function map(\Closure $closure) {
+    public function map(\Closure $closure)
+    {
         $set = new Set();
         foreach ($this as $element) {
             $set->attach($closure($element));
@@ -140,7 +149,8 @@ class Set extends \SplObjectStorage {
      * true is returned or false if no elements pass the
      * given closure
      */
-    public function find(\Closure $closure) {
+    public function find(\Closure $closure)
+    {
         foreach ($this as $element) {
             if ($closure($element)) {
                 return $element;
@@ -154,14 +164,14 @@ class Set extends \SplObjectStorage {
      * A string representation of this set for use in
      * debugging
      */
-    public function __toString() : string {
+    public function __toString() : string
+    {
         $string = '['
-            . implode(',', array_map(function($element) {
+            . implode(',', array_map(function ($element) {
                 return (string)$element;
             }, iterator_to_array($this)))
             . ']';
 
         return $string;
     }
-
 }

--- a/src/phan.php
+++ b/src/phan.php
@@ -21,9 +21,11 @@ $cli = new CLI();
 // If requested, expand the file list to a set of
 // all files that should be re-analyzed
 if (Config::get()->expand_file_list) {
-    assert((bool)(Config::get()->stored_state_file_path),
+    assert(
+        (bool)(Config::get()->stored_state_file_path),
         'Requesting an expanded dependency list can only '
-        . ' be done if a state-file is defined');
+        . ' be done if a state-file is defined'
+    );
 
     // Analyze the file list provided via the CLI
     $dependency_file_list = Phan::expandedFileList(

--- a/src/requirements.php
+++ b/src/requirements.php
@@ -1,7 +1,11 @@
 <?php declare(strict_types = 1);
 
-assert(extension_loaded('ast'),
-    'The php-ast extension must be loaded in order for Phan to work. See https://github.com/etsy/phan#getting-it-running for more details.');
+assert(
+    extension_loaded('ast'),
+    'The php-ast extension must be loaded in order for Phan to work. See https://github.com/etsy/phan#getting-it-running for more details.'
+);
 
-assert((int)phpversion()[0] >= 7,
-    'Phan requires PHP version 7 or greater. See https://github.com/etsy/phan#getting-it-running for more details.');
+assert(
+    (int)phpversion()[0] >= 7,
+    'Phan requires PHP version 7 or greater. See https://github.com/etsy/phan#getting-it-running for more details.'
+);


### PR DESCRIPTION
This is an automatic conversion of the style to be PSR-2 (http://www.php-fig.org/psr/psr-2/) via

```sh
find src \
    -type f \
    -path '*.php' \
    -exec phpcbf \
        --standard=PSR2 {} \;
```

I'd love to hear from folks that wish I wouldn't commit this before they merge their patches in.