### PR TITLE
Make the ordering of files within the same class hierarchy more stable

### DIFF
--- a/src/Phan/Ordering.php
+++ b/src/Phan/Ordering.php
@@ -121,8 +121,11 @@ class Ordering
         // Sort the set of files with a given root by their
         // depth in the hierarchy
         foreach ($root_fqsen_list as $root_fqsen => $list) {
+            // Sort first by depth, and break ties by file name lexicographically
+            // (usort is not a stable sort).
             usort($list, function(array $a, array $b) {
-                return ($a['depth'] <=> $b['depth']);
+                return ($a['depth'] <=> $b['depth']) ?:
+                       strcmp($a['file'], $b['file']);
             });
 
             // Choose which process this file list will be

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -81,6 +81,13 @@ class Phan implements IgnoredFilesFilterInterface {
         // want to run an analysis on
         $analyze_file_path_list = [];
 
+        if (Config::get()->consistent_hashing_file_order) {
+            // Parse the files in lexicographic order.
+            // If there are duplicate class/function definitions,
+            // this ensures they are added to the maps in the same order.
+            sort($file_path_list, SORT_STRING);
+        }
+
         // This first pass parses code and populates the
         // global state we'll need for doing a second
         // analysis after.


### PR DESCRIPTION
usort() is not a stable sort. http://php.net/usort

> If two members compare as equal, their relative order in the sorted
> array is undefined.