### PR TITLE
Support analyzing closures that will be bound (for #309)

### DIFF
--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -20,6 +20,7 @@ class Issue
     const UndeclaredClassInstanceof = 'PhanUndeclaredClassInstanceof';
     const UndeclaredClassMethod     = 'PhanUndeclaredClassMethod';
     const UndeclaredClassReference  = 'PhanUndeclaredClassReference';
+    const UndeclaredClosureScope    = 'PhanUndeclaredClosureScope';
     const UndeclaredConstant        = 'PhanUndeclaredConstant';
     const UndeclaredExtendedClass   = 'PhanUndeclaredExtendedClass';
     const UndeclaredFunction        = 'PhanUndeclaredFunction';
@@ -42,6 +43,7 @@ class Issue
     const TypeConversionFromArray   = 'PhanTypeConversionFromArray';
     const TypeInstantiateAbstract   = 'PhanTypeInstantiateAbstract';
     const TypeInstantiateInterface  = 'PhanTypeInstantiateInterface';
+    const TypeInvalidClosureScope   = 'PhanTypeInvalidClosureScope';
     const TypeInvalidLeftOperand    = 'PhanTypeInvalidLeftOperand';
     const TypeInvalidRightOperand   = 'PhanTypeInvalidRightOperand';
     const TypeMismatchArgument      = 'PhanTypeMismatchArgument';
@@ -417,6 +419,14 @@ class Issue
                 self::REMEDIATION_B,
                 1020
             ),
