### PR TITLE
If phan is installed globally, the global composer autoloader should be usable.

### DIFF
--- a/src/requirements.php
+++ b/src/requirements.php
@@ -11,7 +11,7 @@ assert(
 );
 
 assert(
-    file_exists(__DIR__ . '/../vendor/autoload.php'),
+    file_exists(__DIR__ . '/../vendor/autoload.php') || file_exists(__DIR__ . '/../../../autoload.php'),
     'Autoloader not found. Make sure you run `composer install` before running Phan. See https://github.com/etsy/phan#getting-it-running for more details.'
 );
 


### PR DESCRIPTION
If [PHP assertions](http://php.net/manual/en/function.assert.php) are enabled, a warning is emitted when phan is installed globally:

```
❯ phan           
PHP Warning:  assert(): Autoloader not found. Make sure you run `composer install` before running Phan. See https://github.com/etsy/phan#getting-it-running for more details. failed in /home/kevin/.composer/vendor/etsy/phan/src/requirements.php on line 15

Warning: assert(): Autoloader not found. Make sure you run `composer install` before running Phan. See https://github.com/etsy/phan#getting-it-running for more details. failed in /home/kevin/.composer/vendor/etsy/phan/src/requirements.php on line 15
```

As started by #140, this PR allows phan to use the global autoloader generated by Composer.