### PR TITLE
Refactor doc comment processing in Func&Method. Allow variadic doc comments.

### DIFF
--- a/src/Phan/AST/AnalysisVisitor.php
+++ b/src/Phan/AST/AnalysisVisitor.php
@@ -44,7 +44,7 @@ abstract class AnalysisVisitor extends KindVisitorImplementation
      * @param int $lineno
      * The line number where the issue was found
      *
-     * @param mixed $parameters
+     * @param mixed ...$parameters
      * Template parameters for the issue's error message
      *
      * @return void

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -47,6 +47,8 @@ class Issue
     const TypeMismatchArgument      = 'PhanTypeMismatchArgument';
     const TypeMismatchArgumentInternal = 'PhanTypeMismatchArgumentInternal';
     const TypeMismatchDefault       = 'PhanTypeMismatchDefault';
+    const TypeMismatchVariadicComment = 'PhanMismatchVariadicComment';
+    const TypeMismatchVariadicParam = 'PhanMismatchVariadicParam';
     const TypeMismatchForeach       = 'PhanTypeMismatchForeach';
     const TypeMismatchProperty      = 'PhanTypeMismatchProperty';
     const TypeMismatchReturn        = 'PhanTypeMismatchReturn';
@@ -442,6 +444,22 @@ class Issue
                 "Default value for %s \$%s can't be %s",
                 self::REMEDIATION_B,
                 10002
