### PR TITLE
Fix bugs in type checking Generators, stricten checks.

### DIFF
--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -927,6 +927,16 @@ class Clazz extends AddressableElement
                 );
             }
         }
+        if ($method->getHasYield()) {
+            // There's no phpdoc standard for template types of Generators at the moment.
+            $newType = UnionType::fromFullyQualifiedString('\\Generator');
+            $oldType = $method->getUnionType();
+            if (!$newType->canCastToType($method->getUnionType())) {
+                $method->setUnionType($newType);
+            }
+
+            $method->setUnionType();
+        }
 
         $code_base->addMethod($method);
     }

--- a/src/Phan/Language/Element/Flags.php
+++ b/src/Phan/Language/Element/Flags.php
@@ -14,6 +14,7 @@ class Flags
     const IS_RETURN_TYPE_UNDEFINED     = (1 << 04);
     const HAS_RETURN                   = (1 << 05);
     const IS_OVERRIDE                  = (1 << 06);
+    const HAS_YIELD                    = (1 << 07);
 
     /**
      * Either enable or disable the given flag on

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -90,14 +90,24 @@ interface FunctionInterface extends AddressableElementInterface {
      */
     public function getHasReturn() : bool;
     /**
-
      * @param bool $has_return
      * Set to true to mark this method as having a
-     * return value
+     * return value (Only through `return`)
      *
      * @return void
      */
     public function setHasReturn(bool $has_return);
+
+    /**
+     * @param bool $has_yield
+     * Set to true to mark this method as having a
+     * yield statement (Only through `yield`)
+     * This implies that it has a return value of \Generator.
+     * (or a parent interface)
+     *
+     * @return void
+     */
+    public function setHasYield(bool $has_return);
 
     /**
      * @return Parameter[]

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -117,12 +117,25 @@ trait FunctionTrait {
     /**
      * @return bool
      * True if this method returns a value
+     * (i.e. it has a return with an expression)
      */
     public function getHasReturn() : bool
     {
         return Flags::bitVectorHasState(
             $this->getPhanFlags(),
             Flags::HAS_RETURN
+        );
+    }
+
+    /**
+     * @return bool
+     * True if this method yields any value(i.e. it is a \Generator)
+     */
+    public function getHasYield() : bool
+    {
+        return Flags::bitVectorHasState(
+            $this->getPhanFlags(),
+            Flags::HAS_YIELD
         );
     }
 
@@ -139,6 +152,22 @@ trait FunctionTrait {
             $this->getPhanFlags(),
             Flags::HAS_RETURN,
             $has_return
+        ));
+    }
+
+    /**
+     * @param bool $has_yield
+     * Set to true to mark this method as having a
+     * yield value
+     *
+     * @return void
+     */
+    public function setHasYield(bool $has_yield)
+    {
+        $this->setPhanFlags(Flags::bitVectorWithState(
+            $this->getPhanFlags(),
+            Flags::HAS_YIELD,
+            $has_yield
         ));
     }
 

--- a/tests/files/expected/0221_generator_function_return_type.php.expected
+++ b/tests/files/expected/0221_generator_function_return_type.php.expected
@@ -1,0 +1,4 @@
+%s:4 PhanTypeMismatchReturn Returning type int but bad_generator() is declared to return \Generator
+%s:8 PhanTypeMismatchReturn Returning type int but bad_generator2() is declared to return \Iterator
+%s:12 PhanTypeMismatchReturn Returning type int but bad_generator3() is declared to return \Traversable
+%s:16 PhanTypeMismatchReturn Returning type \Generator but bad_generator4() is declared to return int

--- a/tests/files/expected/0222_generator_method_return_type.php.expected
+++ b/tests/files/expected/0222_generator_method_return_type.php.expected
@@ -1,0 +1,4 @@
+%s:5 PhanTypeMismatchReturn Returning type int but bad_generator() is declared to return \Generator
+%s:9 PhanTypeMismatchReturn Returning type int but bad_generator2() is declared to return \Iterator
+%s:13 PhanTypeMismatchReturn Returning type int but bad_generator3() is declared to return \Traversable
+%s:17 PhanTypeMismatchReturn Returning type \Generator but bad_generator4() is declared to return int

--- a/tests/files/expected/0223_generator_closure_return_type.php.expected
+++ b/tests/files/expected/0223_generator_closure_return_type.php.expected
@@ -1,0 +1,4 @@
+%s:5 PhanTypeMismatchReturn Returning type int but {closure}() is declared to return \Generator
+%s:9 PhanTypeMismatchReturn Returning type int but {closure}() is declared to return \Iterator
+%s:13 PhanTypeMismatchReturn Returning type int but {closure}() is declared to return \Traversable
+%s:17 PhanTypeMismatchReturn Returning type \Generator but {closure}() is declared to return int

