### PR TITLE
scalar_implicit_cast should affect NullType->canCastToType

### DIFF
--- a/src/Phan/Language/Type/NullType.php
+++ b/src/Phan/Language/Type/NullType.php
@@ -59,6 +59,11 @@ class NullType extends ScalarType
             return true;
         }
 
+        // NullType is a sub-type of ScalarType. So it's affected by scalar_implicit_cast.
+        if (Config::get()->scalar_implicit_cast && $type->isScalar()) {
+            return true;
+        }
+
         return false;
     }
 


### PR DESCRIPTION
> If enabled, scalars (int, float, bool, string, null)
> are treated as if they can cast to each other.

The refactoring to use NullType changed the old behavior, and code would now warn about null casting to a scalar (e.g. string) if scalar_implicit_cast is true but null_casts_as_any_type is false.

Expected: no warnings for null casting to a scalar when scalar_implicit_cast is true.