### PR TITLE
Don't issue PhanTypeReturnMissing if the method always throws

### DIFF
--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1076,6 +1076,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 && !$has_interface_class
                 && !$return_type->isEmpty()
                 && !$method->getHasReturn()
+                && !$this->declOnlyThrows($node)
                 && !$return_type->hasType(VoidType::instance())
                 && !$return_type->hasType(NullType::instance())
             ) {
@@ -1101,6 +1102,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         if ($method instanceof Func) {
             if (!$return_type->isEmpty()
                 && !$method->getHasReturn()
+                && !$this->declOnlyThrows($node)
                 && !$return_type->hasType(VoidType::instance())
                 && !$return_type->hasType(NullType::instance())
             ) {
@@ -1149,6 +1151,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
 
         if (!$return_type->isEmpty()
             && !$method->getHasReturn()
+            && !$this->declOnlyThrows($node)
             && !$return_type->hasType(VoidType::instance())
             && !$return_type->hasType(NullType::instance())
         ) {
@@ -1782,5 +1785,20 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 $node->lineno ?? 0
             );
         }
+    }
+
+    /**
+     * @param Decl $node
+     * A decl to check to see if it's only effect
+     * is the throw an exception
+     *
+     * @return bool
+     * True when the decl can only throw an exception
+     */
+    private function declOnlyThrows(Decl $node) {
+        return isset( $node->children['stmts'] )
+            && $node->children['stmts']->kind === \ast\AST_STMT_LIST
+            && count($node->children['stmts']->children) === 1
+            && $node->children['stmts']->children[0]->kind === \ast\AST_THROW;
     }
 }

--- a/tests/files/expected/0092_enforce_return.php.expected
+++ b/tests/files/expected/0092_enforce_return.php.expected
@@ -1,3 +1,3 @@
 %s:4 PhanTypeMissingReturn Method \A::f is declared to return int but has no return value
-%s:17 PhanTypeMissingReturn Method \h is declared to return int but has no return value
+%s:21 PhanTypeMissingReturn Method \h is declared to return int but has no return value
 

--- a/tests/files/src/0092_enforce_return.php
+++ b/tests/files/src/0092_enforce_return.php
@@ -7,6 +7,10 @@ class A {
     public function g() : int {
         return 42;
     }
+
+    public function m() : int {
+        throw new \Exception();
+    }
 }
 
 abstract class B {
@@ -18,4 +22,7 @@ function h() : int {}
 function j() {}
 function k() : int {
     return 42;
+}
+function l() : int {
+    throw new \Exception();
 }


### PR DESCRIPTION
This isn't a complete implementation of the 'only possible to throw'
definition, but seems like a reasonable first start. If the only way
to exit a function is a throw then the return isn't missing, and it
will never return the wrong value.

This is usefull for patterns where a base class defines a method
with a return type, but the implementation is to throw a
NotImplemented exception.