### PR TITLE
Fixed issue with checkstyle not being able to parse non UTF8 characters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - TEST_SUITE="PhanTest"
   - TEST_SUITE="RasmusTest"
   - TEST_SUITE="LanguageTest"
+  - TEST_SUITE="OutputPrinterTest"
 
 sudo: false
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -46,6 +46,9 @@
         <testsuite name="LanguageTest">
             <directory>tests/Phan/Language</directory>
         </testsuite>
+        <testsuite name="OutputPrinterTest">
+            <directory>tests/Phan/Output/Printer</directory>
+        </testsuite>
     </testsuites>
     <filter>
         <whitelist>

--- a/src/Phan/Output/Printer/CheckstylePrinter.php
+++ b/src/Phan/Output/Printer/CheckstylePrinter.php
@@ -54,7 +54,7 @@ final class CheckstylePrinter implements BufferedPrinterInterface
                 // of the error
                 foreach ($error_map as $key => $value) {
                     $error->appendChild(
-                        new \DOMAttr($key, (string)$value)
+                        new \DOMAttr($key, htmlspecialchars((string)$value, ENT_NOQUOTES, 'UTF-8'))
                     );
                 }
             }

--- a/tests/Phan/Output/Printer/CheckstylePrinterTest.php
+++ b/tests/Phan/Output/Printer/CheckstylePrinterTest.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types = 1);
+
+namespace Phan\Tests\Output\Printer;
+
+use Phan\CodeBase;
+use Phan\Issue;
+use Phan\IssueInstance;
+use Phan\Language\Type;
+use Phan\Output\Printer\CheckstylePrinter;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class CheckstylePrinterTest extends PHPUnit_Framework_TestCase {
+
+    /**
+     * @param string $string String to check against
+     *
+     * @dataProvider invalidUTF8StringsProvider
+     */
+    public function testUTF8CharactersDoNotCauseDOMAttrToFail($string) {
+        $output = new BufferedOutput();
+
+        $printer = new CheckstylePrinter();
+        $printer->configureOutput($output);
+        $printer->print(new IssueInstance(Issue::fromType(Issue::SyntaxError), 'test.php', 0, [$string]));
+        $printer->flush();
+    }
+
+    public function invalidUTF8StringsProvider() {
+        return [
+            // Valid ASCII
+            ["a"],
+            // Valid 2 Octet Sequence
+            ["\xc3\xb1"],
+            // Invalid 2 Octet Sequence
+            ["\xc3\x28"],
+            // Invalid Sequence Identifier
+            ["\xa0\xa1"],
+            // Valid 3 Octet Sequence
+            ["\xe2\x82\xa1"],
+            // Invalid 3 Octet Sequence (in 2nd Octet)
+            ["\xe2\x28\xa1"],
+            // Invalid 3 Octet Sequence (in 3rd Octet)
+            ["\xe2\x82\x28"],
+            // Valid 4 Octet Sequence
+            ["\xf0\x90\x8c\xbc"],
+            // Invalid 4 Octet Sequence (in 2nd Octet)
+            ["\xf0\x28\x8c\xbc"],
+            // Invalid 4 Octet Sequence (in 3rd Octet)
+            ["\xf0\x90\x28\xbc"],
+            // Invalid 4 Octet Sequence (in 4th Octet)
+            ["\xf0\x28\x8c\x28"],
+            // Valid 5 Octet Sequence (but not Unicode!)
+            ["\xf8\xa1\xa1\xa1\xa1"],
+            // Valid 6 Octet Sequence (but not Unicode!)
+            ["\xfc\xa1\xa1\xa1\xa1\xa1"],
+        ];
+    }
+}


### PR DESCRIPTION
Invalid UTF-8 characters taken from [http://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt](http://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt)