### PR TITLE
Allow deprecated contexts to call other deprecated code

### DIFF
--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -55,8 +55,13 @@ class ArgumentType
             }
         }
 
-        // Emit an error if this method is marked as deprecated
-        if ($method->isDeprecated()) {
+        // Emit an error if this method is marked as deprecated, unless it
+        // is being called from a deprecated method
+        if ($method->isDeprecated()
+            && (!$context->isInElementScope()
+                || !$context->getElementInScope($code_base)->isDeprecated()
+            )
+        ) {
             Issue::maybeEmit(
                 $code_base,
                 $context,

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -808,7 +808,11 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             foreach ($context_node->getClassList() as $class) {
                 $class->addReference($this->context);
 
-                if ($class->isDeprecated()) {
+                if ($class->isDeprecated()
+                    && (!$this->context->isInElementScope()
+                        || !$this->context->getElementInScope($this->code_base)->isDeprecated()
+                    )
+                ) {
                     $this->emitIssue(
                         Issue::DeprecatedClass,
                         $node->lineno ?? 0,

--- a/tests/files/src/0123_deprecated_class.php
+++ b/tests/files/src/0123_deprecated_class.php
@@ -18,3 +18,12 @@ $v->f();
 function f() {
 }
 f();
+
+/**
+ * @deprecated
+ */
+function g() {
+    f();
+    $v = new C;
+    $v->f();
+}


### PR DESCRIPTION
Often enough when deprecating code entire chains of functions need to be
deprecated. Adjust how deprecation issues are handled by allowing code
that is deprecated to call other deprecated functions/classes.