### PR TITLE
Support access to protected methods of shared subclass

### DIFF
--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1218,8 +1218,13 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         } else if ($method->isProtected()
             && !$method->getDefiningClass($this->code_base)->isTrait()
             && (!$this->context->isInClassScope()
-            || !$this->context->getClassFQSEN()->asType()->canCastToType(
+            || (!$this->context->getClassFQSEN()->asType()->canCastToType(
                     $method->getClassFQSEN()->asType()
+                )
+                && !$this->context->getClassFQSEN()->asType()->isSubclassOf(
+                        $this->code_base,
+                        $method->getDefiningClassFQSEN()->asType()
+                    )
                 )
             )
         ) {

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -321,6 +321,32 @@ class Clazz extends AddressableElement
         return $this->parent_class_fqsen;
     }
 
+    public function isSubclassOf(CodeBase $code_base, Clazz $other) : bool
+    {
+        if (!$this->hasParentClassFQSEN()) {
+            return false;
+        }
+
+        if (!$code_base->hasClassWithFQSEN(
+            $this->getParentClassFQSEN()
+        )) {
+            // Let this emit an issue elsewhere for the
+            // parent not existing
+            return false;
+        }
+
+        // Get the parent class
+        $parent = $code_base->getClassByFQSEN(
+            $this->getParentClassFQSEN()
+        );
+
+        if ($parent === $other) {
+            return true;
+        }
+
+        return $parent->isSubclassOf($code_base, $other);
+    }
+
     /**
      * @param CodeBase $code_base
      * The entire code base from which we'll find ancestor

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -734,6 +734,19 @@ class Type
         });
     }
 
+    public function isSubclassOf(CodeBase $code_base, Type $parent)
+    {
+        $thisClazz = $code_base->getClassByFQSEN(
+            $this->asFQSEN()
+        );
+
+        $parentClazz = $code_base->getClassByFQSEN(
+            $parent->asFQSEN()
+        );
+
+        return $thisClazz->isSubclassOf($code_base, $parentClazz);
+    }
+
     /**
      * @return bool
      * True if this Type can be cast to the given Type

--- a/tests/files/expected/0194_shared_base_class.php.expected
+++ b/tests/files/expected/0194_shared_base_class.php.expected
@@ -1,0 +1,2 @@
+%s:26 PhanAccessPropertyProtected Cannot access protected property \A::$var
+%s:27 PhanAccessMethodProtected Cannot access protected method \A::func defined at %s:6

--- a/tests/files/src/0194_shared_base_class.php
+++ b/tests/files/src/0194_shared_base_class.php
@@ -1,0 +1,29 @@
+<?php
+
+class Base {
+    protected $var;
+
+    protected function func() {
+    }
+}
+
+class A extends Base {
+}
+
+class B extends Base {
+    public function test() {
+        $x = new A;
+        $x->var = 'var';
+        $x->func();
+        $this->var = 'var';
+        $this->func();
+    }
+}
+
+class C {
+    public function test() {
+        $x = new A;
+        $x->var = 'var';
+        $x->func();
+    }
+}


### PR DESCRIPTION
PHP supports accessing the protected members of a class that is not
a member of the classes hierarchy if the protected members come from
a shared subclass.