### PR TITLE
Remove side effect on Config::minimum_severity at CLI

### DIFF
--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -86,6 +86,7 @@ class CLI
         $this->output = new ConsoleOutput();
         $factory = new PrinterFactory();
         $printer_type = 'text';
+        $minimum_severity = Config::get()->minimum_severity;
         $mask = -1;
 
         foreach ($opts ?? [] as $key => $value) {
@@ -191,7 +192,7 @@ class CLI
                     break;
                 case 'y':
                 case 'minimum-severity':
-                    Config::get()->minimum_severity = (int)$value;
+                    $minimum_severity = (int)$value;
                     break;
                 case 'd':
                 case 'project-root-directory':
@@ -212,7 +213,7 @@ class CLI
         $printer = $factory->getPrinter($printer_type, $this->output);
         $filter  = new ChainedIssueFilter([
             new FileIssueFilter(new Phan()),
-            new MinimumSeverityFilter(Config::get()->minimum_severity),
+            new MinimumSeverityFilter($minimum_severity),
             new CategoryIssueFilter($mask)
         ]);
         $collector = new BufferingCollector($filter);


### PR DESCRIPTION
I think we should not touch things, which not used anymore rather than at the point we configure Printer.

With this patch we still can load `minimum_severity` from config and override it from CLI. and touch no global state.

I think we should really load config first, then update config (local instanse) with CLI (having only the same config), configure Phan totally only from config local instance and dispose local config after that.

I hope I propose change on it soon