### PR TITLE
Create scoped variables from if(isset($..))

### DIFF
--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -109,9 +109,6 @@ class ConditionVisitor extends KindVisitorImplementation
      */
     public function visitIsset(Node $node) : Context
     {
-        return $this->context;
-
-        /*
         // Only look at things of the form
         // `isset($variable)`
         if ($node->children['var']->kind !== \ast\AST_VAR) {
@@ -119,12 +116,13 @@ class ConditionVisitor extends KindVisitorImplementation
         }
 
         try {
-            // Get the variable we're operating on
+            // Get the variable we're operating on. Create is ok
+            // because for isset to succeed it must exist.
             $variable = (new ContextNode(
                 $this->code_base,
                 $this->context,
                 $node->children['var']
-            ))->getVariable();
+            ))->getOrCreateVariable();
 
             $v0 = $variable;
 
@@ -147,7 +145,6 @@ class ConditionVisitor extends KindVisitorImplementation
         }
 
         return $this->context;
-        */
     }
 
     /**

--- a/tests/files/expected/0241_conditional_isset.php.expected
+++ b/tests/files/expected/0241_conditional_isset.php.expected
@@ -1,0 +1,1 @@
+%s:12 PhanUndeclaredVariable Variable $prev is undeclared

--- a/tests/files/src/0241_conditional_isset.php
+++ b/tests/files/src/0241_conditional_isset.php
@@ -1,0 +1,18 @@
+<?php
+
+function foo(array $a) {
+    $bar = [];
+
+    foreach ($a as $b) {
+        if (isset($prev)) {
+            // prev must exist here
+            $bar = $prev > $b ? $prev : $b;
+        }
+        // $prev must still be undefined
+        echo $prev;
+        $prev = $b;
+    }
+    return $bar;
+}
+
+foo([1,3,2]);


### PR DESCRIPTION
Inside an if(isset($foo)) block the variable $foo should exist. It looks
like the code was already there, just commented out. The only change i
made was to allow a new variable to be created if the scope didn't know
anything about it.

I played around with a few edge cases I could think of but couldn't
figure out what could have been wrong with the code that required it
being commented out, and the commit history also gave no suggestions.
Perhaps whatever issue there was at the time has been resolved, or there
is something else I'm not seeing.