--- a/tests/files/src/0221_generator_function_return_type.php
+++ b/tests/files/src/0221_generator_function_return_type.php
@@ -1,0 +1,53 @@
+<?php
+
+function bad_generator() : Generator {
+    return 1;  // Should print an error
+}
+
+function bad_generator2() : Iterator {
+    return 1;  // Should print an error
+}
+
+function bad_generator3() : Traversable {
+    return 1;  // Should print an error
+}
+
+/** @return int */
+function bad_generator4() {
+    yield;
+    return 1;  // Should print an error
+}
+
+function good_generator() : Generator {
+    yield 1;
+    return 1;
+}
+
+function good_generator2() : Generator {
+    return good_generator();
+}
+
+function good_generator3() : Traversable {
+    if (rand()) { return 1; }
+    yield;
+}
+
+/** @return Traversable */
+function good_generator3b() {
+    if (rand()) { return 1; }
+    yield;
+}
+
+function good_generator3c() : Generator {
+    if (rand()) { return 1; }
+    yield from good_generator();
+}
+
+function good_generator4() : Generator {
+    return (yield from good_generator());
+}
+
+/** @return Iterator */
+function good_generator5() {
+    yield (new stdClass());
+}

--- a/tests/files/src/0222_generator_method_return_type.php
+++ b/tests/files/src/0222_generator_method_return_type.php
@@ -1,0 +1,55 @@
+<?php
+
+class GeneratorChecks {
+    function bad_generator() : Generator {
+        return 1;  // Should print an error
+    }
+
+    function bad_generator2() : Iterator {
+        return 1;  // Should print an error
+    }
+
+    function bad_generator3() : Traversable {
+        return 1;  // Should print an error
+    }
+
+    /** @return int */
+    function bad_generator4() {
+        yield;
+        return 1;  // Should print an error
+    }
+
+    function good_generator() : Generator {
+        yield 1;
+        return 1;
+    }
+
+    function good_generator2() : Generator {
+        return self::good_generator();
+    }
+
+    function good_generator3() : Traversable {
+        if (rand()) { return 1; }
+        yield;
+    }
+
+    /** @return Traversable */
+    function good_generator3b() {
+        if (rand()) { return 1; }
+        yield;
+    }
+
+    function good_generator3c() : Generator {
+        if (rand()) { return 1; }
+        yield from self::good_generator();
+    }
+
+    function good_generator4() : Generator {
+        return (yield from self::good_generator());
+    }
+
+    /** @return Iterator */
+    function good_generator5() {
+        yield (new stdClass());
+    }
+}

--- a/tests/files/src/0223_generator_closure_return_type.php
+++ b/tests/files/src/0223_generator_closure_return_type.php
@@ -1,0 +1,55 @@
+<?php
+
+function closure_generator_tests() {
+    $bad_generator = function() : Generator {
+        return 1;  // Should print an error
+    };
+
+    $bad_generator2 = function() : Iterator {
+        return 1;  // Should print an error
+    };
+
+    $bad_generator3 = function () : Traversable {
+        return 1;  // Should print an error
+    };
+
+    /** @return int */
+    $bad_generator4 = function () {
+        yield;
+        return 1;  // Should print an error
+    };
+
+    $good_generator = function() : Generator {
+        yield 1;
+        return 1;
+    };
+
+    $good_generator2 = function() use($good_generator) : Generator {
+        return $good_generator();
+    };
+
+    $good_generator3 = function() : Traversable {
+        if (rand()) { return 1; }
+        yield;
+    };
+
+    /** @return Traversable */
+    $good_generator3b = function() {
+        if (rand()) { return 1; }
+        yield;
+    };
+
+    $good_generator3c = function() use($good_generator) : Generator {
+        if (rand()) { return 1; }
+        yield from $good_generator();
+    };
+
+    $good_generator4 = function() use($good_generator) : Generator {
+        return (yield from $good_generator());
+    };
+
+    /** @return Iterator */
+    $good_generator5 = function() {
+        yield (new stdClass());
+    };
+}


### PR DESCRIPTION
Parse the full source of the function/method/closure
**before** analyzing any return statements.
This ensures that phan will properly report buggy functions
that have an incorrect return type of `Generator` (or Traversable, or
Iterable).

It's also possible to have a `return` statement before `yield`
(`if($cond) {return; } yield;`), which the previous solution didn't handle.
(Due to the order in which PostOrderVisitor processed AST nodes)

The old code also failed to analyze the `yield from` case (`visitYieldFrom`)
    
Aside: It doesn't seem like phan will have Generator types in the near future.
https://github.com/phpDocumentor/fig-standards issue 5 discusses that
proposal.

Possibly related to #355 and #399 

E.g. the below snippet would previously pass the type checker

`function foo() : Iterator { return 1; }`