### PR TITLE
Allow users to specify custom PHP file extensions to check

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -220,6 +220,10 @@ return [
         'vendor/symfony/console',
     ],
 
+    // List of case-insensitive file extensions supported by Phan.
+    // (e.g. php, html, htm)
+    'analyzed_file_extensions' => ['php'],
+
     // A directory list that defines files that will be excluded
     // from static analysis, but whose class and method
     // information should be included.

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -460,6 +460,11 @@ EOB;
         $file_list = [];
 
         try {
+            $file_extensions = Config::get()->analyzed_file_extensions;
+            if (!is_array($file_extensions) || count($file_extensions) == 0) {
+                throw new InvalidArgumentException("Empty list in config analyzed_file_extensions - Nothing to analyze");
+            }
+            $extensionRegex = implode('|', array_map(function ($extension) { return preg_quote($extension, '/'); }, $file_extensions));
             $iterator = new \RegexIterator(
                 new \RecursiveIteratorIterator(
                     new \RecursiveDirectoryIterator(
@@ -467,7 +472,7 @@ EOB;
                         \RecursiveDirectoryIterator::FOLLOW_SYMLINKS
                     )
                 ),
-                '/^.+\.php$/i',
+                '/^.+\.(' . $extensionRegex . ')$/i',
                 \RecursiveRegexIterator::GET_MATCH
             );
 

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -35,6 +35,10 @@ class Config
         // your application should be included in this list.
         'directory_list' => [],
 
+        // List of case-insensitive file extensions supported by Phan.
+        // (e.g. php, html, htm)
+        'analyzed_file_extensions' => ['php'],
+
         // A file list that defines files that will be excluded
         // from parsing and analysis and will not be read at all.
         //


### PR DESCRIPTION
(e.g. ['php', 'html'])

Keep the current defaults.