### PR TITLE
Fix trait return type self

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -418,6 +418,12 @@ class UnionTypeVisitor extends AnalysisVisitor
                 }
             }
 
+            if ('self' === $node->children['name']
+                && $this->context->getClassInScope($this->code_base)->isTrait()
+            ) {
+                return new UnionType();
+            }
+
             return Type::fromStringInContext(
                 $node->children['name'],
                 $this->context

--- a/tests/files/src/0195_trait_return_type_self.php
+++ b/tests/files/src/0195_trait_return_type_self.php
@@ -1,0 +1,19 @@
+<?php
+
+trait B {
+    public function g(): self
+    {
+        return $this;
+    }
+}
+
+class A {
+    use B;
+
+    public function f()
+    {
+    }
+}
+
+$a = new A();
+$a->g()->f();


### PR DESCRIPTION
Without the patch, the included test will cause Phan to emit `./tests/files/src/0195_trait_return_type_self.php:19 PhanUndeclaredMethod Call to undeclared method \B::f`.

The fix might not be ideal, since it effectively discards the return type declaration, but arguably it's still better than the status quo.