+            ),
+            new Issue(
+                self::TypeMismatchVariadicComment,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_LOW,
+                "%s is variadic in comment, but not variadic in param (%s)",
+                self::REMEDIATION_B,
+                10021
+            ),
+            new Issue(
+                self::TypeMismatchVariadicParam,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_LOW,
+                "%s is not variadic in comment, but variadic in param (%s)",
+                self::REMEDIATION_B,
+                10022
             ),
             new Issue(
                 self::TypeMismatchArgument,

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -1166,7 +1166,7 @@ class Issue
      * @param int $line
      * The line number (start) where the issue was found
      *
-     * @param mixed $template_parameters
+     * @param mixed ...$template_parameters
      * Any template parameters required for the issue
      * message
      *
@@ -1290,7 +1290,7 @@ class Issue
      * @param int $lineno
      * The line number where the issue was found
      *
-     * @param mixed parameters
+     * @param mixed ...$parameters
      * Template parameters for the issue's error message
      *
      * @return void

--- a/src/Phan/Language/Element/Comment/Parameter.php
+++ b/src/Phan/Language/Element/Comment/Parameter.php
@@ -22,6 +22,12 @@ class Parameter
     private $type;
 
     /**
+     * @var bool
+     * Whether or not the parameter is variadic (in the comment)
+     */
+    private $is_variadic;
+
+    /**
      * @param string $name
      * The name of the parameter
      *
@@ -30,10 +36,12 @@ class Parameter
      */
     public function __construct(
         string $name,
-        UnionType $type
+        UnionType $type,
+        bool $is_variadic = false
     ) {
         $this->name = $name;
         $this->type = $type;
+        $this->is_variadic = $is_variadic;
     }
 
     /**
@@ -70,12 +78,24 @@ class Parameter
         return $this->type;
     }
 
+    /**
+     * @return bool
+     * Whether or not the parameter is variadic
+     */
+    public function isVariadic() : bool
+    {
+        return $this->is_variadic;
+    }
+
     public function __toString() : string
     {
         $string = '';
 
         if (!$this->type->isEmpty()) {
             $string .= "{$this->type} ";
+        }
+        if ($this->is_variadic) {
+            $string .= '...';
         }
 
         $string .= $this->name;

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -154,5 +154,4 @@ interface FunctionInterface extends AddressableElementInterface {
      * in the given context
      */
     public function analyze(Context $context, CodeBase $code_base) : Context;
-
 }

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -399,11 +399,11 @@ class Parameter extends Variable
             $string .= '&';
         }
 
-        $string .= "\${$this->getName()}";
-
         if ($this->isVariadic()) {
-            $string .= ' ...';
+            $string .= '...';
         }
+
+        $string .= "\${$this->getName()}";
 
         if ($this->hasDefaultValue()) {
             if ($this->getDefaultValue() instanceof \ast\Node) {

--- a/tests/files/expected/0258_variadic_comment_parsing.php.expected
+++ b/tests/files/expected/0258_variadic_comment_parsing.php.expected
@@ -1,0 +1,7 @@
+%s:8 PhanMismatchVariadicComment int ...x is variadic in comment, but not variadic in param ($x)
+%s:8 PhanMismatchVariadicParam array y is not variadic in comment, but variadic in param (...$y)
+%s:16 PhanMismatchVariadicParam int y is not variadic in comment, but variadic in param (...$y)
+%s:25 PhanMismatchVariadicComment int ...x is variadic in comment, but not variadic in param ($x)
+%s:25 PhanMismatchVariadicParam array y is not variadic in comment, but variadic in param (...$y)
+%s:32 PhanMismatchVariadicParam int z is not variadic in comment, but variadic in param (...$z)
+%s:36 PhanTypeMismatchArgument Argument 3 (y) is array but \badvariadic258b() takes int defined at %s:16

--- a/tests/files/src/0217_variadic_call_types.php
+++ b/tests/files/src/0217_variadic_call_types.php
@@ -39,7 +39,7 @@ accept_int(test_misc(2, []));  // Wrong
 test_ints_phpdoc(3);
 
 /**
- * @param int $args
+ * @param int ...$args
  * @return int[]
  */
 function test_ints_phpdoc(...$args) {

--- a/tests/files/src/0240_variadic_type.php
+++ b/tests/files/src/0240_variadic_type.php
@@ -1,12 +1,12 @@
 <?php
-/** @param array $args */
+/** @param array ...$args */
 function f461(...$args) {
     print_r($args);
 }
 f461(42, 'string');
 f461([42], ['string']);
 class C461 {
-    /** @param array $args */
+    /** @param array ...$args */
     function f(...$args) {}
 }
 (new C461)->f(42, 'string');

--- a/tests/files/src/0258_variadic_comment_parsing.php
+++ b/tests/files/src/0258_variadic_comment_parsing.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Nonsense comment. This gets parsed as an $x being an int, $y being array of arrays,
+ * @param int ...$x
+ * @param array $y
+ */
+function badvariadic258($x, ...$y) {
+}
+
+/**
+ * Parsed as $y being a variadic array of integers
+ * @param $x
+ * @param int $y
+ */
+function badvariadic258b($x, ...$y) {
+}
+
+class Variadic258 {
+    /**
+     * Nonsense comment. This gets parsed as an $x being an int, $y being array of arrays,
+     * @param int ...$x
+     * @param array $y
+     */
+    public static function bar($x, ...$y) {}
+
+    /**
+     * Parsed as $z being a variadic array of integers
+     * @param $x
+     * @param int $z
+     */
+    public static function baz($x = null, ...$z) {}
+}
+
+badvariadic258(2, [3], [4]);
+badvariadic258b(2, 3, []);
+Variadic258::bar(2, [3], [4]);
+Variadic258::baz(2, 3);


### PR DESCRIPTION
Fixes #508 

Analyze defaults and comments of methods/funcs the same way.

Check that variadics are declared in comments the same way they are
declared in parameters.

- Func and Method got out of sync, and treated null defaults
  differently. Refactor this and change the logic.
  In both, add null default to the UnionType only if there's already another type
  In both, add non-null defaults to the UnionType
  May affect issue #518
- Preserve old inference logic (`@param int ...$x` has the same type
  inferences as `@param int $x`)
- Warn if doc comment says a non-variadic is variadic, or vice versa.
