### PR TITLE
Use socket pair to return results to parent in multi-process mode.

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -31,6 +31,9 @@
         <testsuite name="AnalyzerTest">
             <file>tests/Phan/AnalyzerTest.php</file>
         </testsuite>
+        <testsuite name="ForkPoolTest">
+            <file>tests/Phan/ForkPoolTest.php</file>
+        </testsuite>
         <testsuite name="PhanTest">
             <file>tests/Phan/PhanTest.php</file>
         </testsuite>

--- a/src/Phan/Output/Collector/BufferingCollector.php
+++ b/src/Phan/Output/Collector/BufferingCollector.php
@@ -74,4 +74,12 @@ final class BufferingCollector implements IssueCollectorInterface
     {
         $this->issues = [];
     }
+
+    /**
+     * Removes all collected issues.
+     */
+    public function reset()
+    {
+        $this->issues = [];
+    }
 }

--- a/src/Phan/Output/Collector/ParallelChildCollector.php
+++ b/src/Phan/Output/Collector/ParallelChildCollector.php
@@ -81,4 +81,10 @@ class ParallelChildCollector implements IssueCollectorInterface
         return [];
     }
 
+    /**
+     * This method has not effect on a ParallelChildCollector.
+     */
+    public function reset()
+    {
+    }
 }

--- a/src/Phan/Output/IssueCollectorInterface.php
+++ b/src/Phan/Output/IssueCollectorInterface.php
@@ -16,4 +16,9 @@ interface IssueCollectorInterface
      * @return IssueInstance[]
      */
     public function getCollectedIssues():array;
+
+    /**
+     * Remove all collected issues.
+     */
+    public function reset();
 }

--- a/tests/Phan/ForkPoolTest.php
+++ b/tests/Phan/ForkPoolTest.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types = 1);
+
+namespace Phan\Test;
+
+use Phan\ForkPool;
+
+class ForkPoolTest extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * Test that workers are able to send their data back
+	 * to the parent process.
+	 */
+	public function testBasicForkJoin() {
+		$data = [
+			[1, 2, 3, 4],
+			[5, 6, 7, 8],
+			[9, 10, 11, 12],
+			[13, 14, 15, 16],
+		];
+
+		$worker_data = [];
+		$pool = new ForkPool($data,
+			function() { },
+			function($i, $data) use(&$worker_data) {
+				$worker_data[] = $data;
+			},
+			function() use(&$worker_data) {
+				return $worker_data;
+			});
+
+		$this->assertEquals($data, $pool->wait());
+	}
+
+	/**
+	 * Test that the startup function works.
+	 */
+	public function testStartupFunction() {
+		$did_startup = false;
+		$pool = new ForkPool(
+			[[1], [2], [3], [4]],
+			function() use(&$did_startup) {
+				$did_startup = true;
+			},
+			function($i, $data) {
+			},
+			function() use(&$did_startup){
+				return $did_startup;
+			});
+
+		$this->assertEquals(
+			[true, true, true, true],
+			$pool->wait());
+	}
+}


### PR DESCRIPTION
The test isn't great, but it at least verifies that the basics work. I tested this out on the MailChimp codebase and was pleased to get back only a single JSON array.