### PR TITLE
Allow statically calling __construct to specify any ancestor

### DIFF
--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -89,11 +89,7 @@ class ContextNode
      */
     public function getQualifiedName() : string
     {
-        return (string)UnionTypeVisitor::unionTypeFromClassNode(
-            $this->code_base,
-            $this->context,
-            $this->node
-        );
+        return $this->getClassUnionType()->__toString();
     }
 
     /**
@@ -134,6 +130,18 @@ class ContextNode
     }
 
     /**
+     * @return UnionType the union type of the class for this class node. (Should have just one Type)
+     */
+    public function getClassUnionType() : UnionType
+    {
+        return UnionTypeVisitor::unionTypeFromClassNode(
+            $this->code_base,
+            $this->context,
+            $this->node
+        );
+    }
+
+    /**
      * @param bool $ignore_missing_classes
      * If set to true, missing classes will be ignored and
      * exceptions will be inhibited
@@ -148,11 +156,7 @@ class ContextNode
      */
     public function getClassList($ignore_missing_classes = false)
     {
-        $union_type = UnionTypeVisitor::unionTypeFromClassNode(
-            $this->code_base,
-            $this->context,
-            $this->node
-        );
+        $union_type = $this->getClassUnionType();
 
         $class_list = [];
 

--- a/tests/files/expected/0261_skip_constructor.php.expected
+++ b/tests/files/expected/0261_skip_constructor.php.expected
@@ -1,0 +1,7 @@
+%s:21 PhanUndeclaredStaticMethod Static call to undeclared method D261B::__construct()
+%s:26 PhanUndeclaredClassMethod Call to method __construct from undeclared class \Missing261
+%s:26 PhanUndeclaredStaticMethod Static call to undeclared method Missing261::__construct()
+%s:37 PhanUndeclaredStaticMethod Static call to undeclared method Other261::__construct()
+%s:49 PhanUndeclaredStaticMethod Static call to undeclared method self::__construct()
+%s:55 PhanUndeclaredStaticMethod Static call to undeclared method static::__construct()
+%s:61 PhanUndeclaredStaticMethod Static call to undeclared method Self261C::__construct()

--- a/tests/files/src/0261_skip_constructor.php
+++ b/tests/files/src/0261_skip_constructor.php
@@ -1,0 +1,63 @@
+<?php
+// TODO: Change from undeclared static to undeclared constructor in a future release
+class A261 {
+    public function __construct(string $c) { }
+}
+
+class B261 extends A261 {
+    public function __construct(string $c) {
+        A261::__construct($c);
+    }
+}
+
+class C261 extends B261 {
+    public function __construct(string $c) {
+        A261::__construct('str');
+    }
+}
+
+class C261B extends B261 {
+    public function __construct(string $c) {
+        D261B::__construct($c);  // calling an incorrect constructor: subclass but should be ancestor
+    }
+}
+class C261C extends B261 {
+    public function __construct(string $c) {
+        Missing261::__construct($c);  // calling an incorrect constructor: doesn't exist
+    }
+}
+
+class Other261 {
+    public function __construct(string $c) {
+    }
+}
+
+class C261D extends B261 {
+    public function __construct(string $c) {
+        Other261::__construct($c);  // calling an incorrect constructor: different class hierarchy
+    }
+}
+
+class D261B extends C261B {
+    public function __construct(string $c) {
+        parent::__construct($c);  // would be a stack overflow, but the problem is in the parent.
+    }
+}
+
+class Self261 {
+    public function __construct(string $c) {
+        self::__construct($c);  // stack overflow
+    }
+}
+
+class Self261B {
+    public function __construct(string $c) {
+        static::__construct($c);  // stack overflow
+    }
+}
+
+class Self261C {
+    public function __construct(string $c) {
+        Self261C::__construct($c);  // stack overflow
+    }
+}


### PR DESCRIPTION
Previously, this would warn on anything except for parent::__construct()

- Phan aims for low false positives, so valid code should work (Or emit
  a different type of Issue)

After this, only emit a warning if it's not an ancestor (Different class
hierarchy, subclass, or missing)

- Continue warning about calling self::__construct or
  static::__construct statically.