### PR TITLE
Disable check for camelCase variable names.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -9,6 +9,9 @@ engines:
     enabled: false
   phpmd:
     enabled: true
+    checks:
+      Controversial/CamelCaseVariableName:
+        enabled: false
   phan:
     enabled: true
     config:


### PR DESCRIPTION
The more common convention in pre-existing code and plugins
is $underscore_case. This check adds noise.

https://phpmd.org/rules/controversial.txt
https://docs.codeclimate.com/docs/disabling-individual-checks
e.g. https://github.com/xPaw/GitHub-WebHook/blob/master/.codeclimate.yml