### PR TITLE
Feedback needed: Gracefully handle static[] return types

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1140,12 +1140,17 @@ class UnionTypeVisitor extends AnalysisVisitor
 
                     $union_type = $method->getUnionType();
 
-                    // Remove any references to \static once we're
-                    // talking about the method's return type outside
-                    // of its class
+                    // Remove any references to \static or \static[]
+                    // once we're talking about the method's return
+                    // type outside of its class
                     if ($union_type->hasStaticType()) {
                         $union_type = clone($union_type);
                         $union_type->removeType(\Phan\Language\Type\StaticType::instance());
+                    }
+
+                    if ($union_type->genericArrayElementTypes()->hasStaticType()) {
+                        $union_type = clone($union_type);
+                        $union_type->removeType(\Phan\Language\Type\StaticType::instance()->asGenericArrayType());
                     }
 
                     return $union_type;

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -393,6 +393,15 @@ class Method extends ClassElement implements FunctionInterface
             );
         }
 
+        // If the type is a generic array of 'static', add
+        // a generic array of this context's class to the return type
+        if ($union_type->genericArrayElementTypes()->hasStaticType()) {
+            $union_type = clone($union_type);
+            $union_type->addType(
+                $this->getFQSEN()->getFullyQualifiedClassName()->asType()->asGenericArrayType()
+            );
+        }
+
         return $union_type;
     }
 

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -533,7 +533,7 @@ class Type
      */
     public function isStaticType() : bool
     {
-        return ('static' === (string)$this);
+        return ('static' === (string)$this || '\\static' === (string)$this);
     }
 
     /**

--- a/tests/files/src/0193_call_to_element_of_static_array.php
+++ b/tests/files/src/0193_call_to_element_of_static_array.php
@@ -1,0 +1,19 @@
+<?php
+
+class First {
+    /** @return static[] */
+    public static function getList() {
+        return [new static()];
+    }
+}
+
+class Second extends First {
+    public function bar() {
+        return 2;
+    }
+}
+
+function baz() {
+    $seconds = Second::getList();
+    return $seconds[0]->bar();
+}


### PR DESCRIPTION
This fixes #276 but adds uglyness: 

```php
     public function isStaticType() : bool
     {
-        return ('static' === (string)$this);
+        return ('static' === (string)$this || '\\static' === (string)$this);
     }
```

The need for checking for `\static` seems to come from a bit of type info being lost. `StaticType` has a `__toString()` that returns "static" but `Type` (it's parent class) has a `__toString()` that returns "\\static". Somehow PHP seems to call the constructor of `Type`, not of `StaticType`.

I'm not very familiar with PHP 7.0, so I would appreciate some help on figuring this out.