### PR TITLE
Allow detecting superglobals declared by runkit.

### DIFF
--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -306,6 +306,10 @@ class Config
             // 'PhanVariableUseClause',
         ],
 
+        // A custom list of additional superglobals, for projects using runkit.
+        // (E.g. ['_FOO']) // (Declared in runkit.superglobal ini directive)
+        'runkit_superglobals' => [],
+
         // Emit issue messages with markdown formatting
         'markdown_issue_messages' => false,
 

--- a/src/Phan/Language/Element/Variable.php
+++ b/src/Phan/Language/Element/Variable.php
@@ -3,6 +3,7 @@ namespace Phan\Language\Element;
 
 use Phan\AST\ContextNode;
 use Phan\CodeBase;
+use Phan\Config;
 use Phan\Language\Context;
 use Phan\Language\UnionType;
 use ast\Node;
@@ -110,7 +111,7 @@ class Variable extends TypedElement
     public static function isSuperglobalVariableWithName(
         string $name
     ) : bool {
-        return in_array($name, [
+        if (in_array($name, [
             'argv',
             'argc',
             '_GET',
@@ -123,7 +124,10 @@ class Variable extends TypedElement
             '_SESSION',
             'GLOBALS',
             'http_response_header' // Revisit when we implement sub-block type refining
-        ]);
+        ])) {
+            return true;
+        }
+        return in_array($name, Config::get()->runkit_superglobals ?? []);
     }
 
     public function __toString() : string


### PR DESCRIPTION
The `runkit.superglobal` directive allows declaring a comma-separated
list of user-defined superglobals.
It is used by people who want to add their own superglobals, e.g. 
http://stackoverflow.com/questions/834491/create-superglobal-variables-in-php

The function `runkit_superglobals` returns an array of superglobals,
including custom ones.
e.g. 'runkit.superglobal=_MYSUPERGLOBAL' would result in

["GLOBALS","_GET","_POST","_COOKIE","_SERVER","_ENV","_REQUEST","_FILES",
"_SESSION", "_MYSUPERGLOBAL"]

Support for superglobals is also implemented in the runkit7/runkit7 fork. 
Example usage is https://github.com/runkit7/runkit7/blob/master/tests/runkit_superglobals.phpt
Also see http://php.net/manual/en/runkit.configuration.php#ini.runkit.superglobal

Also, is there a suggested way to annotate that a global is expected to be a certain type ($_GET is an array, $_MYGLOBAL is an instance of MyClass)