### PR TITLE
Allow scope resolution operator to select overwritten method.

### DIFF
--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -995,11 +995,11 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                         || ($calling_method && !$calling_method->isStatic())
                     )
 
-                // Allow static calls to methods from within the constructor
+                // Allow static calls to methods from non-static class methods
                 ) && !(
                     $this->context->isInClassScope()
                     && $this->context->isInFunctionLikeScope()
-                    && $this->context->getFunctionLikeFQSEN()->getName() == '__construct'
+	                && ($calling_method && !$calling_method->isStatic())
                 // Allow static calls parent methods from closure
                 ) && !(
                     $this->context->isInClassScope()

--- a/tests/files/src/0143_nonstaticcalls.php
+++ b/tests/files/src/0143_nonstaticcalls.php
@@ -32,11 +32,11 @@ namespace NS2
     class C extends B
     {
     	public function __construct()
-	    {
-	    	$this->callStatics();
-	    }
+        {
+            $this->callStatics();
+        }
 
-		public function callStatics()
+        public function callStatics()
         {
             self::callNonStaticMethod();
             static::callNonStaticMethod();

--- a/tests/files/src/0143_nonstaticcalls.php
+++ b/tests/files/src/0143_nonstaticcalls.php
@@ -31,7 +31,12 @@ namespace NS2
 
     class C extends B
     {
-        public function __construct()
+    	public function __construct()
+	    {
+	    	$this->callStatics();
+	    }
+
+	    public function callStatics()
         {
             self::callNonStaticMethod();
             static::callNonStaticMethod();
@@ -48,5 +53,6 @@ namespace
 
     new NS1\A();
     new NS2\B();
-    new NS2\C();
+    $c = new NS2\C();
+	$c->callStatics();
 }

--- a/tests/files/src/0143_nonstaticcalls.php
+++ b/tests/files/src/0143_nonstaticcalls.php
@@ -36,7 +36,7 @@ namespace NS2
 	    	$this->callStatics();
 	    }
 
-	    public function callStatics()
+		public function callStatics()
         {
             self::callNonStaticMethod();
             static::callNonStaticMethod();


### PR DESCRIPTION
https://github.com/php/php-langspec/blob/master/spec/10-expressions.md#scope-resolution-operator

"Inside of the object context when $this is defined and the called method is not static and the called class is the same of a parent of the class of $this, then the method is non-static with the same $this. Otherwise it is a static method call."

So technically this isn't about allowing static call to methods (from within the constructor), but selecting (overwritten) methods from a non-static method in object context using the scope resolution operator.

So drop the __construct check and verifiy the calling method isn't static.