### PR TITLE
Add a config option to use consistent hashing.

### DIFF
--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -335,6 +335,13 @@ class Config
         // and fuzz testing purposes only.
         'randomize_file_order' => false,
 
+        // Setting this to true makes the process assignment for file analysis
+        // as predictable as possible, using consistent hashing.
+        // Even if files are added or removed, or process counts change,
+        // relatively few files will move to a different group.
+        // (use when the number of files is much larger than the process count)
+        'consistent_hashing_file_order' => true,
+
         // A list of plugin files to execute
         'plugins' => [
         ],

--- a/src/Phan/Library/Hasher.php
+++ b/src/Phan/Library/Hasher.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Phan\Library;
+
+/**
+ * An interface to map strings to integers representing groups.
+ * getGroup() is called exactly once on each string to be hashed.
+ */
+interface Hasher {
+    /**
+     * Returns an integer between 0 and the number of groups - 1
+     */
+    public function getGroup(string $key) : int;
+
+    /**
+     * @return void
+     * If there is any state, clear it.
+     */
+    public function reset();
+}

--- a/src/Phan/Library/Hasher/Consistent.php
+++ b/src/Phan/Library/Hasher/Consistent.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types=1);
+namespace Phan\Library\Hasher;
+
+use Phan\Library\Hasher;
+
+/**
+ * Hasher implementation mapping keys to sequential groups (first key to 0, second key to 1, looping back to 0)
+ * getGroup() is called exactly once on each string to be hashed.
+ * See https://en.wikipedia.org/wiki/Consistent_hashing
+ */
+class Consistent implements Hasher {
+    const VIRTUAL_COPY_COUNT = 16;  // Larger number means a more balanced distribution.
+    const MAX = 0x40000000;  // i.e. (1 << 30)
+    /** @var int */
+    protected $_groupCount;
+    /** @var int[] - Sorted list of hash values, for binary search. */
+    protected $_hashRingIds;
+    /** @var int[] - Groups corresponding to hash values in _hashRingIds */
+    protected $_hashRingGroups;
+
+    public function __construct(int $groupCount) {
+        $this->_groupCount = $groupCount;
+
+        $map = [];
+        for ($group = 0; $group < $groupCount; $group++) {
+            foreach (self::get_hashes_for_group($group) as $hash) {
+                $map[$hash] = $group;
+            }
+        }
+        $hashRingIds = [];
+        ksort($map);
+        foreach ($map as $key => $group) {
+            $hashRingIds[] = $key;
+            $hashRingGroups[] = $group;
+        }
+        // ... and make the map wrap around.
+        $hashRingIds[] = self::MAX - 1;
+        $hashRingGroups[] = reset($map);
+
+        $this->_hashRingIds = $hashRingIds;
+        $this->_hashRingGroups = $hashRingGroups;
+    }
+
+    /**
+     * Do a binary search in the consistent hashing ring to find the group.
+     * @return int - an integer between 0 and $this->_groupCount - 1, inclusive
+     */
+    public function getGroup(string $key) : int {
+        $searchHash = self::generate_key_hash($key);
+        $begin = 0;
+        $end = count($this->_hashRingIds) - 1;
+        while ($begin <= $end) {
+            $pos = $begin + (($end - $begin) >> 1);
+            $curVal = $this->_hashRingIds[$pos];
+            if ($searchHash > $curVal) {
+                $begin = $pos + 1;
+            } else {
+                $end = $pos - 1;
+            }
+        }
+        // Postcondition: $this->_hashRingIds[$begin] >= $searchHash, and $this->_hashRingIds[$begin - 1] does not exist or is less than $searchHash.
+
+        // Fetch the group corresponding to that hash in the hash ring.
+        return $this->_hashRingGroups[$begin];
+    }
+
+    /**
+     * No-op reset
+     * @return void
+     */
+    public function reset() { }
+
+    /**
+     * @return int[]
+     */
+    public static function get_hashes_for_group(int $group) : array {
+        $hashes = [];
+        for ($i = 0; $i < self::VIRTUAL_COPY_COUNT; $i++) {
+            $hashes[$i] = self::generate_key_hash("${i}@$group");
+        }
+        return $hashes;
+    }
+
+    /**
+     * Returns a 30-bit signed integer (i.e. in the range [0, self::MAX-1])
+     * Designed to work on 32-bit php installations as well.
+     */
+    public static function generate_key_hash(string $material) : int {
+        $bits = md5($material);
+        $result = ((intval($bits[0], 16) & 3) << 28) ^ intval(substr($bits, 1, 7), 16);
+        return $result;
+    }
+}

--- a/src/Phan/Library/Hasher/Sequential.php
+++ b/src/Phan/Library/Hasher/Sequential.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+namespace Phan\Library\Hasher;
+
+use Phan\Library\Hasher;
+
+/**
+ * Hasher implementation mapping keys to sequential groups (first key to 0, second key to 1, looping back to 0)
+ * getGroup() is called exactly once on each string to be hashed.
+ */
+class Sequential implements Hasher {
+    /** @var int */
+    protected $_i;
+    /** @var int */
+    protected $_groupCount;
+
+    public function __construct(int $groupCount) {
+        $this->_i = 1;
+        $this->_groupCount = $groupCount;
+    }
+
+    /**
+     * @return int - an integer between 0 and $this->_groupCount - 1, inclusive
+     */
+    public function getGroup(string $key) : int {
+        return ($this->_i++) % $this->_groupCount;
+    }
+
+    /**
+     * Resets counter
+     * @return void
+     */
+    public function reset() {
+        $this->_i = 1;
+    }
+}

--- a/src/Phan/Ordering.php
+++ b/src/Phan/Ordering.php
@@ -70,6 +70,8 @@ class Ordering
         // elements within that hierarchy
         $root_fqsen_list = [];
 
+        $file_names_for_classes = [];
+
         // Iterate over each class extracting files
         foreach ($this->code_base->getClassMap() as $fqsen => $class) {
 
@@ -86,7 +88,14 @@ class Ordering
                 continue;
             }
             unset($analysis_file_map[$file_name]);
+            $file_names_for_classes[$file_name] = $class;
+        }
 
+        if (Config::get()->consistent_hashing_file_order) {
+            ksort($file_names_for_classes, SORT_STRING);
+        }
+
+        foreach ($file_names_for_classes as $file_name => $class) {
             // Get the class's depth in its object hierarchy and
             // the FQSEN of the object at the root of its hierarchy
             $hierarchy_depth = $class->getHierarchyDepth($this->code_base);


### PR DESCRIPTION
This helps minimize the unpredictability of issues due to
https://github.com/etsy/phan/wiki/Different-Issue-Sets-On-Different-Numbers-of-CPUs

E.g. if the file list was A,B,C,D,F,G,H,I
Phan would previously assign A,C,F,H to group 1, and B,D,G,I to group 2.
If another file was added, e.g. E:
Phan would assign A,C,E,G,I to group 1, and B,D,F,H to group 2.
Half of the files in each group would have been swapped.
(I don't see where the file name sorting step is in Phan... is there one?)

However, with this way of sorting,
phan would (e.g.) assign A,B,G,I to group 1, and C,D,F to group 2,
and when E was added to a project, E would be added to group 1
without changing groups of other elements.
(Higher variance in files per process, but results are more predictable)
(https://en.wikipedia.org/wiki/Consistent_hashing)

Tested locally with config option enabled/disabled