### PR TITLE
Report signature mismatch when overridden method has more required parameters

### DIFF
--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -169,7 +169,7 @@ class ParameterTypesAnalyzer
 
         // Make sure the count of parameters matches
         if ($method->getNumberOfRequiredParameters()
-            > $o_method->getNumberOfParameters()
+            > $o_method->getNumberOfRequiredParameters()
         ) {
             $signatures_match = false;
         } else if ($method->getNumberOfParameters()

--- a/tests/files/expected/0124_override_signature.php.expected
+++ b/tests/files/expected/0124_override_signature.php.expected
@@ -7,3 +7,4 @@
 %s:58 PhanParamSignatureMismatch Declaration of function j() should be compatible with function &j() defined in %s:54
 %s:67 PhanParamSignatureMismatch Declaration of function k(&$a) should be compatible with function k($a) defined in %s:62
 %s:68 PhanParamSignatureMismatch Declaration of function l($b) should be compatible with function l(&$b) defined in %s:63
+%s:76 PhanParamSignatureMismatch Declaration of function m($a) should be compatible with function m($a = null) defined in %s:72

--- a/tests/files/src/0124_override_signature.php
+++ b/tests/files/src/0124_override_signature.php
@@ -67,3 +67,11 @@ class C19 extends C18 {
     public function k(&$a) {}
     public function l($b) {}
 }
+
+class C20 {
+    public function m($a = null) {}
+}
+
+class C21 extends C20 {
+    public function m($a) {}
+}


### PR DESCRIPTION
See https://3v4l.org/XI9Nq

This code produces warning on php 7 and strict standards message:
```php
class Base {
    public function test($a = null) {}
}
class Child extends Base {
    public function test($a) {}
}
```
```
Warning: Declaration of Child::test($a) should be compatible with Base::test($a = NULL) in /in/XI9Nq on line 9
```

We should report it as signature mismatch as well.