### PR TITLE
Fix: Cache composer cache, not vendor directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
 
 cache:
   directories:
-    - ./vendor
+    - $HOME/.composer/cache
 
 before_install:
   - ./tests/setup.sh


### PR DESCRIPTION
This PR

* [x] caches `composer`s cache directory, rather than the `vendor` directory