### PR TITLE
Use the global composer autoloader if phan is installed globally

### DIFF
--- a/src/codebase.php
+++ b/src/codebase.php
@@ -6,7 +6,15 @@ $internal_interface_name_list = get_declared_interfaces();
 $internal_trait_name_list = get_declared_traits();
 $internal_function_name_list = get_defined_functions()['internal'];
 
-require_once __DIR__ . '/../vendor/autoload.php';
+
+if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+  // This is the normal path when Phan is installed only in the scope of a project.
+  require_once __DIR__ . '/../vendor/autoload.php';
+}
+else {
+  // This is the path to autoload.php when Phan is installed globally.
+  require_once __DIR__ . '/../../../autoload.php';
+}
 
 use Phan\CodeBase;
 


### PR DESCRIPTION
If I `composer global require "etsy/phan:dev-master"`, and then run `phan`, I get an error about a missing `autoload.php`. This change allows Phan to be installed globally instead of just per-project.