### PR TITLE
Adding flag for getting markdown formatted issues

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,28 @@
+---
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+        - ruby
+        - javascript
+        - python
+        - php
+  fixme:
+    enabled: true
+  phpmd:
+    enabled: true
+  phan:
+    enabled: true
+    config:
+        file_extensions: "php"
+        minimum-severity: 0
+        ignore-undeclared: false
+        quick: false
+        backward-compatibility-checks: true
+        dead-code-detection: true
+ratings:
+  paths:
+    - "**.php"
+exclude_paths:
+  - tests/**/*

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -70,6 +70,7 @@ class CLI
                 'state-file:',
                 'processes:',
                 'signature-compatibility',
+                'markdown-issue-messages',
             ]
         );
 
@@ -213,6 +214,9 @@ class CLI
                 case 'x':
                 case 'dead-code-detection':
                     Config::get()->dead_code_detection = true;
+                    break;
+                case 'markdown-issue-messages':
+                    Config::get()->markdown_issue_messages = true;
                     break;
                 default:
                     $this->usage("Unknown option '-$key'");

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -168,6 +168,9 @@ class Config
         'suppress_issue_types' => [
             // 'PhanUndeclaredMethod',
         ],
+
+        // Emit issue messages with markdown formatting
+        'markdown_issue_messages' => false,
     ];
 
     /**

--- a/src/Phan/IssueInstance.php
+++ b/src/Phan/IssueInstance.php
@@ -30,8 +30,18 @@ class IssueInstance
         $this->issue = $issue;
         $this->file = $file;
         $this->line = $line;
+
+        $template = $issue->getTemplate();
+
+        if (Config::get()->markdown_issue_messages) {
+            $template = preg_replace(
+                '/([^ ]*%s[^ ]*)/', '`\1`',
+                $template
+            );
+        }
+
         $this->message = vsprintf(
-            $issue->getTemplate(),
+            $template,
             $template_parameters
         );
     }


### PR DESCRIPTION
Result looks like the following.


```sh
phan> ./phan -d tests --markdown-issue-messages tests/files/src/0101_one_of_each.php                                                                asm
tests/files/src/0101_one_of_each.php:5 PhanAccessPropertyPrivate Cannot access private property `\c1::$p`
tests/files/src/0101_one_of_each.php:9 PhanAccessPropertyProtected Cannot access protected property `\c2::$p`
tests/files/src/0101_one_of_each.php:14 PhanUndeclaredVariable Variable `$v1` is undeclared
tests/files/src/0101_one_of_each.php:17 PhanContextNotObject Cannot access `parent` when not in object context
tests/files/src/0101_one_of_each.php:22 PhanDeprecatedFunction Call to deprecated function `\f1()` defined at `tests/files/src/0101_one_of_each.php:21`
tests/files/src/0101_one_of_each.php:25 PhanNoopArray Unused array
tests/files/src/0101_one_of_each.php:28 PhanNoopClosure Unused closure
tests/files/src/0101_one_of_each.php:32 PhanNoopConstant Unused constant
tests/files/src/0101_one_of_each.php:37 PhanNoopProperty Unused property
tests/files/src/0101_one_of_each.php:42 PhanNoopVariable Unused variable
tests/files/src/0101_one_of_each.php:48 PhanParamReqAfterOpt Required argument follows optional
tests/files/src/0101_one_of_each.php:64 PhanParamTooFew Call with 0 arg(s) to `\f6()` which requires 1 arg(s) defined at `tests/files/src/0101_one_of_each.php:63`
tests/files/src/0101_one_of_each.php:71 PhanParamTooMany Call with 2 arg(s) to `\f7()` which only takes 1 arg(s) defined at `tests/files/src/0101_one_of_each.php:70`
tests/files/src/0101_one_of_each.php:74 PhanParamTooManyInternal Call with 2 arg(s) to `\strlen()` which only takes 1 arg(s)
tests/files/src/0101_one_of_each.php:80 PhanRedefineClass `Class \c15` defined at `tests/files/src/0101_one_of_each.php:80` was previously defined as `Class \c15` at `tests/files/src/0101_one_of_each.php:79`
tests/files/src/0101_one_of_each.php:83 PhanRedefineClassInternal `Class \datetime` defined at `tests/files/src/0101_one_of_each.php:83` was previously defined as `Class \datetime` internally
tests/files/src/0101_one_of_each.php:87 PhanRedefineFunction Function `f9` defined at `tests/files/src/0101_one_of_each.php:87` was previously defined at `tests/files/src/0101_one_of_each.php:86`
tests/files/src/0101_one_of_each.php:90 PhanRedefineFunctionInternal Function `strlen` defined at `tests/files/src/0101_one_of_each.php:90` was previously defined internally
tests/files/src/0101_one_of_each.php:94 PhanStaticCallToNonStatic Static call to non-static method `\c19::f()` defined at `tests/files/src/0101_one_of_each.php:93`
tests/files/src/0101_one_of_each.php:98 PhanNonClassMethodCall Call to method `f` on non-class type `null`
tests/files/src/0101_one_of_each.php:104 PhanTypeArraySuspicious Suspicious array access to `bool`
tests/files/src/0101_one_of_each.php:107 PhanTypeComparisonFromArray array to `string` comparison
tests/files/src/0101_one_of_each.php:110 PhanTypeComparisonToArray `int` to array comparison
tests/files/src/0101_one_of_each.php:116 PhanTypeInstantiateAbstract Instantiation of abstract class `\c6`
tests/files/src/0101_one_of_each.php:119 PhanTypeInstantiateInterface Instantiation of interface `\c7`
tests/files/src/0101_one_of_each.php:129 PhanTypeMismatchArgument Argument 1 `(i)` is `string` but `\f8()` takes `int` defined at `tests/files/src/0101_one_of_each.php:128`
tests/files/src/0101_one_of_each.php:132 PhanTypeMismatchArgumentInternal Argument 1 `(string)` is `int` but `\strlen()` takes `string`
tests/files/src/0101_one_of_each.php:138 PhanTypeMismatchForeach `null` passed to foreach instead of array
tests/files/src/0101_one_of_each.php:141 PhanTypeMismatchDefault Default value for `int` `$p` can't be `bool`
tests/files/src/0101_one_of_each.php:144 PhanTypeMismatchReturn Returning type `string` but `f()` is declared to return `int`
tests/files/src/0101_one_of_each.php:147 PhanTypeMissingReturn Method `\c9::f` is declared to return `int` but has no return value
tests/files/src/0101_one_of_each.php:150 PhanUndeclaredClassMethod Call to method `f` from undeclared class `\f`
tests/files/src/0101_one_of_each.php:155 PhanUndeclaredTypeParameter Parameter of undeclared type `\undef`
tests/files/src/0101_one_of_each.php:158 PhanUndeclaredTypeProperty Property of undeclared type `\undef`
tests/files/src/0101_one_of_each.php:161 PhanParentlessClass Reference to parent of class `\c12` that does not extend anything
tests/files/src/0101_one_of_each.php:164 PhanTraitParentReference Reference to parent from trait `\t1`
tests/files/src/0101_one_of_each.php:172 PhanUndeclaredClassCatch Catching undeclared class `\undef`
tests/files/src/0101_one_of_each.php:176 PhanUndeclaredConstant Reference to undeclared constant `\c16::C`
tests/files/src/0101_one_of_each.php:180 PhanUndeclaredClassInstanceof Checking instanceof against undeclared class `\undef`
tests/files/src/0101_one_of_each.php:183 PhanUndeclaredClassMethod Call to method `f5` from undeclared class `\undef`
tests/files/src/0101_one_of_each.php:183 PhanUndeclaredTypeParameter Parameter of undeclared type `\undef`
tests/files/src/0101_one_of_each.php:192 PhanUndeclaredExtendedClass Class extends undeclared class `\undef`
tests/files/src/0101_one_of_each.php:195 PhanUndeclaredFunction Call to undeclared function `\f10()`
tests/files/src/0101_one_of_each.php:198 PhanUndeclaredInterface Class implements undeclared interface `\c18`
tests/files/src/0101_one_of_each.php:206 PhanUndeclaredProperty Reference to undeclared property `\c14->undef`
tests/files/src/0101_one_of_each.php:210 PhanUndeclaredStaticMethod Static call to undeclared method `\c21::f`
tests/files/src/0101_one_of_each.php:214 PhanUndeclaredProperty Reference to undeclared property `\c22->p`
tests/files/src/0101_one_of_each.php:217 PhanUndeclaredTrait Class uses undeclared trait `\t2`
tests/files/src/0101_one_of_each.php:220 PhanUndeclaredVariable Variable `$v10` is undeclared
```