### PR TITLE
Fix: Require builds on PHP 7.1 to pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ sudo: false
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - php: "7.1"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ env:
 
 sudo: false
 
-matrix:
-  fast_finish: true
-
 cache:
   directories:
     - $HOME/.composer/cache


### PR DESCRIPTION
This PR

* [x] requires builds on PHP 7.1 to pass
* [x] removes `fast_finish`, as we require all builds to pass anyway

Follows #446.

💁‍♂️ Looks like builds are passing on PHP 7.1, so why not just require them to pass? See [build for #446](https://travis-ci.org/etsy/phan/builds/183959215).