### PR TITLE
Report signature mismatch when overridden method doesn't return reference.

### DIFF
--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -249,6 +249,11 @@ class ParameterTypesAnalyzer
             }
         }
 
+
+        if ($o_method->returnsRef() && !$method->returnsRef()) {
+            $signatures_match = false;
+        }
+
         if (!$signatures_match) {
             if ($o_method->isInternal()) {
                 Issue::maybeEmit(

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -69,12 +69,23 @@ class Method extends ClassElement implements FunctionInterface
 
     /**
      * @return bool
-     * True if this is an abstract class
+     * True if this is an abstract method
      */
     public function isAbstract() : bool {
         return Flags::bitVectorHasState(
             $this->getFlags(),
             \ast\flags\MODIFIER_ABSTRACT
+        );
+    }
+
+    /**
+     * @return bool
+     * True if this method returns reference
+     */
+    public function returnsRef() : bool {
+        return Flags::bitVectorHasState(
+            $this->getFlags(),
+            \ast\flags\RETURNS_REF
         );
     }
 
@@ -459,7 +470,11 @@ class Method extends ClassElement implements FunctionInterface
     public function __toString() : string {
         $string = '';
 
-        $string .= 'function ' . $this->getName();
+        $string .= 'function ';
+        if ($this->returnsRef()) {
+            $string .= '&';
+        }
+        $string .= $this->getName();
 
         $string .= '(' . implode(', ', $this->getParameterList()) . ')';
 

--- a/tests/files/expected/0124_override_signature.php.expected
+++ b/tests/files/expected/0124_override_signature.php.expected
@@ -3,4 +3,5 @@
 %s:15 PhanParamSignatureMismatch Declaration of function f(string $a) should be compatible with function f(int $a) defined in %s:3
 %s:18 PhanParamSignatureMismatch Declaration of function f($a) should be compatible with function f(int $a) defined in %s:3
 %s:25 PhanParamSignatureMismatch Declaration of function g() : int should be compatible with function g() : string defined in %s:22
+%s:50 PhanParamSignatureMismatch Declaration of function j() should be compatible with function &j() defined in %s:46
 

--- a/tests/files/src/0124_override_signature.php
+++ b/tests/files/src/0124_override_signature.php
@@ -41,3 +41,11 @@ class C12 {
 class C13 extends C12 {
     public function __construct(string $b, bool $c) {}
 }
+
+class C16 {
+    public function &j() {}
+}
+
+class C17 extends C16 {
+    public function j() {}
+}


### PR DESCRIPTION
See https://3v4l.org/k7UBK

```php
class C16 {
    public function &j() {}
}

class C17 extends C16 {
    public function j() {}
}
```

This code produce warning on php7 and strict error on php5.6:
```
Warning: Declaration of C17::j() should be compatible with & C16::j() in /in/k7UBK on line 9
```

We should report it as method signature mismatch