### PR TITLE
`array_unique` files to scan to avoid scanning things twice

### DIFF
--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -267,6 +267,9 @@ class CLI
                     $this->directoryNameToFileList($directory_name)
                 );
             }
+
+            // Don't scan anything twice
+            $this->file_list = array_unique($this->file_list);
         }
 
 


### PR DESCRIPTION
Without this change if you ran phan with a config and then also passed
in one of the directories included in the config with the `--directory`
flag phan would scan the directory twice, emitting tons of
`PhanRedefineClass` errors in the process.