### PR TITLE
update checkstyle output for readability, usability

### DIFF
--- a/src/Phan/Output/Printer/CheckstylePrinter.php
+++ b/src/Phan/Output/Printer/CheckstylePrinter.php
@@ -74,6 +74,7 @@ final class CheckstylePrinter implements BufferedPrinterInterface
             }
         }
 
+        $document->formatOutput = true;
         $this->output->write($document->saveXML());
         $this->files = [];
     }

--- a/src/Phan/Output/Printer/CheckstylePrinter.php
+++ b/src/Phan/Output/Printer/CheckstylePrinter.php
@@ -52,11 +52,25 @@ final class CheckstylePrinter implements BufferedPrinterInterface
 
                 // Write each element of the error as an attribute
                 // of the error
-                foreach ($error_map as $key => $value) {
-                    $error->appendChild(
-                        new \DOMAttr($key, (string)$value)
-                    );
-                }
+                 $error->appendChild(
+                   new\DOMAttr('line', (string)$error_map['line'])
+                );
+                // map phan severity to Jenkins/Checkstyle severity levels
+                switch($error_map['severity']) {
+                    case 'low':      $level = 'info';    break;
+                    case 'critical': $level = 'error';   break;
+                    case 'normal':
+                    default:         $level = 'warning'; break;
+		        }
+                $error->appendChild(
+                   new\DOMAttr('severity', (string)$level)
+                );
+                $error->appendChild(
+                   new\DOMAttr('message', (string)$error_map['message'])
+                );
+                $error->appendChild(
+                   new\DOMAttr('source', (string)$error_map['source'])
+                );
             }
         }
 


### PR DESCRIPTION
* add the line information and map the Phan severities to Checkstyle values (this makes the output parseable by Jenkins' Checkstyle plugin)
* enable the XML output formatting option to enhance readability.
