### PR TITLE
Fix issue when `SoapClient::__construct` signature is incorrect 

### DIFF
--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -753,7 +753,7 @@ class Clazz extends AddressableElement
                 // but doesn't exist yet
                 $default_constructor =
                     Method::defaultConstructorForClassInContext(
-                        $this, $context
+                        $this, $context, $code_base
                     );
 
                 $this->addMethod($code_base, $default_constructor);

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -154,7 +154,8 @@ class Method extends ClassElement implements FunctionInterface
      */
     public static function defaultConstructorForClassInContext(
         Clazz $clazz,
-        Context $context
+        Context $context,
+        CodeBase $code_base
     ) : Method {
 
         $method_fqsen = FullyQualifiedMethodName::make(
@@ -169,6 +170,13 @@ class Method extends ClassElement implements FunctionInterface
             0,
             $method_fqsen
         );
+
+        if ($clazz->hasMethodWithName($code_base, $clazz->getName())) {
+            $old_style_constructor = $clazz->getMethodByName($code_base, $clazz->getName());
+            $method->setParameterList($old_style_constructor->getParameterList());
+            $method->setNumberOfRequiredParameters($old_style_constructor->getNumberOfRequiredParameters());
+            $method->setNumberOfOptionalParameters($old_style_constructor->getNumberOfOptionalParameters());
+        }
 
         return $method;
     }


### PR DESCRIPTION
This should fix #221 although I'm not really happy with the implementation. It would have been more elegant to simply clone the old style constructor method and just change it's name.

Furthermore I'd like to add a test but code like:
```php
$soapClient = new \SoapClient('foo.wsdl');
```
depends on the soap extension. And if the soap extension is not enabled a different error would be shown: `PhanUndeclaredClassMethod Call to method __construct from undeclared class \SoapClient`. Any idea?