### PR TITLE
Report signature mismatch when overridden method modifies pass-by-reference for its parameters

### DIFF
--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -187,6 +187,13 @@ class ParameterTypesAnalyzer
 
                 $o_parameter = $o_parameter_list[$i];
 
+                // Changing pass by reference is not ok
+                // @see https://3v4l.org/Utuo8
+                if ($parameter->isPassByReference() != $o_parameter->isPassByReference()) {
+                    $signatures_match = false;
+                    break;
+                }
+
                 // A stricter type on an overriding method is cool
                 if ($o_parameter->getUnionType()->isEmpty()
                     || $o_parameter->getUnionType()->isType(MixedType::instance())

--- a/tests/files/expected/0124_override_signature.php.expected
+++ b/tests/files/expected/0124_override_signature.php.expected
@@ -3,4 +3,6 @@
 %s:15 PhanParamSignatureMismatch Declaration of function f(string $a) should be compatible with function f(int $a) defined in %s:3
 %s:18 PhanParamSignatureMismatch Declaration of function f($a) should be compatible with function f(int $a) defined in %s:3
 %s:25 PhanParamSignatureMismatch Declaration of function g() : int should be compatible with function g() : string defined in %s:22
+%s:51 PhanParamSignatureMismatch Declaration of function k(&$a) should be compatible with function k($a) defined in %s:46
+%s:52 PhanParamSignatureMismatch Declaration of function l($b) should be compatible with function l(&$b) defined in %s:47
 

--- a/tests/files/src/0124_override_signature.php
+++ b/tests/files/src/0124_override_signature.php
@@ -41,3 +41,13 @@ class C12 {
 class C13 extends C12 {
     public function __construct(string $b, bool $c) {}
 }
+
+class C18 {
+    public function k($a) {}
+    public function l(&$b) {}
+}
+
+class C19 extends C18 {
+    public function k(&$a) {}
+    public function l($b) {}
+}


### PR DESCRIPTION
See https://3v4l.org/Utuo8

```php
class C18 {
    public function k($a) {}
    public function l(&$b) {}
}

class C19 extends C18 {
    public function k(&$a) {}
    public function l($b) {}
}
```

This code gives warning on php7 and strict message on php5.6:
```
Warning: Declaration of C19::k(&$a) should be compatible with C18::k($a) in /in/Utuo8 on line 11

Warning: Declaration of C19::l($b) should be compatible with C18::l(&$b) in /in/Utuo8 on line 11
```

We should report it as method signature mismatch.