### PR TITLE
Compare $node->flags against \ast\flags\USE_* instead

### DIFF
--- a/src/Phan/Analysis/ScopeVisitor.php
+++ b/src/Phan/Analysis/ScopeVisitor.php
@@ -187,6 +187,8 @@ abstract class ScopeVisitor extends AnalysisVisitor {
                     $name
                 );
             } else {
+                assert($target_node->flags == \ast\flags\USE_NORMAL,
+                    'Unknown type for a use statement');
                 $target = FullyQualifiedClassName::fromFullyQualifiedString(
                     $prefix . '\\' . $target
                 );

--- a/src/Phan/Analysis/ScopeVisitor.php
+++ b/src/Phan/Analysis/ScopeVisitor.php
@@ -172,14 +172,14 @@ abstract class ScopeVisitor extends AnalysisVisitor {
                 $target_node = $child_node;
             }
 
-            if ($target_node->flags == T_FUNCTION) {
+            if ($target_node->flags == \ast\flags\USE_FUNCTION) {
                 $parts = explode('\\', $target);
                 $function_name = array_pop($parts);
                 $target = FullyQualifiedFunctionName::make(
                     $prefix . '\\' . implode('\\', $parts),
                     $function_name
                 );
-            } else if ($target_node->flags == T_CONST) {
+            } else if ($target_node->flags == \ast\flags\USE_CONST) {
                 $parts = explode('\\', $target);
                 $name = array_pop($parts);
                 $target = FullyQualifiedGlobalConstantName::make(

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -129,11 +129,11 @@ class Context extends FileRef
         }
 
         switch ($flags) {
-        case T_CLASS:
+        case \ast\flags\USE_NORMAL:
             return FullyQualifiedClassName::fromFullyQualifiedString(
                 (string)$fqsen . '\\' . $suffix
             );
-        case T_FUNCTION:
+        case \ast\flags\USE_FUNCTION:
             return FullyQualifiedFunctionName::fromFullyQualifiedString(
                 (string)$fqsen . '\\' . $suffix
             );

--- a/src/Phan/Language/FQSEN/FullyQualifiedClassConstantName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedClassConstantName.php
@@ -9,10 +9,10 @@ class FullyQualifiedClassConstantName extends FullyQualifiedClassElement impleme
 
     /**
      * @return int
-     * The namespace map type such as T_CLASS or T_FUNCTION
+     * The namespace map type such as \ast\flags\USE_NORMAL or \ast\flags\USE_FUNCTION
      */
     protected static function getNamespaceMapType() : int
     {
-        return T_CONST;
+        return \ast\flags\USE_CONST;
     }
 }

--- a/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
@@ -14,11 +14,11 @@ class FullyQualifiedClassName extends FullyQualifiedGlobalStructuralElement
 
     /**
      * @return int
-     * The namespace map type such as T_CLASS or T_FUNCTION
+     * The namespace map type such as \ast\flags\USE_NORMAL or \ast\flags\USE_FUNCTION
      */
     protected static function getNamespaceMapType() : int
     {
-        return T_CLASS;
+        return \ast\flags\USE_NORMAL;
     }
 
     /**

--- a/src/Phan/Language/FQSEN/FullyQualifiedFunctionName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedFunctionName.php
@@ -12,11 +12,11 @@ class FullyQualifiedFunctionName extends FullyQualifiedGlobalStructuralElement
 
     /**
      * @return int
-     * The namespace map type such as T_CLASS or T_FUNCTION
+     * The namespace map type such as \ast\flags\USE_NORMAL or \ast\flags\USE_FUNCTION
      */
     protected static function getNamespaceMapType() : int
     {
-        return T_FUNCTION;
+        return \ast\flags\USE_FUNCTION;
     }
 
     /**

--- a/src/Phan/Language/FQSEN/FullyQualifiedGlobalConstantName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedGlobalConstantName.php
@@ -8,10 +8,10 @@ class FullyQualifiedGlobalConstantName extends FullyQualifiedGlobalStructuralEle
 {
     /**
      * @return int
-     * The namespace map type such as T_CLASS or T_FUNCTION
+     * The namespace map type such as \ast\flags\USE_NORMAL or \ast\flags\USE_FUNCTION
      */
     protected static function getNamespaceMapType() : int
     {
-        return T_CONST;
+        return \ast\flags\USE_CONST;
     }
 }

--- a/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
@@ -196,7 +196,7 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
 
     /**
      * @return int
-     * The namespace map type such as T_CLASS or T_FUNCTION
+     * The namespace map type such as \ast\flags\USE_NORMAL or \ast\flags\USE_FUNCTION
      */
     abstract protected static function getNamespaceMapType() : int;
 

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -421,12 +421,12 @@ class Type
                 $namespace . '\\' . $non_generic_partially_qualified_array_type_name;
         }
         if ($context->hasNamespaceMapFor(
-            T_CLASS,
+            \ast\flags\USE_NORMAL,
             $non_generic_partially_qualified_array_type_name
         )) {
             $fqsen =
                 $context->getNamespaceMapFor(
-                    T_CLASS,
+                    \ast\flags\USE_NORMAL,
                     $non_generic_partially_qualified_array_type_name
                 );
 

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -153,13 +153,13 @@ class ParseVisitor extends ScopeVisitor
             // Check to see if the name isn't fully qualified
             if ($node->children['extends']->flags & \ast\flags\NAME_NOT_FQ) {
                 if ($this->context->hasNamespaceMapFor(
-                    T_CLASS,
+                    \ast\flags\USE_NORMAL,
                     $parent_class_name
                 )) {
                     // Get a fully-qualified name
                     $parent_class_name =
                         (string)($this->context->getNamespaceMapFor(
-                            T_CLASS,
+                            \ast\flags\USE_NORMAL,
                             $parent_class_name
                         ));
                 } else {


### PR DESCRIPTION
The check if $node->flags was T_* (for a use statement)
is the only use which seems like it would be buggy in 7.2

Use the same constants everywhere just to be consistent.

Fixes #420