### PR TITLE
Tidy has property errorBuffer, not errorbuffer (lowercase)

### DIFF
--- a/src/Phan/Language/Internal/PropertyMap.php
+++ b/src/Phan/Language/Internal/PropertyMap.php
@@ -116,7 +116,7 @@ return [
         'code' => 'int'
     ],
     'tidy' => [
-        'errorbuffer' => 'string'
+        'errorBuffer' => 'string'
     ],
     'filteriterator' => [
         'name' => 'string'


### PR DESCRIPTION
http://php.net/manual/en/tidy.props.errorbuffer.php