### PR TITLE
Fixes #514: Properly analyze uses of varargs within a function.

### DIFF
--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -171,7 +171,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         // parameter definition
         foreach ($method->getParameterList() as $parameter) {
             $context->addScopeVariable(
-                clone($parameter)
+                $parameter->cloneAsNonVariadic()
             );
         }
 
@@ -258,7 +258,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         // parameter definition
         foreach ($function->getParameterList() as $parameter) {
             $context->addScopeVariable(
-                clone($parameter)
+                $parameter->cloneAsNonVariadic()
             );
         }
 

--- a/src/Phan/Language/Element/Flags.php
+++ b/src/Phan/Language/Element/Flags.php
@@ -14,6 +14,7 @@ class Flags
     const HAS_YIELD                    = (1 << 7);
 
     const CLASS_HAS_DYNAMIC_PROPERTIES = (1 << 8);
+    const IS_CLONE_OF_VARIADIC         = (1 << 9);
 
     /**
      * Either enable or disable the given flag on

--- a/src/Phan/Language/Element/TypedElement.php
+++ b/src/Phan/Language/Element/TypedElement.php
@@ -133,6 +133,15 @@ abstract class TypedElement implements TypedElementInterface
     }
 
     /**
+     * @return void
+     */
+    protected function convertToNonVariadic()
+    {
+        // Avoid a redundant clone of toGenericArray()
+        $this->type = $this->getUnionType();
+    }
+
+    /**
      * Variables can't be variadic. This is the same as getUnionType for
      * variables, but not necessarily for subclasses. Method will return
      * the element type (such as `DateTime`) for variadic parameters.

--- a/src/Phan/Language/Element/Variable.php
+++ b/src/Phan/Language/Element/Variable.php
@@ -195,6 +195,15 @@ class Variable extends TypedElement
         return parent::getUnionType();
     }
 
+    /**
+     * @return static - A clone of this object, where isVariadic() is false
+     * Used for analyzing the context **inside** of this method
+     */
+    public function cloneAsNonVariadic()
+    {
+        return clone($this);
+    }
+
     public function __toString() : string
     {
         $string = '';

--- a/tests/files/expected/0260_variadic_bug.php.expected
+++ b/tests/files/expected/0260_variadic_bug.php.expected
@@ -1,0 +1,3 @@
+%s:42 PhanTypeMismatchArgument Argument 3 (arguments) is int[] but \VariadicBug::foo() takes int|string defined at %s:16
+%s:44 PhanTypeMismatchArgument Argument 3 (arguments) is int[] but \variadic_bug_260() takes int|string defined at %s:31
+

--- a/tests/files/src/0260_variadic_bug.php
+++ b/tests/files/src/0260_variadic_bug.php
@@ -1,0 +1,44 @@
+<?php
+
+class VariadicBug {
+    /**
+     * @param string $a
+     * @param int[]|string[] $arguments
+     */
+    public static function nonvaradic($a, $arguments) {
+        printf("%s\n", json_encode($arguments));
+    }
+
+    /**
+     * @param string $a
+     * @param int|string ...$arguments
+     */
+    public static function foo(string $a, ...$arguments) {
+        if (count($arguments) > 0) {
+            // self::nonvariadic($a, $arguments);
+        }
+        if (count($arguments) > 0) {
+            self::nonvaradic($a, $arguments);
+        }
+        self::nonvaradic($a, $arguments);
+    }
+}
+
+/**
+ * @param string $a
+ * @param int|string ...$arguments
+ */
+function variadic_bug_260(string $a, ...$arguments) {
+    if (count($arguments) > 0) {
+        // self::nonvariadic($a, $arguments);
+    }
+    if (count($arguments) > 0) {
+        VariadicBug::nonvaradic($a, $arguments);
+    }
+    VariadicBug::nonvaradic($a, $arguments);
+}
+
+VariadicBug::foo('label', 'a', 2);
+VariadicBug::foo('label', 'a', [2]);
+variadic_bug_260('label', 'a', 2);
+variadic_bug_260('label', 'a', [2]);


### PR DESCRIPTION
- when analyzing code within a function,
  Convert the union type view to toGenericArray()
  and use that instead. Adjust the other functions so that they continue
  returning the same values as before.
  (Makes branched context works, assignments to varargs work)
- Add tests