### PR TITLE
Fix: Disable xdebug to speed up build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ cache:
 
 before_install:
   - ./tests/setup.sh
+  - phpenv config-rm xdebug.ini
 
 install:
   - composer --prefer-source install


### PR DESCRIPTION
This PR

* [x] disables `xdebug` in `before_install` step to speed up builds

💁‍♂️ For reference, see https://docs.travis-ci.com/user/languages/php#Disabling-preinstalled-PHP-extensions.