### PR TITLE
Dump method signatures to a file

### DIFF
--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -60,6 +60,7 @@ class CLI
                 'dead-code-detection',
                 'directory:',
                 'dump-ast',
+                'dump-signatures-file:',
                 'exclude-directory-list:',
                 'exclude-file:',
                 'file-list-only:',
@@ -188,6 +189,9 @@ class CLI
                 case 'a':
                 case 'dump-ast':
                     Config::get()->dump_ast = true;
+                    break;
+                case 'dump-signatures-file':
+                    Config::get()->dump_signatures_file = $value;
                     break;
                 case 'o':
                 case 'output':
@@ -402,6 +406,10 @@ Usage: {$argv[0]} [options] [files...]
 
  -a, --dump-ast
   Emit an AST for each file rather than analyze
+
+ --dump-signatures-file <filename>
+  Emit JSON serialized signatures to the given file.
+  This uses a method signature format similar to FunctionSignatureMap.php.
 
  -q, --quick
   Quick mode - doesn't recurse into all function calls

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -329,6 +329,40 @@ class CodeBase
     }
 
     /**
+     * @return string[][] -
+     * A human readable encoding of $this->func_and_method_set [string $filename => [int|string $pos => string $spec]]
+     * Excludes internal functions and methods.
+     */
+    public function exportFunctionAndMethodSet() : array {
+        $result = [];
+        foreach ($this->func_and_method_set as $function_or_method) {
+            if ($function_or_method->isInternal()) {
+                continue;
+            }
+            $fqsen = $function_or_method->getFQSEN();
+            $function_or_method_name = (string)$fqsen;
+            $signature = [(string)$function_or_method->getUnionType()];
+            foreach ($function_or_method->getParameterList() as $param) {
+                $name = $param->getName();
+                $paramType = (string)$param->getUnionType();
+                if ($param->isVariadic()) {
+                    $name = '...' . $name;
+                }
+                if ($param->isPassByReference()) {
+                    $name = '&' . $name;
+                }
+                if ($param->isOptional()) {
+                    $name = $name . '=';
+                }
+                $signature[$name] = $paramType;
+            }
+            $result[$function_or_method_name] = $signature;
+        }
+        ksort($result);
+        return $result;
+    }
+
+    /**
      * @param Func $function
      * A function to add to the code base
      *

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -181,6 +181,10 @@ class Config
         // analyzing files
         'dump_ast' => false,
 
+        // If set to a string, we'll dump the fully qualified lowercase
+        // function and method signatures instead of analyzing files.
+        'dump_signatures_file' => null,
+
         // If true (and if stored_state_file_path is set) we'll
         // look at the list of files passed in and expand the list
         // to include files that depend on the given files

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -114,6 +114,10 @@ class Phan implements IgnoredFilesFilterInterface {
             exit(EXIT_SUCCESS);
         }
 
+        if (is_string(Config::get()->dump_signatures_file)) {
+            exit(self::dumpSignaturesToFile($code_base, Config::get()->dump_signatures_file));
+        }
+
         // With parsing complete, we need to tell the code base to
         // start hydrating any requested elements on their way out.
         // Hydration expands class types, imports parent methods,
@@ -308,6 +312,19 @@ class Phan implements IgnoredFilesFilterInterface {
         if ($printer instanceof BufferedPrinterInterface) {
             $printer->flush();
         }
+    }
+
+    /**
+     * Save json encoded function&method signature to a map.
+     * @return int - Exit code for process
+     */
+    private static function dumpSignaturesToFile(CodeBase $code_base, string $filename) : int {
+        $encoded_signatures = json_encode($code_base->exportFunctionAndMethodSet(), JSON_PRETTY_PRINT);
+        if (!file_put_contents($filename, $encoded_signatures)) {
+            error_log(sprintf("Could not save contents to path '%s'\n", $filename));
+            return EXIT_FAILURE;
+        }
+        return EXIT_SUCCESS;
     }
 
     /**


### PR DESCRIPTION
This is useful for other tasks using phan's inference, e.g.

- Automatically generating @property annotations based on magic __get implementation
  details.
- Editor integration?
- Debugging unexpected inferences in in Phan.