### PR TITLE
Report signature mismatch when overridden method misses argument with default value.

### DIFF
--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -173,7 +173,7 @@ class ParameterTypesAnalyzer
         ) {
             $signatures_match = false;
         } else if ($method->getNumberOfParameters()
-            < $o_method->getNumberOfRequiredParameters()
+            < $o_method->getNumberOfParameters()
         ) {
             $signatures_match = false;
 

--- a/tests/files/expected/0124_override_signature.php.expected
+++ b/tests/files/expected/0124_override_signature.php.expected
@@ -3,4 +3,5 @@
 %s:15 PhanParamSignatureMismatch Declaration of function f(string $a) should be compatible with function f(int $a) defined in %s:3
 %s:18 PhanParamSignatureMismatch Declaration of function f($a) should be compatible with function f(int $a) defined in %s:3
 %s:25 PhanParamSignatureMismatch Declaration of function g() : int should be compatible with function g() : string defined in %s:22
+%s:50 PhanParamSignatureMismatch Declaration of function i($a) should be compatible with function i($a, string $b = null) defined in %s:46
 

--- a/tests/files/src/0124_override_signature.php
+++ b/tests/files/src/0124_override_signature.php
@@ -41,3 +41,11 @@ class C12 {
 class C13 extends C12 {
     public function __construct(string $b, bool $c) {}
 }
+
+class C14 {
+    public function i($a, $b = 'default') {}
+}
+
+class C15 extends C14 {
+    public function i($a) {}
+}


### PR DESCRIPTION
See https://3v4l.org/KHIhb

```php
class C14 {
    public function i($a, $b = 'default') {}
}

class C15 extends C14 {
    public function i($a) {}
}
```

This code on php7 emits warning:
```
Warning: Declaration of C15::i($a) should be compatible with C14::i($a, $b = 'default') in /in/KHIhb on line 9
```

We should report it as signature mismatch.