### PR TITLE
Fix alternative signature for the same method not working

### DIFF
--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -868,7 +868,8 @@ class Clazz extends AddressableElement
     ) {
         $method_fqsen = FullyQualifiedMethodName::make(
             $this->getFQSEN(),
-            $method->getName()
+            $method->getName(),
+            $method->getFQSEN()->getAlternateId()
         );
 
         // Don't overwrite overridden methods with


### PR DESCRIPTION
Code:
```php
<?php
// function works fine
min([1, 2]);  // OK: 'min' => ['', 'arg1'=>'array'],
min(1, 2);    // OK: 'min\'1' => ['', 'arg1'=>'', 'arg2'=>'', '...='=>''],

$pdo = new \PDO('mysql:host=localhost;dbname=db', 'root', 'root');
$stmt = $pdo->prepare('SELECT 1');
$stmt->setFetchMode(\PDO::FETCH_BOTH);           // OK: 'PDOStatement::setFetchMode' => ['bool', 'mode'=>'int'],
$stmt->setFetchMode(\PDO::FETCH_COLUMN, 1);      // NG: 'PDOStatement::setFetchMode\'1' => ['bool', 'fetch_column'=>'int', 'colno'=>'int'],
$pdo->query('SELECT 1');                         // OK: 'PDO::query' => ['PDOStatement', 'sql'=>'string'],
$pdo->query('SELECT 1', \PDO::FETCH_COLUMN, 1);  // NG: 'PDO::query\'1' => ['PDOStatement', 'sql'=>'string', 'fetch_column'=>'int', 'colno'=>'int'],
```


Result:
```
src/test.php:9 PhanParamTooManyInternal Call with 2 arg(s) to \PDOStatement::setFetchMode() which only takes 1 arg(s)
src/test.php:11 PhanParamTooManyInternal Call with 3 arg(s) to \PDO::query() which only takes 1 arg(s)
```