### PR TITLE
 Fix minor bugs in functions, potential bug in CallableType

### DIFF
--- a/src/Phan/Debug.php
+++ b/src/Phan/Debug.php
@@ -2,6 +2,7 @@
 namespace Phan;
 
 use ast\Node;
+use ast\Node\Decl;
 
 /**
  * Debug utilities

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -61,7 +61,7 @@ class Clazz extends AddressableElement
      * The name of the typed structural element
      *
      * @param UnionType $type,
-     * A '|' delimited set of types satisfyped by this
+     * A '|' delimited set of types satisfied by this
      * typed structural element.
      *
      * @param int $flags,

--- a/src/Phan/Language/Type/CallableType.php
+++ b/src/Phan/Language/Type/CallableType.php
@@ -8,13 +8,24 @@ class CallableType extends NativeType
     const NAME = 'callable';
 
     /**
-     * @var FQSEN
+     * @var FQSEN|null
      */
     private $fqsen;
 
+    // Same as instance(), but guaranteed not to have memoized state.
+    private static function callableInstance() : CallableType {
+        static $instance = null;
+        if (empty($instance)) {
+            $instance = self::make('\\', static::NAME, []);
+        }
+        return $instance;
+    }
+
     public static function instanceWithClosureFQSEN(FQSEN $fqsen)
     {
-        $instance = clone(self::instance());
+        // Use an instance with no memoized or lazily initialized results.
+        // Avoids picking up changes to CallableType::instance() in the case that a result depends on asFQSEN()
+        $instance = clone(self::callableInstance());
         $instance->fqsen = $fqsen;
         return $instance;
     }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -173,11 +173,7 @@ class UnionType implements \Serializable
 
         $canonical_class_name = strtolower($class_name);
 
-        if (isset($map[$canonical_class_name])) {
-            return $map[$canonical_class_name];
-        }
-
-        return [];
+        return $map[$canonical_class_name] ?? [];
     }
 
     /**


### PR DESCRIPTION
If memoization was used more heavily, CallableType::instance() may end up with
modified state in the Memoize trait's property (or elsewhere), that would be different if fqsen changed.
Not a bug at the moment.

Fix missing `use` and typo.
Use `??`