### PR TITLE
Alternative implementation of dynamic properties for #426

### DIFF
--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -45,13 +45,13 @@ class ContextNode
     /** @var Context */
     private $context;
 
-    /** @var Node|string */
+    /** @var Node|string|null */
     private $node;
 
     /**
      * @param CodeBase $code_base
      * @param Context $context
-     * @param Node|string $node
+     * @param Node|string|null $node
      */
     public function __construct(
         CodeBase $code_base,
@@ -547,6 +547,22 @@ class ContextNode
             return $property;
         }
 
+        // Since we didn't find the property on any of the
+        // possible classes, check for classes with dynamic
+        // properties
+        foreach ($class_list as $i => $class) {
+            if (Config::get()->allow_missing_properties
+                || $class->getHasDynamicProperties($this->code_base)
+            ) {
+                return $class->getPropertyByNameInContext(
+                    $this->code_base,
+                    $property_name,
+                    $this->context
+                );
+            }
+        }
+
+        /*
         $std_class_fqsen =
             FullyQualifiedClassName::getStdClassFQSEN();
 
@@ -564,6 +580,7 @@ class ContextNode
                 );
             }
         }
+        */
 
         // If the class isn't found, we'll get the message elsewhere
         if ($class_fqsen) {

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -750,7 +750,8 @@ class Clazz extends AddressableElement
         }
 
         // Check to see if missing properties are allowed
