### PR TITLE
Fix: No need to prefix imports with \

### DIFF
--- a/src/Phan/Ordering.php
+++ b/src/Phan/Ordering.php
@@ -1,9 +1,9 @@
 <?php declare(strict_types=1);
 namespace Phan;
 
-use \Phan\Library\Hasher;
-use \Phan\Library\Hasher\Consistent;
-use \Phan\Library\Hasher\Sequential;
+use Phan\Library\Hasher;
+use Phan\Library\Hasher\Consistent;
+use Phan\Library\Hasher\Sequential;
 
 class Ordering
 {

--- a/tests/.phan/config.php
+++ b/tests/.phan/config.php
@@ -1,6 +1,6 @@
 <?php
 
-use \Phan\Issue;
+use Phan\Issue;
 
 /**
  * This configuration will be read and overlayed on top of the

--- a/tests/Phan/AnalyzerTest.php
+++ b/tests/Phan/AnalyzerTest.php
@@ -8,11 +8,11 @@ $internal_interface_name_list = get_declared_interfaces();
 $internal_trait_name_list = get_declared_traits();
 $internal_function_name_list = get_defined_functions()['internal'];
 
-use \Phan\Analysis;
-use \Phan\CodeBase;
-use \Phan\Config;
-use \Phan\Language\Context;
-use \Phan\Language\FQSEN\FullyQualifiedClassName;
+use Phan\Analysis;
+use Phan\CodeBase;
+use Phan\Config;
+use Phan\Language\Context;
+use Phan\Language\FQSEN\FullyQualifiedClassName;
 
 class AnalyzerTest extends \PHPUnit_Framework_TestCase {
 

--- a/tests/Phan/Language/FQSENTest.php
+++ b/tests/Phan/Language/FQSENTest.php
@@ -2,14 +2,14 @@
 
 namespace Phan\Tests\Language;
 
-use \Phan\Language\Context;
-use \Phan\Language\FQSEN;
-use \Phan\Language\FQSEN\FullyQualifiedClassConstantName;
-use \Phan\Language\FQSEN\FullyQualifiedClassName;
-use \Phan\Language\FQSEN\FullyQualifiedFunctionName;
-use \Phan\Language\FQSEN\FullyQualifiedGlobalConstantName;
-use \Phan\Language\FQSEN\FullyQualifiedMethodName;
-use \Phan\Language\FQSEN\FullyQualifiedPropertyName;
+use Phan\Language\Context;
+use Phan\Language\FQSEN;
+use Phan\Language\FQSEN\FullyQualifiedClassConstantName;
+use Phan\Language\FQSEN\FullyQualifiedClassName;
+use Phan\Language\FQSEN\FullyQualifiedFunctionName;
+use Phan\Language\FQSEN\FullyQualifiedGlobalConstantName;
+use Phan\Language\FQSEN\FullyQualifiedMethodName;
+use Phan\Language\FQSEN\FullyQualifiedPropertyName;
 
 class FQSENTest extends \PHPUnit_Framework_TestCase {
 

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -12,10 +12,10 @@ $internal_interface_name_list = get_declared_interfaces();
 $internal_trait_name_list = get_declared_traits();
 $internal_function_name_list = get_defined_functions()['internal'];
 
-use \Phan\CodeBase;
-use \Phan\Config;
-use \Phan\Language\Context;
-use \Phan\Language\UnionType;
+use Phan\CodeBase;
+use Phan\Config;
+use Phan\Language\Context;
+use Phan\Language\UnionType;
 
 class UnionTypeTest extends \PHPUnit_Framework_TestCase {
 


### PR DESCRIPTION
This PR

* [x] removes useless `\` prefixes from imports