### PR TITLE
Rough sketch of find callers/usages functionality. See #18.

### DIFF
--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -67,6 +67,7 @@ class CLI
                 'project-root-directory:',
                 'quick',
                 'state-file:',
+                'find-refs:',
             ]
         );
 
@@ -201,6 +202,14 @@ class CLI
                 case 'x':
                 case 'dead-code-detection':
                     Config::get()->dead_code_detection = true;
+                    break;
+                case 'find-refs':
+                    if (Config::get()->stored_state_file_path !== null) {
+                        Config::get()->find_refs = true;
+                        Config::get()->query = $value;
+                    } else {
+                        $this->usage('In order to find references, a state file must provided with the -s flag');
+                    }
                     break;
                 default:
                     $this->usage("Unknown option '-$key'");
@@ -354,6 +363,14 @@ Usage: {$argv[0]} [options] [files...]
   Emit issues for classes, methods, functions, constants and
   properties that are probably never referenced and can
   possibly be removed.
+
+ --find-refs <FQSEN>
+  Find all known references to the provided FQSEN
+  See https://github.com/etsy/phan/wiki/Developer%27s-Guide-To-Phan#fqsen
+  for how to construct a FQSEN.
+
+  Requires that the --state-file flag be set and the target database
+  is populated.
 
  -h,--help
   This help information

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -127,6 +127,14 @@ class Config
         // parts of Phan took to run. You likely don't care to do
         // this.
         'profiler_enabled' => false,
+
+        // Find references to a given FQSEN
+        // Does not run analysis
+        // Requires state database to be present
+        'find_refs' => false,
+
+        // Which FQSEN to find refs for
+        'ref_query' => '',
     ];
 
     /**

--- a/src/Phan/Model/CalledBy.php
+++ b/src/Phan/Model/CalledBy.php
@@ -102,12 +102,14 @@ class CalledBy extends ModelOne
     }
 
     /**
+     * @param Database $database
+     * @param FQSEN|String $fqsen
      * @return CalledBy[]
      * The set of callers for the given FQSEN
      */
     public static function findManyByFQSEN(
         Database $database,
-        FQSEN $fqsen
+        $fqsen
     ) : array {
         // Ensure that we've initialized this model
         static::schema()->initializeOnce($database);
@@ -199,5 +201,13 @@ class CalledBy extends ModelOne
                 ->withFile($row['file_path'])
                 ->withLineNumberStart((int)$row['line_number'])
         );
+    }
+
+    /**
+     * @return string
+     * The string representation of the location for this reference
+     */
+    public function referenceLocation(): string {
+        return "{$this->file_ref->getFile()}:{$this->file_ref->getLineNumberStart()}";
     }
 }

--- a/src/Phan/RefFinder.php
+++ b/src/Phan/RefFinder.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+namespace Phan;
+
+use \Phan\CodeBase;
+use \Phan\Config;
+
+class RefFinder {
+    public static function find(string $fqsen): array {
+        $database = new Database();
+        $callers = Model\CalledBy::findManyByFQSEN($database, $fqsen);
+
+        $reference_locations = [];
+        foreach ($callers as $caller) {
+            $reference_locations[] = $caller->referenceLocation();
+        }
+
+        return $reference_locations;
+    }
+}

--- a/src/phan.php
+++ b/src/phan.php
@@ -14,6 +14,7 @@ use Phan\CLI;
 use Phan\CodeBase;
 use Phan\Config;
 use Phan\Phan;
+use Phan\RefFinder;
 
 // Create our CLI interface and load arguments
 $cli = new CLI();
@@ -33,8 +34,16 @@ if (Config::get()->expand_file_list) {
     $file_list = Phan::expandedFileList($code_base, $file_list);
 }
 
-// Analyze the file list provided via the CLI
-Phan::analyzeFileList(
-    $code_base,
-    $file_list
-);
+if (Config::get()->find_refs) {
+    $query = Config::get()->query;
+    $results = RefFinder::find($query);
+    foreach ($results as $result) {
+        echo "$result\n";
+    }
+} else {
+    // Analyze the file list provided via the CLI
+    Phan::analyzeFileList(
+        $code_base,
+        $file_list
+    );
+}


### PR DESCRIPTION
This implements basic find callers/usages/references functionality. The query must be supplied as a [FQSEN](https://github.com/etsy/phan/wiki/Developer%27s-Guide-To-Phan#fqsen) that **exactly** matches the element in question.

This functionality is only available when a state database has been created and provided over the command line. Note that the state database functionality is currently disabled in master.

Results will be returned in the format `path_to_file:line_number`. Usage looks like this:

```
$ ../phan/phan -s ./state.sqlite3 --find-refs "\class::method"
your/file.php:63
```

Note that currently the class name of the FQSEN must always be given as lowercase. See #43 for more information. One possible solution would just be to lowercase the query that is being provided on input.