### PR TITLE
Stop using the Memoize trait in TypedElement - it's unused.

### DIFF
--- a/src/Phan/Language/Element/AddressableElement.php
+++ b/src/Phan/Language/Element/AddressableElement.php
@@ -10,6 +10,8 @@ use Phan\Model\CalledBy;
 
 abstract class AddressableElement extends TypedElement implements AddressableElementInterface
 {
+    use \Phan\Memoize;
+
     /**
      * @var FQSEN
      */
@@ -155,4 +157,24 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
         return count($this->reference_list);
     }
 
+    /**
+     * This method must be called before analysis
+     * begins.
+     *
+     * @return void
+     * @override
+     */
+    public final function hydrate(CodeBase $code_base)
+    {
+        if (!$this->isFirstExecution(__METHOD__)) {
+            return;
+        }
+
+        $this->hydrateOnce($code_base);
+    }
+
+    protected function hydrateOnce(CodeBase $code_base)
+    {
+        // Do nothing unless overridden
+    }
 }

--- a/src/Phan/Language/Element/TypedElement.php
+++ b/src/Phan/Language/Element/TypedElement.php
@@ -13,8 +13,6 @@ use Phan\Language\UnionType;
  */
 abstract class TypedElement implements TypedElementInterface
 {
-    use \Phan\Memoize;
-
     /**
      * @var string
      * The name of the typed structural element
@@ -288,22 +286,8 @@ abstract class TypedElement implements TypedElementInterface
      *
      * @return void
      */
-    public final function hydrate(CodeBase $code_base)
+    public function hydrate(CodeBase $code_base)
     {
-        if (!$this->isFirstExecution(__METHOD__)) {
-            return;
-        }
-
-        $this->hydrateOnce($code_base );
-    }
-
-    /**
-     * This method must be called before analysis
-     * begins.
-     *
-     * @return void
-     */
-    protected function hydrateOnce(CodeBase $code_base) {
         // Do nothing unless overridden
     }
 }


### PR DESCRIPTION
Move it into AddressableElement (Functions, classes, etc.)

- It adds extra memory to keep the memoize map in Variables, Params, etc
- Cloning/building property takes slightly more time
- It was unclear if there is any state being memoized (There wasn't)