### PR TITLE
Implement UnionTypeVisitor->visitAssignRef

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -353,6 +353,7 @@ class UnionTypeVisitor extends AnalysisVisitor
 
     /**
      * Visit a node with kind `\ast\AST_ASSIGN_REF`
+     * @see $this->visitAssign
      *
      * @param Node $node
      * A node of the type indicated by the method name that we'd
@@ -364,8 +365,9 @@ class UnionTypeVisitor extends AnalysisVisitor
      */
     public function visitAssignRef(Node $node) : UnionType
     {
-        // TODO
-        return new UnionType();
+        // TODO: Is there any way this should differ from analysis
+        // (e.g. should subsequent assignments affect the right hand Node?)
+        return $this->visitAssign($node);
     }
 
     /**

--- a/tests/files/expected/0236_assign_ref_analyzed.php.expected
+++ b/tests/files/expected/0236_assign_ref_analyzed.php.expected
@@ -1,0 +1,2 @@
+%s:10 PhanTypeMismatchProperty Assigning \A236 to property but \A236::badDoc is string
+%s:12 PhanTypeMismatchProperty Assigning \A236 to property but \A236::badDoc is string

--- a/tests/files/src/0236_assign_ref_analyzed.php
+++ b/tests/files/src/0236_assign_ref_analyzed.php
@@ -1,0 +1,15 @@
+<?php
+
+class A236 {
+    /** @var string */
+    public $badDoc;
+
+    /** @var A236 */
+    public $goodDoc;
+    public function foo() {
+        $this->badDoc = &$this;
+        $this->goodDoc = &$this;
+        $this->badDoc = $this;
+        $this->goodDoc = $this;
+    }
+}


### PR DESCRIPTION
(Do it the same way as visitAssign. Ignore fact it is a reference for now)

visitAssignRef was added as a stub in 577c0cfd, I didn't see any tasks for this in github Issues.
Also, I was seeing spurious phan failures for (real mismatch, but passed some of the time) code assigning to properties by reference (`$a->prop =& $this`). Not sure why.