### PR TITLE
Improve the way phan parses varargs parameters as arrays

### DIFF
--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -223,7 +223,7 @@ class ArgumentType
         foreach ($node->children ?? [] as $i => $argument) {
 
             // Get the parameter associated with this argument
-            $parameter = $method->getParameterList()[$i] ?? null;
+            $parameter = $method->getParameterForCaller($i);
 
             // This issue should be caught elsewhere
             if (!$parameter) {
@@ -293,13 +293,12 @@ class ArgumentType
             foreach ($method->alternateGenerator($code_base)
                 as $alternate_id => $alternate_method
             ) {
-                if (empty($alternate_method->getParameterList()[$i])) {
+                // Get the parameter associated with this argument
+                $candidate_alternate_parameter = $alternate_method->getParameterForCaller($i);
+                if (is_null($candidate_alternate_parameter)) {
                     continue;
                 }
-
-                // Get the parameter associated with this argument
-                $alternate_parameter =
-                    $alternate_method->getParameterList()[$i] ?? null;
+                $alternate_parameter = $candidate_alternate_parameter;
 
                 // See if the argument can be cast to the
                 // parameter
@@ -320,7 +319,7 @@ class ArgumentType
                     ? $alternate_parameter->getUnionType()
                     : 'unknown';
 
-                if ($parameter_type->hasTemplateType()) {
+                if (is_object($parameter_type) && $parameter_type->hasTemplateType()) {
                     // Don't worry about template types
                 } elseif ($method->isInternal()) {
                     Issue::maybeEmit(

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -626,7 +626,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
 
         // Mark the method as returning something
         $method->setHasReturn(
-            ($node->children['expr'] ?? null) !== null
+            isset($node->children['expr'])
         );
 
         return $this->context;
@@ -1486,9 +1486,12 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         // parameters
         $argument_list = $node->children['args'];
         foreach ($argument_list->children as $i => $argument) {
-            $parameter = $method->getParameterList()[$i] ?? null;
+            if (!is_object($argument)) {
+                continue;
+            }
 
-            if (!$parameter || !is_object($argument)) {
+            $parameter = $method->getParameterForCaller($i);
+            if (!$parameter) {
                 continue;
             }
 
@@ -1547,9 +1550,12 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         // Take another pass over pass-by-reference parameters
         // and assign types to passed in variables
         foreach ($argument_list->children as $i => $argument) {
-            $parameter = $method->getParameterList()[$i] ?? null;
+            if (!is_object($argument)) {
+                continue;
+            }
+            $parameter = $method->getParameterForCaller($i);
 
-            if (!$parameter || !is_object($argument)) {
+            if (!$parameter) {
                 continue;
             }
 
@@ -1604,7 +1610,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
 
                 if ($variable) {
                     $variable->getUnionType()->addUnionType(
-                        $parameter->getUnionType()
+                        $parameter->getIndividualUnionType()
                     );
                 }
             }
@@ -1637,7 +1643,10 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         $original_method_scope = $method->getInternalScope();
 
         foreach ($argument_list->children as $i => $argument) {
-            $parameter = $method->getParameterList()[$i] ?? null;
+            // TODO(Issue #376): Support inference on the child in **the set of vargs**, not just the first vararg
+            // This is just testing the first vararg.
+            // The implementer will also need to restore the original parameter list.
+            $parameter = $original_parameter_list[$i] ?? null;
 
             if (!$parameter) {
                 continue;
@@ -1645,28 +1654,29 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
 
             // If the parameter has no type, pass the
             // argument's type to it
-            if ($parameter->getUnionType()->isEmpty()) {
+            if ($parameter->getIndividualUnionType()->isEmpty()) {
                 $has_argument_parameter_mismatch = true;
-                $argument_type = UnionType::fromNode(
-                    $this->context,
-                    $this->code_base,
-                    $argument
-                );
-
                 // If this isn't an internal function or method
                 // and it has no type, add the argument's type
                 // to it so we can compare it to subsequent
                 // calls
                 if (!$parameter->isInternal()) {
+                    $argument_type = UnionType::fromNode(
+                        $this->context,
+                        $this->code_base,
+                        $argument
+                    );
+
                     // Clone the parameter in the original
                     // parameter list so we can reset it
                     // later
-                    $original_parameter_list[$i] = clone($parameter);
+                    // TODO: If there are varargs and this is beyond the end, ensure last arg is cloned.
+                    $original_parameter_list[$i] = clone($original_parameter_list[$i]);
 
                     // Then set the new type on that parameter based
                     // on the argument's type. We'll use this to
                     // retest the method with the passed in types
-                    $parameter->getUnionType()->addUnionType(
+                    $parameter->getIndividualUnionType()->addUnionType(
                         $argument_type
                     );
 
@@ -1678,7 +1688,11 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                     // we're dealing with wrapped up and shoved into
                     // the scope of the method
                     if ($parameter->isPassByReference()) {
-                        if ($argument->kind == \ast\AST_VAR) {
+                        if ($original_parameter_list[$i]->isVariadic()) {
+                            // For now, give up and work on it later.
+                            // TODO(Issue #376): It's possible to have a parameter `&...$args`. Analysing that is going to be a problem.
+                            // Is it possible to create `PassByReferenceVariableCollection extends Variable` or something similar?
+                        } elseif ($argument->kind == \ast\AST_VAR) {
                             // Get the variable
                             $variable = (new ContextNode(
                                 $this->code_base,

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1610,7 +1610,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
 
                 if ($variable) {
                     $variable->getUnionType()->addUnionType(
-                        $parameter->getIndividualUnionType()
+                        $parameter->getVariadicElementUnionType()
                     );
                 }
             }
@@ -1654,7 +1654,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
 
             // If the parameter has no type, pass the
             // argument's type to it
-            if ($parameter->getIndividualUnionType()->isEmpty()) {
+            if ($parameter->getVariadicElementUnionType()->isEmpty()) {
                 $has_argument_parameter_mismatch = true;
                 // If this isn't an internal function or method
                 // and it has no type, add the argument's type
@@ -1676,7 +1676,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                     // Then set the new type on that parameter based
                     // on the argument's type. We'll use this to
                     // retest the method with the passed in types
-                    $parameter->getIndividualUnionType()->addUnionType(
+                    $parameter->getVariadicElementUnionType()->addUnionType(
                         $argument_type
                     );
 

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -106,6 +106,17 @@ interface FunctionInterface extends AddressableElementInterface {
     public function getParameterList();
 
     /**
+     * Gets the $ith parameter for the **caller**.
+     * In the case of variadic arguments, an infinite number of parameters exist.
+     * (The callee would see variadic arguments(T ...$args) as a single variable of type T[],
+     * while the caller sees a place expecting an expression of type T.
+     *
+     * @param int $i - offset of the parameter.
+     * @return Parameter|null The parameter type that the **caller** observes.
+     */
+    public function getParameterForCaller(int $i);
+
+    /**
      * @param Parameter[] $parameter_list
      * A list of parameters to set on this method
      *

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -151,6 +151,31 @@ trait FunctionTrait {
     }
 
     /**
+     * Gets the $ith parameter for the **caller**.
+     * In the case of variadic arguments, an infinite number of parameters exist.
+     * (The callee would see variadic arguments(T ...$args) as a single variable of type T[],
+     * while the caller sees a place expecting an expression of type T.
+     *
+     * @param int $i - offset of the parameter.
+     * @return Parameter|null The parameter type that the **caller** observes.
+     */
+    public function getParameterForCaller(int $i) {
+        $list = $this->parameter_list;
+        if (count($list) === 0) {
+            return null;
+        }
+        $parameter = $list[$i] ?? null;
+        if ($parameter) {
+            return $parameter->asNonVariadic();
+        }
+        $lastParameter = $list[count($list) - 1];
+        if ($lastParameter->isVariadic()) {
+            return $lastParameter->asNonVariadic();
+        }
+        return null;
+    }
+
+    /**
      * @param Parameter[] $parameter_list
      * A list of parameters to set on this method
      *

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -296,7 +296,7 @@ class Parameter extends Variable
     }
 
     /**
-     * If this parameter is variadic, calling `getUnionType` will return an array type such as `DateTime[]`. This
+     * If this Parameter is variadic, calling `getUnionType` will return an array type such as `DateTime[]`. This
      * method will return the element type (such as `DateTime`) for variadic parameters.
      */
     public function getVariadicElementUnionType() : UnionType {

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -273,9 +273,9 @@ class Parameter extends Variable
      *
      * If this parameter is not variadic, returns $this.
      *
-     * @return Parameter (usually $this)
+     * @return static (usually $this)
      */
-    public function asNonVariadic() : Parameter
+    public function asNonVariadic()
     {
         if (!$this->isVariadic()) {
             return $this;

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -265,6 +265,16 @@ class Parameter extends Variable
         );
     }
 
+    /**
+     * Returns the Parameter in the form expected by a caller.
+     *
+     * If this parameter is variadic (e.g. `DateTime ...$args`), then this
+     * would return a parameter with the type of the elements (e.g. `DateTime`)
+     *
+     * If this parameter is not variadic, returns $this.
+     *
+     * @return Parameter (usually $this)
+     */
     public function asNonVariadic() : Parameter
     {
         if (!$this->isVariadic()) {

--- a/src/Phan/Language/Element/PassByReferenceVariable.php
+++ b/src/Phan/Language/Element/PassByReferenceVariable.php
@@ -36,6 +36,14 @@ class PassByReferenceVariable extends Variable
         return $this->parameter->getName();
     }
 
+    /**
+     * Variables can't be variadic. This is the same as getUnionType for variables, but not necessarily for subclasses.
+     * method will return the element type (such as `DateTime`) for variadic parameters.
+     */
+    public function getVariadicElementUnionType() : UnionType {
+        return $this->element->getVariadicElementUnionType();
+    }
+
     public function getUnionType() : UnionType
     {
         return $this->element->getUnionType();

--- a/src/Phan/Language/Element/Variable.php
+++ b/src/Phan/Language/Element/Variable.php
@@ -62,6 +62,15 @@ class Variable extends TypedElement
     }
 
     /**
+     * Stub for compatibility with Parameter, since we replace the Parameter with a Variable and call setParameterList in PostOrderAnalysisVisitor->visitStaticCall
+     * TODO: Should that code create a new Parameter instance instead?
+     * @return static
+     */
+    public function asNonVariadic() {
+        return $this;
+    }
+
+    /**
      * @param Node $node
      * An AST_VAR node
      *

--- a/src/Phan/Language/Element/Variable.php
+++ b/src/Phan/Language/Element/Variable.php
@@ -139,6 +139,14 @@ class Variable extends TypedElement
         return in_array($name, Config::get()->runkit_superglobals ?? []);
     }
 
+    /**
+     * Variables can't be variadic. This is the same as getUnionType for variables, but not necessarily for subclasses.
+     * method will return the element type (such as `DateTime`) for variadic parameters.
+     */
+    public function getVariadicElementUnionType() : UnionType {
+        return parent::getUnionType();
+    }
+
     public function __toString() : string
     {
         $string = '';

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -75,7 +75,7 @@ class UnionType implements \Serializable
     public static function fromFullyQualifiedString(
         string $fully_qualified_string
     ) : UnionType {
-        if (empty($fully_qualified_string)) {
+        if ($fully_qualified_string === '') {
             return new UnionType();
         }
 

--- a/tests/files/expected/0217_variadic_call_types.php.expected
+++ b/tests/files/expected/0217_variadic_call_types.php.expected
@@ -1,0 +1,7 @@
+%s:26 PhanTypeMismatchArgument Argument 5 (params) is int[] but \test_ints() takes int defined at %s:6
+%s:28 PhanTypeMismatchArgument Argument 1 (req) is string[] but \test_ints() takes string defined at %s:6
+%s:29 PhanParamTooFew Call with 0 arg(s) to \test_ints() which requires 1 arg(s) defined at %s:6
+%s:30 PhanTypeMismatchArgument Argument 2 (params) is \DateTime|\DateTimeInterface but \test_ints() takes int defined at %s:6
+%s:31 PhanTypeMismatchArgument Argument 2 (params) is int[] but \test_ints() takes int defined at %s:6
+%s:35 PhanTypeMismatchArgument Argument 1 (date_time_list) is int but \test_vararg_within_function() takes \DateTime defined at %s:9
+%s:38 PhanTypeMismatchArgument Argument 1 (a) is int[] but \accept_int() takes int defined at %s:17

--- a/tests/files/src/0217_variadic_call_types.php
+++ b/tests/files/src/0217_variadic_call_types.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @return int[]
+ */
+function test_ints(string $req, int ...$params) {
+    return $params;
+}
+function test_vararg_within_function(DateTime ...$date_time_list) : array {
+    return array_map(function (DateTime $date_time) : int {
+        return 42;
+    }, $date_time_list);
+}
+
+function accept_array(array $a) {
+}
+function accept_int(int $a) {
+}
+
+function test_misc(...$args) {
+    return $args;
+}
+
+
+test_ints('foo',2,3,4,5);
+test_ints('foo',2,3,4,[5]);
+test_ints('bar');
+test_ints(['baz']);
+test_ints();
+test_ints('baz', new DateTime());
+test_ints('abc', [2,3,4,5]);
+
+test_vararg_within_function(new DateTime());
+test_vararg_within_function();
+test_vararg_within_function(42);
+
+accept_array(test_misc(2, []));  // Correct, should infer type was array.
+accept_int(test_misc(2, []));  // Wrong
+test_ints_phpdoc(3);
+
+/**
+ * @param int[] $args - FIXME: `int[]` should probably take precedence over the explicit type `array` and make this fail.
+ * @return string[]
+ */
+function test_ints_phpdoc(...$args) {
+    return $args;
+}

--- a/tests/files/src/0217_variadic_call_types.php
+++ b/tests/files/src/0217_variadic_call_types.php
@@ -40,7 +40,7 @@ test_ints_phpdoc(3);
 
 /**
  * @param int[] $args - FIXME: `int[]` should probably take precedence over the explicit type `array` and make this fail.
- * @return string[]
+ * @return int[]
  */
 function test_ints_phpdoc(...$args) {
     return $args;


### PR DESCRIPTION
This is related to https://github.com/etsy/phan/issues/376 . It partially solves it when code is annotated with correct PHPDoc.

Some work is incomplete:

- Not planning on analyzing mixtures of references and variadic args in this PR. `function foo(&...$args){}`. That can probably be done later. (Maybe that should emit a warning)
- Previously and currently, this only analyzes the first of multiple varargs at the callee by placing them into the scope. `private function analyzeCallToMethod` in PostOrderAnalysisVisitor.
  This is slightly better than the incorrect inference
- The inferred types of individual varargs might not propogate from callee to caller right now (not sure)

Additionally, `@param T[]` varargs doesn't yet affect analysis. The type of `...$args` is inferred as `array`, and that probably takes precedence (Or getUnionType() is a temporary value, so the change doesn't take effect)

The related snippet to be changed would be

```
$comment_type =
    $comment->getParameterWithNameOrOffset(
        $parameter->getName(),
        $parameter_offset
    )->getUnionType();

// If this is varargs, this would need to convert 
// "@param int[] $varargs" to the union type for T
// "@param Traversable $varargs" (or array) to the union type for anything, etc.
// "@param int $varargs"to a phan Issue (Varargs are arrays
// and modify getInternalUnionType instead of getUnionType
$parameter->getUnionType()->addUnionType(
    $comment_type
);  
```