### PR TITLE
Fixes Issue #471 : process aliases such as `boolean` only in phpdoc

### DIFF
--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -218,7 +218,8 @@ class Comment
 
         $return_union_type = UnionType::fromStringInContext(
             $return_union_type_string,
-            $context
+            $context,
+            true
         );
 
         return $return_union_type;
@@ -254,7 +255,8 @@ class Comment
                 $union_type =
                     UnionType::fromStringInContext(
                         $type,
-                        $context
+                        $context,
+                        true
                     );
             } else {
                 $union_type = new UnionType();
@@ -313,7 +315,8 @@ class Comment
 
             $type = new Some(Type::fromStringInContext(
                 $type_string,
-                $context
+                $context,
+                true
             ));
 
             return $type;

--- a/src/Phan/Language/Internal/PropertyMap.php
+++ b/src/Phan/Language/Internal/PropertyMap.php
@@ -64,8 +64,8 @@ return [
         'contiguous-space' => 'int'
     ],
     'mongocursor' => [
-        'slaveokay' => 'boolean',
-        'timeout' => 'integer'
+        'slaveokay' => 'bool',
+        'timeout' => 'int'
     ],
     'domxpath' => [
         'document' => 'DOMDocument'
@@ -92,7 +92,7 @@ return [
         'comment' => 'string'
     ],
     'solrexception' => [
-        'sourceline' => 'integer',
+        'sourceline' => 'int',
         'sourcefile' => 'string',
         'zif-name' => 'string'
     ],
@@ -103,13 +103,13 @@ return [
         'id' => 'string'
     ],
     'dateinterval' => [
-        'y' => 'integer',
-        'm' => 'integer',
-        'd' => 'integer',
-        'h' => 'integer',
-        'i' => 'integer',
-        's' => 'integer',
-        'invert' => 'integer',
+        'y' => 'int',
+        'm' => 'int',
+        'd' => 'int',
+        'h' => 'int',
+        'i' => 'int',
+        's' => 'int',
+        'invert' => 'int',
         'days' => 'mixed'
     ],
     'tokyotyrantexception' => [
@@ -181,14 +181,14 @@ return [
         'length' => 'int'
     ],
     'mongodb' => [
-        'w' => 'integer',
-        'wtimeout' => 'integer'
+        'w' => 'int',
+        'wtimeout' => 'int'
     ],
     'splpriorityqueue' => [
         'name' => 'string'
     ],
     'mongoclient' => [
-        'connected' => 'boolean',
+        'connected' => 'bool',
         'status' => 'string'
     ],
     'domdocument' => [
@@ -260,8 +260,8 @@ return [
     ],
     'mongocollection' => [
         'db' => 'MongoDB',
-        'w' => 'integer',
-        'wtimeout' => 'integer'
+        'w' => 'int',
+        'wtimeout' => 'int'
     ],
     'mongoint64' => [
         'value' => 'string'
@@ -294,8 +294,8 @@ return [
         'name' => 'string'
     ],
     'solrresponse' => [
-        'http-status' => 'integer',
-        'parser-mode' => 'integer',
+        'http-status' => 'int',
+        'parser-mode' => 'int',
         'success' => 'bool',
         'http-status-message' => 'string',
         'http-request-url' => 'string',
@@ -383,8 +383,8 @@ return [
         'xmllang' => 'string'
     ],
     'eventbufferevent' => [
-        'fd' => 'integer',
-        'priority' => 'integer',
+        'fd' => 'int',
+        'priority' => 'int',
         'input' => 'EventBuffer',
         'output' => 'EventBuffer'
     ],

--- a/src/Phan/Language/Type/TemplateType.php
+++ b/src/Phan/Language/Type/TemplateType.php
@@ -13,7 +13,7 @@ class TemplateType extends Type
      * An identifier for the template type
      */
     public function __construct(
-        $template_type_identifier
+        string $template_type_identifier
     ) {
         $this->template_type_identifier = $template_type_identifier;
     }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -93,11 +93,15 @@ class UnionType implements \Serializable
      * The context in which the type string was
      * found
      *
+     * @param bool $from_phpdoc
+     * True if $type_string was extracted from a doc comment.
+     *
      * @return UnionType
      */
     public static function fromStringInContext(
         string $type_string,
-        Context $context
+        Context $context,
+        bool $from_phpdoc = false
     ) : UnionType {
         if (empty($type_string)) {
             return new UnionType();
@@ -112,11 +116,12 @@ class UnionType implements \Serializable
         }
 
         return new UnionType(
-            array_map(function (string $type_name) use ($context, $type_string) {
+            array_map(function (string $type_name) use ($context, $type_string, $from_phpdoc) {
                 assert($type_name !== '', "Type cannot be empty.");
                 return Type::fromStringInContext(
                     $type_name,
-                    $context
+                    $context,
+                    $from_phpdoc
                 );
             }, array_filter(array_map(function (string $type_name) {
                 return trim($type_name);

--- a/tests/files/expected/0263_alias_outside_phpdoc.php.expected
+++ b/tests/files/expected/0263_alias_outside_phpdoc.php.expected
@@ -1,0 +1,10 @@
+%s:4 PhanUndeclaredTypeParameter Parameter of undeclared type \boolean
+%s:4 PhanUndeclaredTypeParameter Parameter of undeclared type \callback
+%s:4 PhanUndeclaredTypeParameter Parameter of undeclared type \double
+%s:4 PhanUndeclaredTypeParameter Parameter of undeclared type \integer
+%s:5 PhanTypeMismatchReturn Returning type bool but foo263() is declared to return \boolean
+%s:7 PhanTypeMismatchArgument Argument 1 (a) is bool but \foo263() takes \boolean defined at %s:4
+%s:7 PhanTypeMismatchArgument Argument 2 (b) is int but \foo263() takes \integer defined at %s:4
+%s:7 PhanTypeMismatchArgument Argument 3 (c) is callable but \foo263() takes \callback defined at %s:4
+%s:7 PhanTypeMismatchArgument Argument 4 (d) is float but \foo263() takes \double defined at %s:4
+%s:7 PhanTypeMismatchArgument Argument 5 (e) is float but \foo263() takes \double defined at %s:4

--- a/tests/files/src/0263_alias_outside_phpdoc.php
+++ b/tests/files/src/0263_alias_outside_phpdoc.php
@@ -1,0 +1,7 @@
+<?php
+
+// This is completely invalid, classes instead of native types
+function foo263(boolean $a, integer $b, callback $c, double $d, double ...$e) : boolean {
+    return false;
+}
+foo263(false, 2, function() {}, 1.2345, 3.14);


### PR DESCRIPTION
e.g. Emit warning if `bool` is mistyped as `boolean` in the actual declared
types, and there's no definition for a `class boolean`