### PR TITLE
Handle aliased namespaces correctly

### DIFF
--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -414,14 +414,20 @@ class Type
         // Gotta check this before checking for native types
         // because there are monsters out there that will
         // remap the names via things like `use \Foo\String`.
+        $non_generic_partially_qualified_array_type_name =
+            $non_generic_array_type_name;
+        if ($namespace) {
+            $non_generic_partially_qualified_array_type_name =
+                $namespace . '\\' . $non_generic_partially_qualified_array_type_name;
+        }
         if ($context->hasNamespaceMapFor(
             T_CLASS,
-            $non_generic_array_type_name
+            $non_generic_partially_qualified_array_type_name
         )) {
             $fqsen =
                 $context->getNamespaceMapFor(
                     T_CLASS,
-                    $non_generic_array_type_name
+                    $non_generic_partially_qualified_array_type_name
                 );
 
             if ($is_generic_array_type) {

--- a/tests/files/src/0136_alias_with_suffix.php
+++ b/tests/files/src/0136_alias_with_suffix.php
@@ -8,7 +8,7 @@ namespace NS2 {
     }
 }
 
-namespace NS\C {
+namespace NS2\C {
     class D {
         const STATUS = 1;
         public function f() {


### PR DESCRIPTION
Aliased namespaces were not being handled correctly, per issue #329.
This was broken in 1121ab9. This seems to have snuck in due to an
incorrect test. The expectation for 0136_alias_with_suffix.php claimed
to have no issues, but running the file through php results in:

  PHP Fatal error:  Uncaught Error: Class 'NS2\C\D' not found in ...

Patch adjusts the test to be correct, and makes the necessary update in
Type.php to pass through the namespace prefix so that the alias is
properly resolved.

Fixes #329