### PR TITLE
Account for backslashes in Phan::isExcludedAnalysisFile

### DIFF
--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -286,6 +286,7 @@ class Phan implements IgnoredFilesFilterInterface {
     private static function isExcludedAnalysisFile(
         string $file_path
     ) : bool {
+        $file_path = str_replace('\\', '/', $file_path);
         foreach (Config::get()->exclude_analysis_directory_list
                  as $directory
         ) {


### PR DESCRIPTION
Fixes #489

I have gone for a simple approach doing a str_replace
on all paths that pass through the isExcludedAnalysisFile
method.

Other posibilities would be to check if the path contained
a \ and then do the replace, or check the OS that the code
is running on and only do the replace on Windows.