### PR TITLE
Fixes issue #465 : Apply conditionals such as is_string to ternary operator, and to null coalescing operator

### DIFF
--- a/src/Phan/Language/Type/NullType.php
+++ b/src/Phan/Language/Type/NullType.php
@@ -50,7 +50,7 @@ class NullType extends ScalarType
             return true;
         }
 
-        // A nullable type cannot cast to a non-nullable type
+        // Null can cast to a nullable type.
         if ($type->getIsNullable()) {
             return true;
         }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -316,7 +316,7 @@ class UnionType implements \Serializable
     /**
      * Add the given types to this type
      *
-     * @return null
+     * @return void
      */
     public function addUnionType(UnionType $union_type)
     {
@@ -542,6 +542,36 @@ class UnionType implements \Serializable
     public function isEqualTo(UnionType $union_type) : bool
     {
         return ((string)$this === (string)$union_type);
+    }
+
+    /**
+     * @return bool - True if not empty and at least one type is NullType or nullable.
+     */
+    public function containsNullable() : bool
+    {
+        foreach ($this->getTypeSet() as $type) {
+            if ($type->getIsNullable()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public function nonNullableClone() : UnionType
+    {
+        $result = new UnionType();
+        foreach ($this->getTypeSet() as $type) {
+            if (!$type->getIsNullable()) {
+                $result->addType($type);
+                continue;
+            }
+            if ($type === NullType::instance(false)) {
+                continue;
+            }
+
+            $result->addType($type->withIsNullable(false));
+        }
+        return $result;
     }
 
     /**

--- a/tests/files/expected/0264_emptiness_check.php.expected
+++ b/tests/files/expected/0264_emptiness_check.php.expected
@@ -1,0 +1,14 @@
+%s:35 PhanTypeMismatchArgument Argument 1 (x) is null|object but \A263::expect_array() takes array defined at %s:7
+%s:37 PhanTypeMismatchArgument Argument 1 (x) is object but \A263::expect_array() takes array defined at %s:7
+%s:40 PhanTypeMismatchArgument Argument 1 (x) is null|object but \A263::expect_array() takes array defined at %s:7
+%s:42 PhanTypeMismatchArgument Argument 1 (x) is object but \A263::expect_array() takes array defined at %s:7
+%s:44 PhanTypeMismatchArgument Argument 1 (x) is null|object but \A263::expect_array() takes array defined at %s:7
+%s:46 PhanTypeMismatchArgument Argument 1 (x) is object but \A263::expect_array() takes array defined at %s:7
+%s:54 PhanTypeMismatchArgument Argument 1 (x) is bool|null but \A263::expect_array() takes array defined at %s:7
+%s:56 PhanTypeMismatchArgument Argument 1 (x) is bool but \A263::expect_array() takes array defined at %s:7
+%s:59 PhanTypeMismatchArgument Argument 1 (x) is bool|null but \A263::expect_array() takes array defined at %s:7
+%s:61 PhanTypeMismatchArgument Argument 1 (x) is bool but \A263::expect_array() takes array defined at %s:7
+%s:63 PhanTypeMismatchArgument Argument 1 (x) is bool|null but \A263::expect_array() takes array defined at %s:7
+%s:65 PhanTypeMismatchArgument Argument 1 (x) is bool but \A263::expect_array() takes array defined at %s:7
+%s:73 PhanTypeMismatchArgument Argument 1 (x) is ?bool but \A263::expect_array() takes array defined at %s:7
+%s:75 PhanTypeMismatchArgument Argument 1 (x) is bool but \A263::expect_array() takes array defined at %s:7

--- a/tests/files/expected/0265_ternary_guards.php.expected
+++ b/tests/files/expected/0265_ternary_guards.php.expected
@@ -1,0 +1,1 @@
+%s:9 PhanTypeMismatchArgumentInternal Argument 1 (str) is int but \urldecode() takes string

--- a/tests/files/expected/0266_nullable_guards.php.expected
+++ b/tests/files/expected/0266_nullable_guards.php.expected
@@ -1,0 +1,1 @@
+%s:8 PhanTypeMismatchArgument Argument 1 (x) is string but \expects_nullable_int266() takes int|null defined at %s:3

--- a/tests/files/src/0264_emptiness_check.php
+++ b/tests/files/src/0264_emptiness_check.php
@@ -1,0 +1,80 @@
+<?php
+
+class A263{
+    /**
+     * @param array $x
+     */
+    public static function expect_array($x) {
+    }
+
+    /**
+     * @param object $x
+     */
+    public static function expect_object($x) {
+    }
+
+    /**
+     * @param bool $x
+     */
+    public static function expect_bool($x) {
+    }
+
+    /**
+     * @param null $x - No code would actually be like this, just enforcing the types
+     */
+    public static function foo($x = null) {
+        if (isset($x)) {
+            self::expect_object($x);  // should not emit an issue, since Phan has no idea what $x is.
+        }
+    }
+
+    /**
+     * @param object|null $x
+     */
+    public static function with_nullable_object($x) {
+        self::expect_array($x);  // type is object|null.
+        if ($x) {
+            self::expect_array($x);  // type is object. This cuts down on false negatives for scalar_cast and null_casts_as_any_type
+            self::expect_object($x);
+        }
+        self::expect_array($x);  // type is object|null.
+        if (!is_null($x)) {
+            self::expect_array($x);  // type is object
+        }
+        self::expect_array($x);  // type is object|null.
+        if (isset($x)) {
+            self::expect_array($x);  // type is object
+        }
+    }
+
+    /**
+     * @param bool|null $x
+     */
+    public static function with_nullable_scalar($x) {
+        self::expect_array($x);  // type is bool|null.
+        if ($x) {
+            self::expect_array($x);  // type is bool. This cuts down on false negatives for null_casts_as_any_type
+            self::expect_bool($x);  // type is bool
+        }
+        self::expect_array($x);  // type is bool|null
+        if (!is_null($x)) {
+            self::expect_array($x);  // type is bool
+        }
+        self::expect_array($x);  // type is bool|null.
+        if (isset($x)) {
+            self::expect_array($x);  // type is bool
+        }
+    }
+
+    /**
+     * @param ?bool $x
+     */
+    public static function with_new_nullable_scalar($x) {
+        self::expect_array($x);  // type is ?bool
+        if ($x) {
+            self::expect_array($x);  // type is bool. This cuts down on false negatives for null_casts_as_any_type
+        }
+    }
+}
+
+A263::foo();

--- a/tests/files/src/0265_ternary_guards.php
+++ b/tests/files/src/0265_ternary_guards.php
@@ -1,0 +1,10 @@
+<?php
+function foo265_good() : string {
+    $x = [];
+    return is_string($x) ? urldecode($x) : "default";
+}
+
+function foo265_issue() : string {
+    $x = [];
+    return is_int($x) ? urldecode($x) : "default";
+}

--- a/tests/files/src/0266_nullable_guards.php
+++ b/tests/files/src/0266_nullable_guards.php
@@ -1,0 +1,12 @@
+<?php
+
+function expects_nullable_int266(int $x = null) {
+}
+
+/** @param string|null $x */
+function coalescingTest266($x) {
+    expects_nullable_int266($x ?? "default"); // infer string
+    expects_nullable_int266($x ?? null);      // infer string|null, conservatively avoid false positive
+    expects_nullable_int266(null ?? null);    // infer null, avoid false positive
+    expects_nullable_int266(null ?? $x);      // infer string|null, conservatively
+}


### PR DESCRIPTION
This depends on PR https://github.com/etsy/phan/pull/530 (First commit consists of that)

- Within the truthy part of the ternary, apply the assertion to the cond.
  (Don't apply the assertion to the short for `$a ?: $b`)
  E.g. this means that `($x instanceof Foo ? $x->fooMethod() : $default)` will
  stop emitting warnings about $x being the wrong type.
- If the right hand side has any inferred types (and none of those types are 
  null/nullable), then remove null/nullability from the 
  possible values of the left hand side of `$a ?? $b` 
- Also add new context when evaluating types of ternary expressions
  e.g. `$x = is_string($y) ? $y : "default"`; will always have $x be inferred
  as a string, with no other possible types.


Currently, phan doesn't visit the null coalescing operator in BlockAnalysisVisitor, so nothing was changed for BlockAnalysisVisitor->visitCoalesce()