### PR TITLE
Fix bug in checking for __toString method of class:

### DIFF
--- a/tests/files/expected/0225_internal_tostring_parameter_strict.php.expected
+++ b/tests/files/expected/0225_internal_tostring_parameter_strict.php.expected
@@ -1,0 +1,1 @@
+%s:5 PhanTypeMismatchArgumentInternal Argument 1 (message) is \Exception|\Throwable but \error_log() takes string

--- a/tests/files/expected/0226_internal_tostring_parameter_undeclared.php.expected
+++ b/tests/files/expected/0226_internal_tostring_parameter_undeclared.php.expected
@@ -1,0 +1,1 @@
+%s:8 PhanTypeMismatchArgumentInternal Argument 1 (message) is \urlstring but \error_log() takes string

--- a/tests/files/src/0225_internal_tostring_parameter_strict.php
+++ b/tests/files/src/0225_internal_tostring_parameter_strict.php
@@ -1,1 +1,6 @@
-0225_internal_tostring_parameter_strict.php:5 PhanTypeMismatchArgumentInternal Argument 1 (message) is \Exception|\Throwable but \error_log() takes string
+<?php declare(strict_types=1);
+try {
+    throw new Exception("message");
+} catch(\Exception $e) {
+    error_log($e);
+}

--- a/tests/files/src/0226_internal_tostring_parameter_undeclared.php
+++ b/tests/files/src/0226_internal_tostring_parameter_undeclared.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * @return urlstring
+ * @suppress PhanTypeMismatchReturn
+ */
+function foo() {return 'a';}
+
+error_log(foo());


### PR DESCRIPTION
A CodeBaseException was not caught if the class is undeclared
(e.g. due to invalid phpdoc)