### PR TITLE
Fix @return, @param and @var types

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -74,7 +74,7 @@ class UnionTypeVisitor extends AnalysisVisitor
      * The context of the parser at the node for which we'd
      * like to determine a type
      *
-     * @param Node|mixed $node
+     * @param Node|string|bool|int|float|null $node
      * The node for which we'd like to determine its type
      *
      * @param bool $should_catch_issue_exception

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -160,7 +160,7 @@ class Analysis
      * Take a pass over all functions verifying various
      * states.
      *
-     * @return null
+     * @return void
      */
     public static function analyzeFunctions(CodeBase $code_base)
     {

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -33,7 +33,7 @@ class ArgumentType
      * @param CodeBase $code_base
      * The global code base
      *
-     * @return null
+     * @return void
      *
      * @see \Phan\Deprecated\Pass2::arg_check
      * Formerly `function arg_check`
@@ -204,7 +204,7 @@ class ArgumentType
      * @param Context $context
      * The context in which we see the call
      *
-     * @return null
+     * @return void
      *
      * @see \Phan\Deprecated\Pass2::arglist_type_check
      * Formerly `function arglist_type_check`
@@ -328,7 +328,7 @@ class ArgumentType
                 } elseif ($method->isInternal()) {
                     // If we are not in strict mode and we accept a string parameter
                     // and the argument we are passing has a __toString method then it is ok
-                    if(!$context->getIsStrictTypes() && $parameter_type->hasType(StringType::instance(false))) {
+                    if(!$context->getIsStrictTypes() && is_object($parameter_type) && $parameter_type->hasType(StringType::instance(false))) {
                         try {
                             foreach($argument_type_expanded->asClassList($code_base, $context) as $clazz) {
                                 if($clazz->hasMethodWithName($code_base, "__toString")) {
@@ -373,7 +373,7 @@ class ArgumentType
      * Emit a log message if the type of the given
      * node cannot be cast to the given type
      *
-     * @param Node|null|string|int $node
+     * @param Node|null|string|int|float $node
      * A node or whatever php-ast feels like returning
      *
      * @param Context $context

--- a/src/Phan/Analysis/DuplicateClassAnalyzer.php
+++ b/src/Phan/Analysis/DuplicateClassAnalyzer.php
@@ -11,7 +11,7 @@ class DuplicateClassAnalyzer
     /**
      * Check to see if the given Clazz is a duplicate
      *
-     * @return null
+     * @return void
      */
     public static function analyzeDuplicateClass(
         CodeBase $code_base,

--- a/src/Phan/Analysis/DuplicateFunctionAnalyzer.php
+++ b/src/Phan/Analysis/DuplicateFunctionAnalyzer.php
@@ -12,7 +12,7 @@ class DuplicateFunctionAnalyzer
     /**
      * Check to see if the given Clazz is a duplicate
      *
-     * @return null
+     * @return void
      */
     public static function analyzeDuplicateFunction(
         CodeBase $code_base,

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -16,7 +16,7 @@ class ParameterTypesAnalyzer
     /**
      * Check method parameters to make sure they're valid
      *
-     * @return null
+     * @return void
      */
     public static function analyzeParameterTypes(
         CodeBase $code_base,

--- a/src/Phan/Analysis/ParentClassExistsAnalyzer.php
+++ b/src/Phan/Analysis/ParentClassExistsAnalyzer.php
@@ -13,7 +13,7 @@ class ParentClassExistsAnalyzer
     /**
      * Check to see if the given Clazz is a duplicate
      *
-     * @return null
+     * @return void
      */
     public static function analyzeParentClassExists(
         CodeBase $code_base,

--- a/src/Phan/Analysis/ParentConstructorCalledAnalyzer.php
+++ b/src/Phan/Analysis/ParentConstructorCalledAnalyzer.php
@@ -12,7 +12,7 @@ class ParentConstructorCalledAnalyzer
     /**
      * Check to see if the given Clazz is a duplicate
      *
-     * @return null
+     * @return void
      */
     public static function analyzeParentConstructorCalled(
         CodeBase $code_base,

--- a/src/Phan/Analysis/PropertyTypesAnalyzer.php
+++ b/src/Phan/Analysis/PropertyTypesAnalyzer.php
@@ -13,7 +13,7 @@ class PropertyTypesAnalyzer
     /**
      * Check to see if the given Clazz is a duplicate
      *
-     * @return null
+     * @return void
      */
     public static function analyzePropertyTypes(CodeBase $code_base, Clazz $clazz)
     {

--- a/src/Phan/Analysis/ReferenceCountsAnalyzer.php
+++ b/src/Phan/Analysis/ReferenceCountsAnalyzer.php
@@ -141,7 +141,7 @@ class ReferenceCountsAnalyzer
     /**
      * Check to see if the given Clazz is a duplicate
      *
-     * @return null
+     * @return void
      */
     public static function analyzeElementReferenceCounts(
         CodeBase $code_base,

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -13,6 +13,9 @@ use Symfony\Component\Console\Output\StreamOutput;
 
 class CLI
 {
+    /**
+     * @var OutputInterface
+     */
     private $output;
 
     /**
@@ -504,7 +507,7 @@ EOB;
      * How frequently we should update the progress
      * bar, randomly sampled
      *
-     * @return null
+     * @return void
      */
     public static function progress(
         string $msg,

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -148,16 +148,13 @@ class CodeBase
      * @param string[] $function_name_list
      * A list of function names to load type information for
      */
-    private function addFunctionsByNames(array $function_name_list) {
+    private function addFunctionsByNames(array $function_name_list)
+    {
         foreach ($function_name_list as $i => $function_name) {
             foreach (FunctionFactory::functionListFromName($this, $function_name)
                 as $function_or_method
             ) {
-                if ($function_or_method instanceof Method) {
-                    $this->addMethod($function_or_method);
-                } else {
-                    $this->addFunction($function_or_method);
-                }
+                $this->addFunction($function_or_method);
             }
         }
     }

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -10,7 +10,7 @@ class Config
 {
 
     /**
-     * @var string
+     * @var string|null
      * The root directory of the project. This is used to
      * store canonical path names and find project resources
      */

--- a/src/Phan/Debug.php
+++ b/src/Phan/Debug.php
@@ -27,7 +27,7 @@ class Debug
      *
      * Print an AST node
      *
-     * @return null
+     * @return void
      *
      * @suppress PhanUnreferencedMethod
      */
@@ -160,7 +160,7 @@ class Debug
     }
 
     /**
-     * @return string
+     * @return void
      * Pretty-printer for debug_backtrace
      *
      * @suppress PhanUnreferencedMethod

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -246,7 +246,7 @@ class Context extends FileRef
      * @param Variable $variable
      * A variable to inject into this context
      *
-     * @return null
+     * @return void
      */
     public function addScopeVariable(
         Variable $variable

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -74,8 +74,8 @@ class Clazz extends AddressableElement
      * A fully qualified name for this class
      *
      * @param Type|null $parent_type
-     * @param FullyQualifiedClassName[]|null $interface_fqsen_list
-     * @param FullyQualifiedClassName[]|null $trait_fqsen_list
+     * @param FullyQualifiedClassName[] $interface_fqsen_list
+     * @param FullyQualifiedClassName[] $trait_fqsen_list
      */
     public function __construct(
         Context $context,
@@ -520,7 +520,7 @@ class Clazz extends AddressableElement
      * Add the given FQSEN to the list of implemented
      * interfaces for this class
      *
-     * @return null
+     * @return void
      */
     public function addInterfaceClassFQSEN(FQSEN $fqsen)
     {
@@ -956,7 +956,7 @@ class Clazz extends AddressableElement
      * A possibly defined type used to define template
      * parameter types when importing the method
      *
-     * @return null
+     * @return void
      */
     public function addMethod(
         CodeBase $code_base,
@@ -1234,7 +1234,7 @@ class Clazz extends AddressableElement
     }
 
     /**
-     * @return null
+     * @return void
      */
     public function addTraitFQSEN(FQSEN $fqsen)
     {
@@ -1478,7 +1478,7 @@ class Clazz extends AddressableElement
      * The entire code base from which we'll find ancestor
      * details
      *
-     * @return null
+     * @return void
      */
     public function importAncestorClasses(CodeBase $code_base)
     {

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -50,14 +50,14 @@ class Comment
     private $template_type_list = [];
 
     /**
-     * @var Option<Type>
+     * @var Option<Type>|null
      * Classes may specify their inherited type explicitly
      * via `@inherits Type`.
      */
     private $inherited_type = null;
 
     /**
-     * @var UnionType
+     * @var UnionType|null
      * A UnionType defined by a @return directive
      */
     private $return_union_type = null;
@@ -76,7 +76,7 @@ class Comment
      * Set to true if the comment contains a 'deprecated'
      * directive.
      *
-     * @param Variable[] $variable_list
+     * @param CommentParameter[] $variable_list
      *
      * @param CommentParameter[] $parameter_list
      *

--- a/src/Phan/Language/Element/FunctionFactory.php
+++ b/src/Phan/Language/Element/FunctionFactory.php
@@ -11,7 +11,7 @@ use Phan\Language\UnionType;
 class FunctionFactory {
 
     /**
-     * @return FunctionInterface[]
+     * @return Func[]
      * One or more (alternate) methods begotten from
      * reflection info and internal method data
      */

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -17,7 +17,7 @@ class Parameter extends Variable
 {
 
     /**
-     * @var UnionType
+     * @var UnionType|null
      * The type of the default value if any
      */
     private $default_value_type = null;

--- a/src/Phan/Language/Element/PassByReferenceVariable.php
+++ b/src/Phan/Language/Element/PassByReferenceVariable.php
@@ -15,7 +15,7 @@ use Phan\Language\UnionType;
 class PassByReferenceVariable extends Variable
 {
 
-    /** @var Parameter */
+    /** @var Variable */
     private $parameter;
 
     /** @var TypedElement */

--- a/src/Phan/Language/Element/TypedElement.php
+++ b/src/Phan/Language/Element/TypedElement.php
@@ -20,7 +20,7 @@ abstract class TypedElement implements TypedElementInterface
     private $name;
 
     /**
-     * @var UnionType
+     * @var UnionType|null
      * A set of types satisfyped by this typed structural
      * element.
      */
@@ -43,7 +43,7 @@ abstract class TypedElement implements TypedElementInterface
     private $phan_flags = 0;
 
     /**
-     * @var Context
+     * @var Context|null
      * The context in which the structural element lives
      */
     private $context = null;

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -84,14 +84,14 @@ class Type
     ];
 
     /**
-     * @var string
+     * @var string|null
      * The namespace of this type such as '\' or
      * '\Phan\Language'
      */
     protected $namespace = null;
 
     /**
-     * @var string
+     * @var string|null
      * The name of this type such as 'int' or 'MyClass'
      */
     protected $name = null;
@@ -887,10 +887,11 @@ class Type
      * @param CodeBase $code_base
      * The code base to look up classes against
      *
-     * @return Type[]
+     * @return UnionType[]
      * A map from template type identifier to a concrete type
      */
-    public function getTemplateParameterTypeMap(CodeBase $code_base) {
+    public function getTemplateParameterTypeMap(CodeBase $code_base)
+    {
         return $this->memoize(__METHOD__, function () use ($code_base) {
             $fqsen = $this->asFQSEN();
 

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -8,7 +8,7 @@ class GenericArrayType extends ArrayType
     const NAME = 'array';
 
     /**
-     * @var Type
+     * @var Type|null
      * The type of every element in this array
      */
     private $element_type = null;

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -137,7 +137,7 @@ class UnionType implements \Serializable
      * @param CodeBase $code_base
      * The code base within which we're operating
      *
-     * @param Node|string|null $node
+     * @param Node|string|bool|int|float|null $node
      * The node for which we'd like to determine its type
      *
      * @param bool $should_catch_issue_exception

--- a/src/Phan/Memoize.php
+++ b/src/Phan/Memoize.php
@@ -82,7 +82,7 @@ trait Memoize
     /**
      * Delete all memoized data
      *
-     * @return null
+     * @return void
      */
     protected function memoizeFlushAll()
     {

--- a/src/Phan/Ordering.php
+++ b/src/Phan/Ordering.php
@@ -7,7 +7,7 @@ use Phan\Library\Hasher\Sequential;
 
 class Ordering
 {
-    /** @param CodeBase */
+    /** @var CodeBase */
     private $code_base;
 
     /**

--- a/src/Phan/Output/Collector/BufferingCollector.php
+++ b/src/Phan/Output/Collector/BufferingCollector.php
@@ -12,7 +12,7 @@ final class BufferingCollector implements IssueCollectorInterface
     /** @var  IssueInstance[] */
     private $issues = [];
 
-    /** @var IssueFilterInterface */
+    /** @var IssueFilterInterface|null */
     private $filter;
 
     /**


### PR DESCRIPTION
This is mostly just changing `@return null` to `@return void`, with two other notable changes:

- the last two args of `Clazz::__construct` are no longer nullable
- fixed `@return` of `Type::getTemplateParameterTypeMap` as Psalm emitted an error [here](https://github.com/etsy/phan/blob/55cd20bf23c906e2c80e3083b72759d75a27057c/src/Phan/Analysis/ParameterTypesAnalyzer.php#L142-L144)