-        // or we're stdclass
+        // or we're working with a class with dynamic
+        // properties such as stdclass.
         if (Config::get()->allow_missing_properties
             || $this->getHasDynamicProperties($code_base)
         ) {

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -219,7 +219,6 @@ class Clazz extends AddressableElement
             $clazz->getName()
         ) as $property_name => $property_type_string) {
 
-
             // An asterisk indicates that the class supports
             // dynamic properties
             if ($property_name === '*') {

--- a/src/Phan/Language/Element/Flags.php
+++ b/src/Phan/Language/Element/Flags.php
@@ -3,15 +3,15 @@ namespace Phan\Language\Element;
 
 class Flags
 {
-    const IS_DEPRECATED                = (1 << 01);
-    const IS_INTERNAL                  = (1 << 02);
+    const IS_DEPRECATED                = (1 << 1);
+    const IS_INTERNAL                  = (1 << 2);
 
-    const IS_PARENT_CONSTRUCTOR_CALLED = (1 << 03);
+    const IS_PARENT_CONSTRUCTOR_CALLED = (1 << 3);
 
-    const IS_RETURN_TYPE_UNDEFINED     = (1 << 04);
-    const HAS_RETURN                   = (1 << 05);
-    const IS_OVERRIDE                  = (1 << 06);
-    const HAS_YIELD                    = (1 << 07);
+    const IS_RETURN_TYPE_UNDEFINED     = (1 << 4);
+    const HAS_RETURN                   = (1 << 5);
+    const IS_OVERRIDE                  = (1 << 6);
+    const HAS_YIELD                    = (1 << 7);
 
     const CLASS_HAS_DYNAMIC_PROPERTIES = (1 << 8);
 

--- a/src/Phan/Language/Element/Flags.php
+++ b/src/Phan/Language/Element/Flags.php
@@ -3,18 +3,17 @@ namespace Phan\Language\Element;
 
 class Flags
 {
-    // Typed Structural Element
     const IS_DEPRECATED                = (1 << 01);
     const IS_INTERNAL                  = (1 << 02);
 
-    // Classes
     const IS_PARENT_CONSTRUCTOR_CALLED = (1 << 03);
 
-    // Methods
     const IS_RETURN_TYPE_UNDEFINED     = (1 << 04);
     const HAS_RETURN                   = (1 << 05);
     const IS_OVERRIDE                  = (1 << 06);
     const HAS_YIELD                    = (1 << 07);
+
+    const CLASS_HAS_DYNAMIC_PROPERTIES = (1 << 8);
 
     /**
      * Either enable or disable the given flag on

--- a/src/Phan/Language/Internal/DynamicPropertyMap.php
+++ b/src/Phan/Language/Internal/DynamicPropertyMap.php
@@ -2,13 +2,10 @@
 namespace Phan\Language\Internal;
 
 /**
- * A mapping from class name to the type of dynamic
- * properties on that class, if dynamic properties
- * are allowed.
- *
- * These values have been manually entered.
+ * A list of classes that support dynamic properties. These have
+ * been manually entered.
  */
 return [
-    'stdclass' => 'mixed',
-    'simplexmlelement' => 'simplexmlelement',
+    'stdclass',
+    'simplexmlelement',
 ];

--- a/src/Phan/Language/Internal/DynamicPropertyMap.php
+++ b/src/Phan/Language/Internal/DynamicPropertyMap.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+namespace Phan\Language\Internal;
+
+/**
+ * A mapping from class name to the type of dynamic
+ * properties on that class, if dynamic properties
+ * are allowed.
+ *
+ * These values have been manually entered.
+ */
+return [
+    'stdclass' => 'mixed',
+    'simplexmlelement' => 'simplexmlelement',
+];

--- a/src/Phan/Language/Internal/PropertyMap.php
+++ b/src/Phan/Language/Internal/PropertyMap.php
@@ -9,6 +9,9 @@ namespace Phan\Language\Internal;
  * This structure is of the form
  * [ class_name => [ property_name => type ] ]
  *
+ * with the special case that '*' as a property name indicates
+ * that the class supports dynamic properties.
+ *
  * # How to Generate
  *
  * ```sh
@@ -396,5 +399,11 @@ return [
         'code' => 'int',
         'file' => 'string',
         'line' => 'int'
+    ],
+    'stdclass' => [
+        '*' => true,
+    ],
+    'simplexmlelement' => [
+        '*' => true,
     ],
 ];

--- a/src/Phan/Language/Internal/PropertyMap.php
+++ b/src/Phan/Language/Internal/PropertyMap.php
@@ -9,9 +9,6 @@ namespace Phan\Language\Internal;
  * This structure is of the form
  * [ class_name => [ property_name => type ] ]
  *
- * with the special case that '*' as a property name indicates
- * that the class supports dynamic properties.
- *
  * # How to Generate
  *
  * ```sh
@@ -399,11 +396,5 @@ return [
         'code' => 'int',
         'file' => 'string',
         'line' => 'int'
-    ],
-    'stdclass' => [
-        '*' => true,
-    ],
-    'simplexmlelement' => [
-        '*' => true,
     ],
 ];

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -191,6 +191,16 @@ class UnionType implements \Serializable
             foreach ($map_raw as $key => $value) {
                 $map[strtolower($key)] = $value;
             }
+
+            // Merge in the types for dynamic properties
+            // such as for stdclass.
+            $dynamic_map = require(__DIR__.'/Internal/DynamicPropertyMap.php');
+            foreach ($dynamic_map as $class_name => $dynamic_property_type) {
+                $map[strtolower($class_name)] = array_merge(
+                    $map[strtolower($class_name)] ?? [],
+                    [ '*' => $dynamic_property_type ]
+                );
+            }
         }
 
         return $map;

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -192,14 +192,10 @@ class UnionType implements \Serializable
                 $map[strtolower($key)] = $value;
             }
 
-            // Merge in the types for dynamic properties
-            // such as for stdclass.
-            $dynamic_map = require(__DIR__.'/Internal/DynamicPropertyMap.php');
-            foreach ($dynamic_map as $class_name => $dynamic_property_type) {
-                $map[strtolower($class_name)] = array_merge(
-                    $map[strtolower($class_name)] ?? [],
-                    [ '*' => $dynamic_property_type ]
-                );
+            // Merge in an empty type for dynamic properties on any
+            // classes listed as supporting them.
+            foreach (require(__DIR__.'/Internal/DynamicPropertyMap.php') as $class_name) {
+                $map[strtolower($class_name)]['*'] = '';
             }
         }
 

--- a/tests/files/src/0228_simplexmlelement.php
+++ b/tests/files/src/0228_simplexmlelement.php
@@ -1,0 +1,3 @@
+<?php
+$x = new SimpleXMLElement('<body><foo>x</foo></body>');
+var_export($x->foo[0]->asXML());

--- a/tests/files/src/0228_simplexmlelement.php
+++ b/tests/files/src/0228_simplexmlelement.php
@@ -1,3 +1,9 @@
 <?php
 $x = new SimpleXMLElement('<body><foo>x</foo></body>');
 var_export($x->foo[0]->asXML());
+
+function f(SimpleXMLElement $v) {}
+f($x->foo);
+
+function g(bool $v) {}
+g($x->foo);


### PR DESCRIPTION
@TysonAndre Can I get your comments on this patch as an alternative to #426?

The idea is to encode classes with dynamic properties in `src/Phan/Language/Internal/PropertyMap.php` and make it a bit on a `Clazz` if it supports dynamic properties or not.