### PR TITLE
Remove null from type if a conditional asserts var is set/truthy

### DIFF
--- a/src/Phan/Language/Type/NullType.php
+++ b/src/Phan/Language/Type/NullType.php
@@ -50,7 +50,7 @@ class NullType extends ScalarType
             return true;
         }
 
-        // A nullable type cannot cast to a non-nullable type
+        // Null can cast to a nullable type.
         if ($type->getIsNullable()) {
             return true;
         }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -316,7 +316,7 @@ class UnionType implements \Serializable
     /**
      * Add the given types to this type
      *
-     * @return null
+     * @return void
      */
     public function addUnionType(UnionType $union_type)
     {
@@ -542,6 +542,36 @@ class UnionType implements \Serializable
     public function isEqualTo(UnionType $union_type) : bool
     {
         return ((string)$this === (string)$union_type);
+    }
+
+    /**
+     * @return bool - True if not empty and at least one type is NullType or nullable.
+     */
+    public function containsNullable() : bool
+    {
+        foreach ($this->getTypeSet() as $type) {
+            if ($type->getIsNullable()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public function nonNullableClone() : UnionType
+    {
+        $result = new UnionType();
+        foreach ($this->getTypeSet() as $type) {
+            if (!$type->getIsNullable()) {
+                $result->addType($type);
+                continue;
+            }
+            if ($type === NullType::instance(false)) {
+                continue;
+            }
+
+            $result->addType($type->withIsNullable(false));
+        }
+        return $result;
     }
 
     /**

--- a/tests/files/expected/0264_emptiness_check.php.expected
+++ b/tests/files/expected/0264_emptiness_check.php.expected
@@ -1,0 +1,14 @@
+%s:35 PhanTypeMismatchArgument Argument 1 (x) is null|object but \A263::expect_array() takes array defined at %s:7
+%s:37 PhanTypeMismatchArgument Argument 1 (x) is object but \A263::expect_array() takes array defined at %s:7
+%s:40 PhanTypeMismatchArgument Argument 1 (x) is null|object but \A263::expect_array() takes array defined at %s:7
+%s:42 PhanTypeMismatchArgument Argument 1 (x) is object but \A263::expect_array() takes array defined at %s:7
+%s:44 PhanTypeMismatchArgument Argument 1 (x) is null|object but \A263::expect_array() takes array defined at %s:7
+%s:46 PhanTypeMismatchArgument Argument 1 (x) is object but \A263::expect_array() takes array defined at %s:7
+%s:54 PhanTypeMismatchArgument Argument 1 (x) is bool|null but \A263::expect_array() takes array defined at %s:7
+%s:56 PhanTypeMismatchArgument Argument 1 (x) is bool but \A263::expect_array() takes array defined at %s:7
+%s:59 PhanTypeMismatchArgument Argument 1 (x) is bool|null but \A263::expect_array() takes array defined at %s:7
+%s:61 PhanTypeMismatchArgument Argument 1 (x) is bool but \A263::expect_array() takes array defined at %s:7
+%s:63 PhanTypeMismatchArgument Argument 1 (x) is bool|null but \A263::expect_array() takes array defined at %s:7
+%s:65 PhanTypeMismatchArgument Argument 1 (x) is bool but \A263::expect_array() takes array defined at %s:7
+%s:73 PhanTypeMismatchArgument Argument 1 (x) is ?bool but \A263::expect_array() takes array defined at %s:7
+%s:75 PhanTypeMismatchArgument Argument 1 (x) is bool but \A263::expect_array() takes array defined at %s:7

--- a/tests/files/src/0264_emptiness_check.php
+++ b/tests/files/src/0264_emptiness_check.php
@@ -1,0 +1,80 @@
+<?php
+
+class A263{
+    /**
+     * @param array $x
+     */
+    public static function expect_array($x) {
+    }
+
+    /**
+     * @param object $x
+     */
+    public static function expect_object($x) {
+    }
+
+    /**
+     * @param bool $x
+     */
+    public static function expect_bool($x) {
+    }
+
+    /**
+     * @param null $x - No code would actually be like this, just enforcing the types
+     */
+    public static function foo($x = null) {
+        if (isset($x)) {
+            self::expect_object($x);  // should not emit an issue, since Phan has no idea what $x is.
+        }
+    }
+
+    /**
+     * @param object|null $x
+     */
+    public static function with_nullable_object($x) {
+        self::expect_array($x);  // type is object|null.
+        if ($x) {
+            self::expect_array($x);  // type is object. This cuts down on false negatives for scalar_cast and null_casts_as_any_type
+            self::expect_object($x);
+        }
+        self::expect_array($x);  // type is object|null.
+        if (!is_null($x)) {
+            self::expect_array($x);  // type is object
+        }
+        self::expect_array($x);  // type is object|null.
+        if (isset($x)) {
+            self::expect_array($x);  // type is object
+        }
+    }
+
+    /**
+     * @param bool|null $x
+     */
+    public static function with_nullable_scalar($x) {
+        self::expect_array($x);  // type is bool|null.
+        if ($x) {
+            self::expect_array($x);  // type is bool. This cuts down on false negatives for null_casts_as_any_type
+            self::expect_bool($x);  // type is bool
+        }
+        self::expect_array($x);  // type is bool|null
+        if (!is_null($x)) {
+            self::expect_array($x);  // type is bool
+        }
+        self::expect_array($x);  // type is bool|null.
+        if (isset($x)) {
+            self::expect_array($x);  // type is bool
+        }
+    }
+
+    /**
+     * @param ?bool $x
+     */
+    public static function with_new_nullable_scalar($x) {
+        self::expect_array($x);  // type is ?bool
+        if ($x) {
+            self::expect_array($x);  // type is bool. This cuts down on false negatives for null_casts_as_any_type
+        }
+    }
+}
+
+A263::foo();


### PR DESCRIPTION
Implements most of #518
(Supports everything mentioned there except `$x !== null`)

- Cuts down on false negatives (May reduce actual errors detected in
  possibly unreachable statements)
- May make this more accurate for unionTypes with multiple known types,
  including null (if null_casts_as_any_type or scalar_implicit_cast is used)
- The goal is to stop false positives such as "attempted to call method on null"
  if the code would be unreachable for null (e.g. #518)

---

Also, is there a reason why visitBinaryOp doesn't have code for boolean and (`&&`) (or why visitAnd (`and`) wasn't added)