### PR TITLE
Fixes #331: bugs in type checking addition of arrays

### DIFF
--- a/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
@@ -346,13 +346,13 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
         }
 
         $left_is_array = (
-            !empty($left->genericArrayElementTypes())
-            && empty($left->nonGenericArrayTypes())
+            !$left->genericArrayElementTypes()->isEmpty()
+            && $left->nonArrayTypes()->isEmpty()
         ) || $left->isType(ArrayType::instance());
 
         $right_is_array = (
-            !empty($right->genericArrayElementTypes())
-            && empty($right->nonGenericArrayTypes())
+            !$right->genericArrayElementTypes()->isEmpty()
+            && $right->nonArrayTypes()->isEmpty()
         ) || $right->isType(ArrayType::instance());
 
         if ($left_is_array

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -697,7 +697,7 @@ class Type
             Type::make('\\', 'ArrayAccess', []);
 
         return (
-            $this == ArrayType::instance()
+            $this === ArrayType::instance()
             || $this->isGenericArray()
             || $this === $array_access_type
         );

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -801,6 +801,27 @@ class UnionType implements \Serializable
     }
 
     /**
+     * Takes "a|b[]|c|d[]|e|array|ArrayAccess" and returns "a|c|e|ArrayAccess"
+     *
+     * @return UnionType
+     * A UnionType with generic types(as well as the non-generic type "array")
+     * filtered out.
+     *
+     * @see nonGenericArrayTypes
+     */
+    public function nonArrayTypes() : UnionType
+    {
+        return new UnionType(
+            $this->type_set->filter(
+                function (Type $type) : bool {
+                    return !$type->isGenericArray()
+                        && $type !== ArrayType::instance();
+                }
+            )
+        );
+    }
+
+    /**
      * @return bool
      * True if this is exclusively generic types
      */

--- a/tests/files/expected/0114_array_concatenation.php.expected
+++ b/tests/files/expected/0114_array_concatenation.php.expected
@@ -1,3 +1,3 @@
 %s:6 PhanTypeMismatchArgument Argument 1 (p) is array but \g() takes int defined at %s:5
 %s:7 PhanTypeMismatchArgument Argument 1 (p) is int[] but \g() takes int defined at %s:5
-
+%s:12 PhanTypeInvalidLeftOperand Invalid operator: right operand is array and left is not

--- a/tests/files/src/0114_array_concatenation.php
+++ b/tests/files/src/0114_array_concatenation.php
@@ -1,8 +1,12 @@
 <?php
 function f(array $v) {}
 f([1, 2] + [2, 3]);
-
+f([2] + C::$array);
 function g(int $p) {}
 g([1, 2] + ['foo', 'bar']);
 g([1, 2] + [3]);
-
+class C {
+    /** @var array */
+    public static $array = [1];
+}
+$a = 2 + C::$array;


### PR DESCRIPTION
$left_is_array was previously false for the type `int[]|array`
This makes it true.

`empty($var)` is equivalent to `(defined($var) && !$var)`
Use UnionType->isEmpty() instead.
Both of the methods of UnionType being checked never return null.

all user-defined objects are truthy,
so this check was incorrect.
(one class in a DOM library can be falsey)