+            new Issue(
+                self::UndeclaredClosureScope,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_NORMAL,
+                "Reference to undeclared class %s in PhanClosureScope",
+                self::REMEDIATION_B,
+                1021
+            ),
 
             // Issue::CATEGORY_ANALYSIS
             new Issue(
@@ -564,6 +574,14 @@ class Issue
                 "Instantiation of interface %s",
                 self::REMEDIATION_B,
                 10014
+            ),
+            new Issue(
+                self::TypeInvalidClosureScope,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "Invalid PhanClosureScope: expected a class name, got %s",
+                self::REMEDIATION_B,
+                10023
             ),
             new Issue(
                 self::TypeInvalidRightOperand,

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -145,7 +145,7 @@ class Comment
 
         if (!Config::get()->read_type_annotations) {
             return new Comment(
-                false, [], [], [], new None, new UnionType(), [], null
+                false, [], [], [], new None, new UnionType(), [], new None()
             );
         }
 

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -69,6 +69,13 @@ class Comment
     private $suppress_issue_list = [];
 
     /**
+     * @var Option<Type>
+     * An optional class name defined by a @PhanClosureScope directive.
+     * (overrides the class in which it is analyzed)
+     */
+    private $closure_scope = null;
+
+    /**
      * A private constructor meant to ingest a parsed comment
      * docblock.
      *
@@ -86,10 +93,14 @@ class Comment
      * @param Option<Type> $inherited_type
      * An override on the type of the extended class
      *
-     * @param UnionType $return
+     * @param UnionType $return_union_type
      *
      * @param string[] $suppress_issue_list
      * A list of tags for error type to be suppressed
+     *
+     * @param Option<type> $closure_scope
+     * For closures: Allows us to document the class of the object
+     * to which a closure will be bound.
      */
     private function __construct(
         bool $is_deprecated,
@@ -98,7 +109,8 @@ class Comment
         array $template_type_list,
         Option $inherited_type,
         UnionType $return_union_type,
-        array $suppress_issue_list
+        array $suppress_issue_list,
+        Option $closure_scope
     ) {
         $this->is_deprecated = $is_deprecated;
         $this->variable_list = $variable_list;
@@ -107,6 +119,7 @@ class Comment
         $this->inherited_type = $inherited_type;
         $this->return_union_type = $return_union_type;
         $this->suppress_issue_list = $suppress_issue_list;
+        $this->closure_scope = $closure_scope;
 
         foreach ($this->parameter_list as $i => $parameter) {
             $name = $parameter->getName();
@@ -132,7 +145,7 @@ class Comment
 
         if (!Config::get()->read_type_annotations) {
             return new Comment(
-                false, [], [], [], new None, new UnionType(), []
+                false, [], [], [], new None, new UnionType(), [], null
             );
         }
 
@@ -143,6 +156,7 @@ class Comment
         $inherited_type = new None;
         $return_union_type = new UnionType();
         $suppress_issue_list = [];
+        $closure_scope = new None;
 
         $lines = explode("\n", $comment);
 
@@ -176,9 +190,11 @@ class Comment
             } elseif (stripos($line, '@suppress') !== false) {
                 $suppress_issue_list[] =
                     self::suppressIssueFromCommentLine($line);
+            } elseif (stripos($line, '@PhanClosureScope') !== false) {
+                $closure_scope = self::getPhanClosureScopeFromCommentLine($context, $line);
             }
 
-            if (($pos=stripos($line, '@deprecated')) !== false) {
+            if (stripos($line, '@deprecated') !== false) {
                 if (preg_match('/@deprecated\b/', $line, $match)) {
                     $is_deprecated = true;
                 }
@@ -192,7 +208,8 @@ class Comment
             $template_type_list,
             $inherited_type,
             $return_union_type,
-            $suppress_issue_list
+            $suppress_issue_list,
+            $closure_scope
         );
     }
 
@@ -354,6 +371,41 @@ class Comment
     }
 
     /**
+     * @param Context $context
+     * The context in which the comment line appears
+     *
+     * @param string $line
+     * An individual line of a comment
+     *
+     * @return Option<Type>
+     * A class/interface to use as a context for a closure.
+     * (Phan expects a ClassScope to have exactly one type)
+     */
+    private static function getPhanClosureScopeFromCommentLine(
+        Context $context,
+        string $line
+    ) : Option {
+        $closure_scope_union_type_string = '';
+
+        // https://secure.php.net/manual/en/closure.bindto.php
+        // There wasn't anything in the phpdoc standard to indicate the class to which
+        // a Closure would be bound with bind() or bindTo(), so using a custom tag.
+        //
+        // TODO: Also add a version which forbids using $this in the closure?
+        if (preg_match('/@PhanClosureScope\s+(' . UnionType::union_type_regex . '+)/', $line, $match)) {
+            $closure_scope_union_type_string = $match[1];
+        }
+
+        if ($closure_scope_union_type_string !== '') {
+            return new Some(Type::fromStringInContext(
+                $closure_scope_union_type_string,
+                $context
+            ));
+        }
+        return new None();
+    }
+
+    /**
      * @return bool
      * Set to true if the comment contains a 'deprecated'
      * directive.
@@ -379,7 +431,17 @@ class Comment
      */
     public function hasReturnUnionType() : bool
     {
-        return !empty($this->return_union_type) && !$this->return_union_type->isEmpty();
+        return !$this->return_union_type->isEmpty();
+    }
+
+    /**
+     * @return Option
+     * An optional Type defined by a (at)PhanClosureScope
+     * directive specifying a single type.
+     */
+    public function getClosureScopeOption() : Option
+    {
+        return $this->closure_scope;
     }
 
     /**
@@ -405,7 +467,7 @@ class Comment
      * @return Option<Type>
      * An optional type declaring what a class extends.
      */
-    public function getInheritedTypeOption()
+    public function getInheritedTypeOption() : Option
     {
         return $this->inherited_type;
     }

--- a/src/Phan/Language/Scope/FunctionLikeScope.php
+++ b/src/Phan/Language/Scope/FunctionLikeScope.php
@@ -4,6 +4,7 @@ namespace Phan\Language\Scope;
 use Phan\Language\FQSEN\FullyQualifiedFunctionName;
 use Phan\Language\FQSEN\FullyQualifiedMethodName;
 
+// TODO: Wrap this with a ClosureLikeScope
 class FunctionLikeScope extends ClosedScope {
 
     /**

--- a/tests/files/expected/0264_closure_override_context.php.expected
+++ b/tests/files/expected/0264_closure_override_context.php.expected
@@ -1,0 +1,4 @@
+%s:44 PhanUndeclaredProperty Reference to undeclared property \closure264\BoundClass264->d
+%s:50 PhanTypeInvalidClosureScope Invalid PhanClosureScope: expected a class name, got string
+%s:51 PhanUndeclaredProperty Reference to undeclared property \closure264\TestFramework->b
+%s:51 PhanUndeclaredProperty Reference to undeclared property \closure264\TestFramework->d

--- a/tests/files/src/0264_closure_override_context.php
+++ b/tests/files/src/0264_closure_override_context.php
@@ -1,0 +1,54 @@
+<?php
+namespace closure264;
+
+class BoundClass264 {
+    /** @var string $b */
+    protected $b = 'a';
+
+    /** @var string $b */
+    public $c = 'a';
+
+    protected static function a_static_method() { }
+}
+
+class TestFramework {
+    /** @var string */
+    protected $_frameworkProperty = 'value';
+    public function mockA() : string {
+        // BoundClass264::a_static_method(); // What? This should emit an issue.
+
+        /**
+         * blank, should be ignored?
+         * @PhanClosureScope
+         */
+        $w = function() : string {
+            // BoundClass264::a_static_method();  // should emit an issue?
+            return $this->_frameworkProperty;
+        };
+
+        /**
+         * @PhanClosureScope BoundClass264
+         */
+        $x = function() : string {
+            BoundClass264::a_static_method();
+            self::a_static_method();
+            return $this->b . $this->c;
+        };
+
+        /**
+         * @PhanClosureScope \closure264\BoundClass264
+         */
+        $y = function() : string {
+            BoundClass264::a_static_method();
+            self::a_static_method();
+            return $this->b . $this->d;
+        };
+        /**
+         * BoundClass264 scope of a native type(string, array, object, bool, etc.) makes no sense. Phan should warn.
+         * @PhanClosureScope string
+         */
+        $z = function() : string {
+            return $this->b . $this->d;
+        };
+    }
+}


### PR DESCRIPTION
- bindTo() may be called outside of the analyzed method, so an alternative way to annotate is needed
- There is no phpdoc standard for this, and I haven't checked if any
  other analysis tools have their own way of doing it. (Never seen it, though)
  e.g. https://youtrack.jetbrains.com/issue/WI-16785 phpstorm doesn't support it.
- Use $this from the bound class
- Only use this annotation for Closures.

For https://github.com/etsy/phan/issues/309

- Further work would be to check if bindTo() or Closure::bind
  is called immediately after creating the closure. Not done in this PR.