### PR TITLE
Generalize check if class can have arbitrary properties

### DIFF
--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -547,12 +547,9 @@ class ContextNode
             return $property;
         }
 
-        $std_class_fqsen =
-            FullyQualifiedClassName::getStdClassFQSEN();
-
         // If missing properties are cool, create it on
         // the first class we found
-        if (($class_fqsen && ($class_fqsen === $std_class_fqsen))
+        if (($class_fqsen && FullyQualifiedClassName::isClassWithDynamicProperties($class_fqsen))
             || Config::get()->allow_missing_properties
         ) {
             if (count($class_list) > 0) {

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -12,6 +12,7 @@ use Phan\Exception\NodeException;
 use Phan\Exception\UnanalyzableException;
 use Phan\Issue;
 use Phan\Language\Context;
+use Phan\Language\Element\Clazz;
 use Phan\Language\Element\Comment;
 use Phan\Language\Element\Parameter;
 use Phan\Language\Element\Variable;
@@ -357,13 +358,9 @@ class AssignmentVisitor extends AnalysisVisitor
             return $this->context;
         }
 
-        $std_class_fqsen =
-            FullyQualifiedClassName::getStdClassFQSEN();
+        $is_class_with_arbitrary_types = isset($class_list[0]) ? FullyQualifiedClassName::isClassWithDynamicProperties($class_list[0]->getFQSEN()) : false;
 
-        if (Config::get()->allow_missing_properties
-            || (!empty($class_list)
-                && $class_list[0]->getFQSEN() == $std_class_fqsen)
-        ) {
+        if (Config::get()->allow_missing_properties || $is_class_with_arbitrary_types) {
             try {
                 // Create the property
                 $property = (new ContextNode(

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -743,7 +743,7 @@ class Clazz extends AddressableElement
         // Check to see if missing properties are allowed
         // or we're stdclass
         if (Config::get()->allow_missing_properties
-            || $this->getFQSEN() == FullyQualifiedClassName::getStdClassFQSEN()
+            || FullyQualifiedClassName::isClassWithDynamicProperties($this->getFQSEN())
         ) {
             $property = new Property(
                 $context,

--- a/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
@@ -72,4 +72,23 @@ class FullyQualifiedClassName extends FullyQualifiedGlobalStructuralElement
             return self::fromFullyQualifiedString("\stdClass");
         });
     }
+
+    /**
+     * @return FullyQualifiedClassName
+     * The FQSEN for \stdClass.
+     */
+    public static function getSimpleXMLElementFQSEN() : FullyQualifiedClassName
+    {
+        return self::memoizeStatic(__METHOD__, function() {
+            return self::fromFullyQualifiedString("\SimpleXMLElement");
+        });
+    }
+
+    // TODO: if this gets arbitrarily large,
+    // then check if in_array($class_fqsen, $arbitrary_types_fqsen, true) (or use SPLObjectStorage)
+    public static function isClassWithDynamicProperties(FullyQualifiedClassName $class_fqsen) : bool {
+        return $class_fqsen === FullyQualifiedClassName::getStdClassFQSEN() ||
+            $class_fqsen === FullyQualifiedClassName::getSimpleXMLElementFQSEN();
+    }
+
 }

--- a/tests/files/src/0228_simplexmlelement.php
+++ b/tests/files/src/0228_simplexmlelement.php
@@ -1,0 +1,3 @@
+<?php
+$x = new SimpleXMLElement('<body><foo>x</foo></body>');
+var_export($x->foo[0]->asXML());


### PR DESCRIPTION
Also allow SimpleXMLElement to have arbitrary properties to reduce false
positives
see https://secure.php.net/manual/en/simplexmlelement.construct.php
Fixes #404