### PR TITLE
fix file_exists check

### DIFF
--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -92,7 +92,7 @@ class Phan implements IgnoredFilesFilterInterface {
             $code_base->flushDependenciesForFile($file_path);
 
             // If the file is gone, no need to continue
-            if (!file_exists(realpath($file_path))) {
+            if (($real = realpath($file_path)) === false || !file_exists($real)) {
                 continue;
             }
             try {


### PR DESCRIPTION
realpath returns false if file does not exist. Do we even need file_exists in that case?