### PR TITLE
Ensure return types match

### DIFF
--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -816,7 +816,7 @@ class ContextNode
     }
 
     /**
-     * @return Method
+     * @return Func
      */
     public function getClosure() : Func
     {

--- a/src/Phan/Analysis/Analyzable.php
+++ b/src/Phan/Analysis/Analyzable.php
@@ -66,7 +66,7 @@ trait Analyzable
     }
 
     /**
-     * @return null
+     * @return Context
      * Analyze the node associated with this object
      * in the given context
      */

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -232,7 +232,7 @@ class CodeBase
     }
 
     /**
-     * @return Clazz[]|Map
+     * @return Map
      * A list of all classes
      */
     public function getClassMap() : Map
@@ -306,7 +306,7 @@ class CodeBase
     }
 
     /**
-     * @return Method[]|Set
+     * @return Set
      * A set of all known methods with the given name
      */
     public function getMethodSetByName(string $name) : Set
@@ -320,7 +320,7 @@ class CodeBase
     }
 
     /**
-     * @return Method[]|Func[]|Set
+     * @return Set
      * The set of all methods and functions
      */
     public function getFunctionAndMethodSet() : Set
@@ -380,7 +380,7 @@ class CodeBase
     }
 
     /**
-     * @return Map|Func[]
+     * @return Map
      */
     public function getFunctionMap() : Map
     {
@@ -475,7 +475,7 @@ class CodeBase
     }
 
     /**
-     * @return Map|GlobalConstant[]
+     * @return Map
      */
     public function getGlobalConstantMap() : Map
     {
@@ -569,7 +569,7 @@ class CodeBase
     }
 
     /**
-     * @return Map|ClassMap[]
+     * @return Map
      */
     public function getClassMapMap() : Map
     {

--- a/src/Phan/Language/Element/ClassElement.php
+++ b/src/Phan/Language/Element/ClassElement.php
@@ -36,7 +36,7 @@ abstract class ClassElement extends AddressableElement
     }
 
     /**
-     * @return FullyQualifiedClassElement
+     * @return FullyQualifiedClassName
      * The FQSEN of this class element from where it was
      * originally defined
      */

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -374,7 +374,7 @@ class Clazz extends AddressableElement
     }
 
     /**
-     * @return FQSEN
+     * @return FullyQualifiedClassName
      * The parent class of this class if one exists
      *
      * @throws \Exception

--- a/src/Phan/Language/Element/Func.php
+++ b/src/Phan/Language/Element/Func.php
@@ -248,7 +248,7 @@ class Func extends AddressableElement implements FunctionInterface
     }
 
     /**
-     * @return Func[]|\Generator
+     * @return \Generator
      * The set of all alternates to this function
      */
     public function alternateGenerator(CodeBase $code_base) : \Generator {

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -122,13 +122,13 @@ interface FunctionInterface extends AddressableElementInterface {
     public function appendParameter(Parameter $parameter);
 
     /**
-     * @return FunctionInterface[]|\Generator
+     * @return \Generator
      * The set of all alternates to this function
      */
     public function alternateGenerator(CodeBase $code_base) : \Generator;
 
     /**
-     * @return void
+     * @return Context
      * Analyze the node associated with this object
      * in the given context
      */

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -254,7 +254,7 @@ class Method extends ClassElement implements FunctionInterface
         }
 
         // Pull out the method return type
-        $return_type_hint = UnionType::fromNode(
+        $return_type = UnionType::fromNode(
             $context,
             $code_base,
             $node->children['returnType']
@@ -280,13 +280,9 @@ class Method extends ClassElement implements FunctionInterface
             }
 
             // Check that the comment return type matches the method return type
-            // Note: A comment may specifiy a 'narrowed' array type and still
+            // Note: A comment may specify a 'narrowed' array type and still
             // match, e.g. @return SomeType[] matches fn() : array {}
-            if ($return_type_hint->isEmpty() ||
-                $comment_return_type->isEqualTo($return_type_hint) ||
-                $comment_return_type->isNarrowedArrayFormOf($return_type_hint) ||
-                $comment_return_type->isStaticFormOf($return_type_hint, $context)) {
-
+            if ($comment_return_type->isEquivalentToReturnType($return_type, $context)) {
                 $method->getUnionType()->addUnionType($comment_return_type);
             } else {
                 Issue::maybeEmit(
@@ -294,14 +290,14 @@ class Method extends ClassElement implements FunctionInterface
                     $context,
                     Issue::TypeMismatchReturn,
                     $node->lineno ?? 0,
-                    (string)$return_type_hint,
+                    (string)$return_type,
                     $method->getName(),
                     (string)$comment_return_type
                 );
             }
 
         } else {
-            $method->getUnionType()->addUnionType($return_type_hint);
+            $method->getUnionType()->addUnionType($return_type);
         }
 
         // Add params to local scope for user functions

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -9,6 +9,7 @@ use Phan\Language\FQSEN;
 use Phan\Language\FQSEN\FullyQualifiedMethodName;
 use Phan\Language\Scope\FunctionLikeScope;
 use Phan\Language\Type;
+use Phan\Language\Type\ArrayType;
 use Phan\Language\Type\NullType;
 use Phan\Language\UnionType;
 use ast\Node;
@@ -252,24 +253,18 @@ class Method extends ClassElement implements FunctionInterface
             $method->setNumberOfRequiredParameters(0);
         }
 
-        // Take a look at method return types
-        if($node->children['returnType'] !== null) {
-            // Get the type of the parameter
-            $union_type = UnionType::fromNode(
-                $context,
-                $code_base,
-                $node->children['returnType']
-            );
+        // Pull out the method return type
+        $return_type_hint = UnionType::fromNode(
+            $context,
+            $code_base,
+            $node->children['returnType']
+        );
 
-            $method->getUnionType()->addUnionType($union_type);
-        }
-
+        // See if we have a return type specified in the comment
         if ($comment->hasReturnUnionType()) {
+            $comment_return_type = $comment->getReturnType();
 
-            // See if we have a return type specified in the comment
-            $union_type = $comment->getReturnType();
-
-            if ($union_type->hasSelfType()) {
+            if ($comment_return_type->hasSelfType()) {
                 // We can't actually figure out 'static' at this
                 // point, but fill it in regardless. It will be partially
                 // correct
@@ -278,13 +273,35 @@ class Method extends ClassElement implements FunctionInterface
                     //       or $this in the type because I'm guessing
                     //       it doesn't really matter. Apologies if it
                     //       ends up being an issue.
-                    $union_type->addUnionType(
+                    $comment_return_type->addUnionType(
                         $context->getClassFQSEN()->asUnionType()
                     );
                 }
             }
 
-            $method->getUnionType()->addUnionType($union_type);
+            // Check that the comment return type matches the method return type
+            // Note: A comment may specifiy a 'narrowed' array type and still
+            // match, e.g. @return SomeType[] matches fn() : array {}
+            if ($return_type_hint->isEmpty() ||
+                $comment_return_type->isEqualTo($return_type_hint) ||
+                $comment_return_type->isNarrowedArrayFormOf($return_type_hint) ||
+                $comment_return_type->isStaticFormOf($return_type_hint, $context)) {
+
+                $method->getUnionType()->addUnionType($comment_return_type);
+            } else {
+                Issue::maybeEmit(
+                    $code_base,
+                    $context,
+                    Issue::TypeMismatchReturn,
+                    $node->lineno ?? 0,
+                    (string)$return_type_hint,
+                    $method->getName(),
+                    (string)$comment_return_type
+                );
+            }
+
+        } else {
+            $method->getUnionType()->addUnionType($return_type_hint);
         }
 
         // Add params to local scope for user functions

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -419,7 +419,7 @@ class Method extends ClassElement implements FunctionInterface
     }
 
     /**
-     * @return Method[]|\Generator
+     * @return \Generator
      * The set of all alternates to this method
      */
     public function alternateGenerator(CodeBase $code_base) : \Generator {
@@ -441,7 +441,7 @@ class Method extends ClassElement implements FunctionInterface
      */
     public function getOverriddenMethod(
         CodeBase $code_base
-    ) : ClassElement {
+    ) : Method {
         // Get the class that defines this method
         $class = $this->getClass($code_base);
 

--- a/src/Phan/Language/FQSEN/Alternatives.php
+++ b/src/Phan/Language/FQSEN/Alternatives.php
@@ -66,7 +66,7 @@ trait Alternatives
     }
 
     /**
-     * @return FQSEN
+     * @return static
      * A FQSEN with the given alternate_id set
      */
     abstract public function withAlternateId(

--- a/src/Phan/Language/FileRef.php
+++ b/src/Phan/Language/FileRef.php
@@ -33,7 +33,7 @@ class FileRef implements \Serializable
      * @param string $file
      * The path to the file in which this element is defined
      *
-     * @return Context
+     * @return static
      * This context with the given value is returned
      */
     public function withFile(string $file) : FileRef
@@ -89,7 +89,7 @@ class FileRef implements \Serializable
      * @var int $line_number
      * The starting line number of the element within the file
      *
-     * @return Context
+     * @return static
      * This context with the given value is returned
      */
     public function withLineNumberStart(int $line_number) : FileRef
@@ -111,7 +111,7 @@ class FileRef implements \Serializable
      * @param int $line_number
      * The ending line number of the element within the $file
      *
-     * @return Context
+     * @return static
      * This context with the given value is returned
      */
     public function withLineNumberEnd(int $line_number) : FileRef

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -316,7 +316,7 @@ class Type
      * The context in which the type string was
      * found
      *
-     * @return UnionType
+     * @return Type
      */
     public static function fromFullyQualifiedString(
         string $fully_qualified_string

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -540,6 +540,32 @@ class UnionType implements \Serializable
     }
 
     /**
+     * @return bool
+     * True iff this union contains only generic array types and the given union
+     * type is an array.
+     */
+    public function isNarrowedArrayFormOf(UnionType $union_type) : bool
+    {
+        return $this->isGenericArray() &&
+               $union_type->typeCount() === 1 &&
+               $union_type->hasType(ArrayType::instance());
+    }
+
+    /**
+     * @return bool
+     * True iff this union contains only a static type and the given union type
+     * type is the class the static type was referenced in.
+     */
+    public function isStaticFormOf(UnionType $union_type, Context $context) : bool {
+        $resolved = $this->withStaticResolvedInContext($context);
+
+        return $this->typeCount() === 1 &&
+               $this->hasStaticType() &&
+               $union_type->isEqualTo($resolved);
+    }
+
+
+    /**
      * @param Type[] $type_list
      * A list of types
      *

--- a/tests/files/expected/0214_matching_return_types.php.expected
+++ b/tests/files/expected/0214_matching_return_types.php.expected
@@ -1,0 +1,2 @@
+%s:8 PhanTypeMismatchReturn Returning type int but returnInt() is declared to return string
+%s:40 PhanTypeMismatchReturn Returning type \A but returnA() is declared to return \B

--- a/tests/files/expected/0214_matching_return_types.php.expected
+++ b/tests/files/expected/0214_matching_return_types.php.expected
@@ -1,2 +1,3 @@
 %s:8 PhanTypeMismatchReturn Returning type int but returnInt() is declared to return string
 %s:40 PhanTypeMismatchReturn Returning type \A but returnA() is declared to return \B
+%s:47 PhanTypeMismatchReturn Returning type \B but returnB() is declared to return \A

--- a/tests/files/src/0214_matching_return_types.php
+++ b/tests/files/src/0214_matching_return_types.php
@@ -1,0 +1,44 @@
+<?php
+
+class A {
+
+    /**
+     * @return string
+     */
+    public function returnInt() : int {
+        return 7;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function returnStringArray() : array {
+        return array('a', 'b', 'c');
+    }
+
+    /**
+     * @return $this
+     */
+    public function returnThis() : A {
+        return $this;
+    }
+
+    /**
+     * @return static
+     */
+    public static function makeStatic() : A {
+        return new static();
+    }
+
+}
+
+class B extends A {
+
+    /**
+     * @return B
+     */
+    public function returnA() : A {
+        return new B;
+    }
+
+}

--- a/tests/files/src/0214_matching_return_types.php
+++ b/tests/files/src/0214_matching_return_types.php
@@ -41,4 +41,11 @@ class B extends A {
         return new B;
     }
 
+    /**
+     * @return A
+     */
+    public function returnB() : B {
+        return new B;
+    }
+
 }


### PR DESCRIPTION
This change makes Phan check that the return type specified in a docblock matches the type in a PHP7+ return type hint. Previously return types were simply unioned together, meaning some specificity may have been lost in the case where a function returns `SomeType[]` but the return type hint is simply `array`.

The new logic for checking return types is as follows:
- if either is missing, use the one that exists, or none if both are missing
- if both exist, the comment return type must either:
  - strictly match
  - be a narrower array form (`SomeType[]` and `array`)
  - be `static` with a return type hint that matches the class

Included in this change are a number of fixes to the Phan codebase itself. There are three remaining `PhanTypeMismatchReturn` issues:

```
src/Phan/Language/Element/Clazz.php:1519 PhanTypeMismatchReturn Returning type \Phan\Language\Type\TemplateType[] but getTemplateTypeMap() is declared to return \Phan\Language\Element\TemplateType[]
src/Phan/Language/FQSEN/Alternatives.php:72 PhanTypeMismatchReturn Returning type \Phan\Language\FQSEN but withAlternateId() is declared to return static
src/Phan/Language/FQSEN/Alternatives.php:81 PhanTypeMismatchReturn Returning type \Phan\Language\FQSEN but getCanonicalFQSEN() is declared to return static
```

I believe the issue in `Clazz` is due to Phan using the current namespace (`\Phan\Language\Element`) and assuming it means `@return \Phan\Language\Element\TemplateType` (which does not exist). This can be solved by adding a `use Phan\Language\Type\TemplateType;` but I feel like this may be a bug.

The two `FQSEN\Alternatives` issues are due to the methods declaring they return `FQSEN` and `@return static`, but as it is a Trait I don't think it can actually make those guarantees.
