### PR TITLE
Stricten types for analysis of superglobals, fix bug

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -82,7 +82,11 @@ return [
 
     // Override if runkit.superglobal ini directive is used.
     // See Phan\Config.
-    'runkit_superglobals_map' => [],
+    'runkit_superglobals' => [],
+
+    // Override to hardcode existence and types of (non-builtin) globals.
+    // Class names must be prefixed with '\\'.
+    'globals_type_map' => [],
 
     // The minimum severity level to report on. This can be
     // set to Issue::SEVERITY_LOW, Issue::SEVERITY_NORMAL or

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -80,6 +80,10 @@ return [
     // nodes.
     'should_visit_all_nodes' => true,
 
+    // Override if runkit.superglobal ini directive is used.
+    // See Phan\Config.
+    'runkit_superglobals_map' => [],
+
     // The minimum severity level to report on. This can be
     // set to Issue::SEVERITY_LOW, Issue::SEVERITY_NORMAL or
     // Issue::SEVERITY_CRITICAL.

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -909,7 +909,7 @@ class UnionTypeVisitor extends AnalysisVisitor
 
         if (!$this->context->getScope()->hasVariableWithName($variable_name)) {
             if (Variable::isSuperglobalVariableWithName($variable_name)) {
-                return Variable::getUnionTypeOfSuperglobalVariableWithName($variable_name, $this->context);
+                return Variable::getUnionTypeOfHardcodedGlobalVariableWithName($variable_name, $this->context);
             }
             if (!Config::get()->ignore_undeclared_variables_in_global_scope
                 || !$this->context->isInGlobalScope()

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -908,9 +908,11 @@ class UnionTypeVisitor extends AnalysisVisitor
             $node->children['name'];
 
         if (!$this->context->getScope()->hasVariableWithName($variable_name)) {
-            if (!Variable::isSuperglobalVariableWithName($variable_name)
-                && (!Config::get()->ignore_undeclared_variables_in_global_scope
-                    || !$this->context->isInGlobalScope())
+            if (Variable::isSuperglobalVariableWithName($variable_name)) {
+                return Variable::getUnionTypeOfSuperglobalVariableWithName($variable_name);
+            }
+            if (!Config::get()->ignore_undeclared_variables_in_global_scope
+                || !$this->context->isInGlobalScope()
             ) {
                 throw new IssueException(
                     Issue::fromType(Issue::UndeclaredVariable)(

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -909,7 +909,7 @@ class UnionTypeVisitor extends AnalysisVisitor
 
         if (!$this->context->getScope()->hasVariableWithName($variable_name)) {
             if (Variable::isSuperglobalVariableWithName($variable_name)) {
-                return Variable::getUnionTypeOfSuperglobalVariableWithName($variable_name);
+                return Variable::getUnionTypeOfSuperglobalVariableWithName($variable_name, $this->context);
             }
             if (!Config::get()->ignore_undeclared_variables_in_global_scope
                 || !$this->context->isInGlobalScope()

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -208,14 +208,15 @@ class AssignmentVisitor extends AnalysisVisitor
                 $node
             ))->getVariableName();
 
-            if (Variable::isSuperglobalVariableWithName($variable_name)) {
+            if ('GLOBALS' === $variable_name) {
+                // When setting $GLOBALS['a'] = 'b', ensure there is a global scope
                 $dim = $node->children['dim'];
 
                 if (is_string($dim)) {
                     // You're not going to believe this, but I just
                     // found a piece of code like $GLOBALS[mt_rand()].
                     // Super weird, right?
-                    assert(is_string($dim), "dim is not a string");
+                    // assert(is_string($dim), "dim is not a string");
 
                     $variable = new Variable(
                         $this->context,

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -210,7 +210,6 @@ class AssignmentVisitor extends AnalysisVisitor
 
             if (Variable::isSuperglobalVariableWithName($variable_name)) {
                 $dim = $node->children['dim'];
-                // When setting $GLOBALS['a'] = 'b', ensure there is a global scope
                 if ('GLOBALS' === $variable_name && is_string($dim)) {
                     // You're not going to believe this, but I just
                     // found a piece of code like $GLOBALS[mt_rand()].

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -306,9 +306,11 @@ class Config
             // 'PhanVariableUseClause',
         ],
 
-        // A custom list of additional superglobals, for projects using runkit.
-        // (E.g. ['_FOO']) // (Declared in runkit.superglobal ini directive)
-        'runkit_superglobals' => [],
+        // A custom list of additional superglobals and their types, for projects using runkit.
+        // Class names must be prefixed with '\\'.
+        // (Corresponding keys are declared in runkit.superglobal ini directive)
+        // (E.g. ['_FOO' => '\\FooClass', '_BAR' => '', '_BAT' => 'mixed', '_BAZ' => 'string[]'])
+        'runkit_superglobals_map' => [],
 
         // Emit issue messages with markdown formatting
         'markdown_issue_messages' => false,

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -306,11 +306,17 @@ class Config
             // 'PhanVariableUseClause',
         ],
 
+        // Override if runkit.superglobal ini directive is used.
         // A custom list of additional superglobals and their types, for projects using runkit.
-        // Class names must be prefixed with '\\'.
         // (Corresponding keys are declared in runkit.superglobal ini directive)
-        // (E.g. ['_FOO' => '\\FooClass', '_BAR' => '', '_BAT' => 'mixed', '_BAZ' => 'string[]'])
-        'runkit_superglobals_map' => [],
+        // global_type_map should be set for entries.
+        // E.g ['_FOO'];
+        'runkit_superglobals' => [],
+
+        // Override to hardcode existence and types of (non-builtin) globals in the global scope.
+        // Class names must be prefixed with '\\'.
+        // (E.g. ['_FOO' => '\\FooClass', 'page' => '\\PageClass', 'userId' => 'int'])
+        'globals_type_map' => [],
 
         // Emit issue messages with markdown formatting
         'markdown_issue_messages' => false,

--- a/src/Phan/Language/Element/Variable.php
+++ b/src/Phan/Language/Element/Variable.php
@@ -142,11 +142,16 @@ class Variable extends TypedElement
      * Returns null otherwise.
      */
     public static function getUnionTypeOfSuperglobalVariableWithName(
-        string $name
+        string $name,
+        Context $context
     ) {
-        $typeString = self::_BUILTIN_SUPERGLOBAL_TYPES[$name] ?? Config::get()->runkit_superglobals_map[$name] ?? null;
-        if (is_string($typeString)) {
-            return UnionType::fromFullyQualifiedString($typeString);
+        $type_string = self::_BUILTIN_SUPERGLOBAL_TYPES[$name] ?? Config::get()->runkit_superglobals_map[$name] ?? null;
+        if (is_string($type_string)) {
+            if (array_key_exists($name, self::_BUILTIN_SUPERGLOBAL_TYPES)) {
+                // More efficient than using context.
+                return UnionType::fromFullyQualifiedString($type_string);
+            }
+            return UnionType::fromStringInContext($type_string, $context);
         }
         return null;
     }

--- a/src/Phan/Language/Scope/GlobalScope.php
+++ b/src/Phan/Language/Scope/GlobalScope.php
@@ -75,6 +75,12 @@ class GlobalScope extends Scope {
      */
     public function addVariable(Variable $variable)
     {
+        $variable_name = $variable->getName();
+        if (Variable::isSuperglobalVariableWithName($variable_name)) {
+            // Silently ignore globally replacing $_POST, $argv, runkit superglobals, etc.
+            // with superglobals.,. TODO: Add a warning for incompatible assignments.
+            return;
+        }
         self::$global_variable_map[$variable->getName()] = $variable;
     }
 

--- a/src/Phan/Language/Scope/GlobalScope.php
+++ b/src/Phan/Language/Scope/GlobalScope.php
@@ -76,9 +76,10 @@ class GlobalScope extends Scope {
     public function addVariable(Variable $variable)
     {
         $variable_name = $variable->getName();
-        if (Variable::isSuperglobalVariableWithName($variable_name)) {
+        if (Variable::isHardcodedGlobalVariableWithName($variable_name)) {
             // Silently ignore globally replacing $_POST, $argv, runkit superglobals, etc.
-            // with superglobals.,. TODO: Add a warning for incompatible assignments.
+            // with superglobals.
+            // TODO: Add a warning for incompatible assignments in callers.
             return;
         }
         self::$global_variable_map[$variable->getName()] = $variable;

--- a/tests/files/expected/0219_superglobal_type_check.php.expected
+++ b/tests/files/expected/0219_superglobal_type_check.php.expected
@@ -1,0 +1,10 @@
+%s:5 PhanTypeMismatchArgumentInternal Argument 1 (string) is string[]|string[][] but \strlen() takes string
+%s:10 PhanTypeMismatchArgumentInternal Argument 1 (string) is string[] but \strlen() takes string
+%s:12 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
+%s:13 PhanTypeMismatchArgumentInternal Argument 1 (string) is string[]|string[][] but \strlen() takes string
+%s:15 PhanTypeMismatchArgumentInternal Argument 1 (string) is string[]|string[][] but \strlen() takes string
+%s:20 PhanTypeMismatchArgumentInternal Argument 1 (string) is string[] but \strlen() takes string
+%s:27 PhanTypeMismatchArgumentInternal Argument 1 (string) is array but \strlen() takes string
+%s:34 PhanTypeMismatchArgumentInternal Argument 1 (string) is int[]|int[][]|string[]|string[][] but \strlen() takes string
+%s:37 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is int[]|int[][]|string[]|string[][] but \intdiv() takes int
+%s:40 PhanTypeMismatchArgumentInternal Argument 1 (string) is null|string[] but \strlen() takes string

--- a/tests/files/expected/0220_superglobal_dim_bugs.php.expected
+++ b/tests/files/expected/0220_superglobal_dim_bugs.php.expected
@@ -1,0 +1,2 @@
+%s:7 PhanUndeclaredVariable Variable $b is undeclared
+%s:14 PhanUndeclaredVariable Variable $d is undeclared

--- a/tests/files/src/0219_superglobal_type_check.php
+++ b/tests/files/src/0219_superglobal_type_check.php
@@ -1,0 +1,46 @@
+<?php
+
+// Sanity checking phan's checks on the types of built in superglobals.
+function superglobal_sanity_check(bool $exec = false) {
+    var_dump(strlen($_POST));
+    var_dump(count($_POST));
+    var_dump(count($_GET));
+    var_dump(intdiv($argc, $argc + 1));
+    var_dump(count($argv));
+    var_dump(strlen($argv));
+    var_dump(strlen($argv[0]));  // valid
+    var_dump(intdiv($argv[0], 2));  // invalid
+    var_dump(strlen($_COOKIE));  // invalid
+    var_dump(count($_COOKIE));
+    var_dump(strlen($_REQUEST));  // invalid
+    var_dump(count($_REQUEST));
+    $_SERVER = 'foo';  // Invalid for the purpose of type checking, but still valid php.
+    var_dump(strlen($_SERVER));  // invalid
+    var_dump(count($_SERVER));
+    var_dump(strlen($_ENV));
+    var_dump(count($_ENV));
+    var_dump(count($_ENV['HOME'])); // invalid
+
+    var_dump(strlen($_ENV['HOME'])); // valid
+    var_dump(count($_ENV['HOME'])); // invalid
+
+    var_dump(strlen($GLOBALS)); // valid
+    var_dump(count($GLOBALS)); // invalid
+
+    // https://secure.php.net/manual/en/features.file-upload.post-method.php
+    // https://secure.php.net/manual/en/features.file-upload.multiple.php - Can have array of files with the same label.
+    var_dump(strlen($_FILES['foo.txt']['name'][0])); // Possibly valid
+    var_dump(strlen($_FILES['bar.txt']['name'])); // Also possibly valid
+    var_dump(strlen($_FILES['bar.txt'])); // Invalid
+    var_dump(intdiv($_FILES['foo.txt']['size'][0], 1000)); // Possibly valid. We don't actually process the file size
+    var_dump(intdiv($_FILES['bar.txt']['size'], 1000)); // Also possibly valid
+    var_dump(intdiv($_FILES['bar.txt'], 1000)); // Invalid
+    if ($exec) {
+        file_get_contents('http://127.0.0.1:1234');
+        var_export(strlen($http_response_header));  // invalid
+        var_export(strlen($http_response_header[0]));  // valid
+        var_export(count($http_response_header));  // Valid
+        $http_response_headers = null;  // Valid - Want to assert that http_response_headers being null is a valid state.
+    }
+}
+superglobal_sanity_check();

--- a/tests/files/src/0220_superglobal_dim_bugs.php
+++ b/tests/files/src/0220_superglobal_dim_bugs.php
@@ -1,0 +1,19 @@
+<?php
+
+if (isset($_GET['a'])) {
+    $_GET['b'] = $_GET['a'];
+}
+$GLOBALS['c'] = $_GET['a'];
+var_dump($b);  // $_GET does not create globals.
+var_dump($c);  // $_GLOBALS['c'] does create globals.
+
+function foo() {
+    global $e;
+    $GLOBALS['d'] = 'value';
+    $GLOBALS['e'] = 'v2';
+    var_dump($d);  // Error, didn't declare `global $d` in the function.
+    var_dump($e);
+}
+
+array_merge([], $_GET);
+foo();


### PR DESCRIPTION
Use types which are as strict as possible for built in superglobals.
Switch to manually specifying the union types of runkit superglobals.
(old `['_FOO']` is equivalent to `['_FOO' => '']`)

Also fix a bug in the fix for https://github.com/etsy/phan/issues/317
(36a29098ed64075e42031d8b29fa795dfe084919)
The expression `$_GET['a'] = 'value';` would
improperly declare a global variable $a.
Only $_GLOBALS['a'] = 'value' declares global variables.

- Now that $_GET has a declared type, it isn't guessed to be null.

The superglobal config was tested locally, with the example config entry

`  'runkit_superglobals_map' => ['_DATE' => '\\DateTime'],`

and the code

```php
function runkit_superglobal_test() {
    var_export(intdiv($_DATE, 2));
    var_export($_DATE->getTimestamp());
}
runkit_superglobal_test();
```

verified to emit a warning for using $_DATE as an integer.