### PR TITLE
Mark tests skipped instead of requiring pcntl

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
         "symfony/console": "~2.3|~3.0"
     },
     "require-dev": {
-        "ext-pcntl": "*",
         "phpunit/phpunit": "~5",
         "phpdocumentor/phpdocumentor": "dev-master",
         "squizlabs/php_codesniffer": "^2.5"

--- a/tests/Phan/ForkPoolTest.php
+++ b/tests/Phan/ForkPoolTest.php
@@ -4,6 +4,9 @@ namespace Phan\Test;
 
 use Phan\ForkPool;
 
+/**
+ * @requires extension pcntl
+ */
 class ForkPoolTest extends \PHPUnit_Framework_TestCase
 {
 	/**


### PR DESCRIPTION
IMO this wasn't the right fix (in #225).. It means we can't install phan dependencies on windows at all anymore as pcntl is not available there AFAIK. Skipping the tests that need it is a bit nicer :)

![image](https://cloud.githubusercontent.com/assets/183678/14607895/788238d2-057b-11e6-91ee-81c493df3551.png)
