### PR TITLE
Detect undeclared constants/class constants in array literals.

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -966,12 +966,11 @@ class UnionTypeVisitor extends AnalysisVisitor
                     constant($node->children['name']->children['name'])
                 )->asUnionType();
             } else {
-                // Figure out the name of the constant if its
+                // Figure out the name of the constant if it's
                 // a string.
+                // NOTE: It seems like this will always be '' because defined() would catch everything except absence?
                 $constant_name =
-                    isset($node->children['name']->children['name'])
-                    ? $node->children['name']->children['name']
-                    : '';
+                    $node->children['name']->children['name'] ?? '';
 
                 // If the constant is referring to the current
                 // class, return that as a type

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -57,7 +57,7 @@ class Type
     /**
      * @var string
      * A legal type identifier matching a type optionally with a []
-     * indicating that its a generic typed array (e.g. 'int[]',
+     * indicating that it's a generic typed array (e.g. 'int[]',
      * 'string' or 'Set<DateTime>')
      */
     const type_regex =
@@ -457,7 +457,7 @@ class Type
         ) {
             return self::fromInternalTypeName($type_name);
         } else {
-            // Check to see if its a builtin type
+            // Check to see if it's a builtin type
             switch (strtolower(self::canonicalNameFromName($type_name))) {
                 case 'array':
                     return \Phan\Language\Type\ArrayType::instance();

--- a/tests/files/expected/0236_array_key_undefined_class_const.php.expected
+++ b/tests/files/expected/0236_array_key_undefined_class_const.php.expected
@@ -1,0 +1,4 @@
+%s:11 PhanUndeclaredConstant Reference to undeclared constant \Bar::B
+%s:12 PhanUndeclaredConstant Reference to undeclared constant \Bar::C
+%s:14 PhanUndeclaredConstant Reference to undeclared constant \FooParent::Y
+%s:16 PhanUndeclaredConstant Reference to undeclared constant \Foo::UNDECLARED_PAST_FIRST_5

--- a/tests/files/expected/0237_self_as_undefined_constant.php.expected
+++ b/tests/files/expected/0237_self_as_undefined_constant.php.expected
@@ -1,0 +1,2 @@
+%s:5 PhanUndeclaredConstant Reference to undeclared constant \self
+%s:8 PhanUndeclaredConstant Reference to undeclared constant \A237

--- a/tests/files/src/0027_assert_parameter_types.php
+++ b/tests/files/src/0027_assert_parameter_types.php
@@ -1,11 +1,11 @@
 <?php
-
+// This test validates phan checking the types of params passed to assert()
 class A {
     public static function f() : bool {
         return false;
     }
 }
 
-assert(!A::f, 'string');
+assert(!A::f(), 'string');
 
 assert(10 > 1, 'string');

--- a/tests/files/src/0104_self_array.php
+++ b/tests/files/src/0104_self_array.php
@@ -2,7 +2,7 @@
 class A {
     /** @return self[] */
     function f() {
-        return [self, self];
+        return [new self(), new self()];
     }
 
     function g() {

--- a/tests/files/src/0236_array_key_undefined_class_const.php
+++ b/tests/files/src/0236_array_key_undefined_class_const.php
@@ -1,0 +1,23 @@
+<?php
+
+class FooParent {
+    const X = 'x';
+}
+
+class Foo extends FooParent {
+    public static function my_method() {
+        $labels = [
+            Bar::A => 'a',
+            Bar::B => 'a',
+            'well' => Bar::C,
+            parent::X => 'c',
+            parent::Y => 'd',
+            self::X => static::X,  // good
+            'key' => static::UNDECLARED_PAST_FIRST_5,
+        ];
+        return $labels;
+    }
+}
+class Bar {
+    const A = 'a';
+}

--- a/tests/files/src/0237_self_as_undefined_constant.php
+++ b/tests/files/src/0237_self_as_undefined_constant.php
@@ -1,0 +1,10 @@
+<?php
+// Warn about undefined constants. They are undefined even if they resemble the class name.
+class A237 {
+    public static function f() {
+        return self;  // not the same as self::class();
+    }
+    public static function b() {
+        return A237;  // will emit a php notice for undefined, and assume 'A237'
+    }
+}


### PR DESCRIPTION
This was seen in a large array used for string lookup.

As well as values past the first 5 (Only types of the first 5 array values are
analyzed by phan)

Aside: function calls in array literals are also not analyzed. This
seems less important.

This will possibly emit duplicate exceptions (UnionTypeVisitor visits
most uses of class constants, but not all.

Add tests related to edge cases of class constants and constants