### PR TITLE
Add extra assertions to narrow uniontypes

### DIFF
--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -228,6 +228,11 @@ class ContextNode
             "Method name must be a string. Found non-string in context."
         );
 
+        assert(
+            $this->node instanceof \ast\Node,
+            '$this->node must be a node'
+        );
+
         try {
             $class_list = (new ContextNode(
                 $this->code_base,
@@ -369,6 +374,11 @@ class ContextNode
             }
         }
 
+        assert(
+            $this->node instanceof \ast\Node,
+            '$this->node must be a node'
+        );
+
         // Make sure the method we're calling actually exists
         if (!$this->code_base->hasFunctionWithFQSEN($function_fqsen)) {
             throw new IssueException(
@@ -396,6 +406,11 @@ class ContextNode
      */
     public function getVariable() : Variable
     {
+        assert(
+            $this->node instanceof \ast\Node,
+            '$this->node must be a node'
+        );
+
         // Get the name of the variable
         $variable_name = $this->getVariableName();
 
@@ -437,6 +452,11 @@ class ContextNode
             // Swallow it
         }
 
+        assert(
+            $this->node instanceof \ast\Node,
+            '$this->node must be a node'
+        );
+
         // Create a new variable
         $variable = Variable::fromNodeInContext(
             $this->node,
@@ -476,6 +496,11 @@ class ContextNode
     public function getProperty(
         $property_name
     ) : Property {
+
+        assert(
+            $this->node instanceof \ast\Node,
+            '$this->node must be a node'
+        );
 
         $property_name = $this->node->children['prop'];
 
@@ -631,6 +656,11 @@ class ContextNode
             // property
         }
 
+        assert(
+            $this->node instanceof \ast\Node,
+            '$this->node must be a node'
+        );
+
         try {
             $class_list = (new ContextNode(
                 $this->code_base,
@@ -695,6 +725,11 @@ class ContextNode
     public function getConst() : GlobalConstant
     {
         assert(
+            $this->node instanceof \ast\Node,
+            '$this->node must be a node'
+        );
+
+        assert(
             $this->node->kind === \ast\AST_CONST,
             "Node must be of type \ast\AST_CONST"
         );
@@ -756,6 +791,11 @@ class ContextNode
      */
     public function getClassConst() : ClassConstant
     {
+        assert(
+            $this->node instanceof \ast\Node,
+            '$this->node must be a node'
+        );
+
         assert(
             $this->node->kind === \ast\AST_CLASS_CONST,
             "Node must be of type \ast\AST_CLASS_CONST"
@@ -823,6 +863,11 @@ class ContextNode
     public function getUnqualifiedNameForAnonymousClass() : string
     {
         assert(
+            $this->node instanceof \ast\Node,
+            '$this->node must be a node'
+        );
+
+        assert(
             (bool)($this->node->flags & \ast\flags\CLASS_ANONYMOUS),
             "Node must be an anonymous class node"
         );
@@ -867,7 +912,7 @@ class ContextNode
             return;
         }
 
-        if (empty($this->node->children['expr'])) {
+        if (!($this->node instanceof \ast\Node) || empty($this->node->children['expr'])) {
             return;
         }
 
@@ -977,6 +1022,7 @@ class ContextNode
             $ftemp = new \SplFileObject($this->context->getFile());
             $ftemp->seek($this->node->lineno-1);
             $line = $ftemp->current();
+            assert(is_string($line));
             unset($ftemp);
             if (strpos($line, '}[') === false
                 || strpos($line, ']}') === false

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1416,6 +1416,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             $ftemp = new \SplFileObject($this->context->getFile());
             $ftemp->seek($node->lineno-1);
             $line = $ftemp->current();
+            assert(is_string($line));
             unset($ftemp);
             if (strpos($line, '{') === false
                 || strpos($line, '}') === false
@@ -1437,6 +1438,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             $ftemp = new \SplFileObject($this->context->getFile());
             $ftemp->seek($node->lineno-1);
             $line = $ftemp->current();
+            assert(is_string($line));
             unset($ftemp);
             if (strpos($line, '{') === false
                 || strpos($line, '}') === false
@@ -1547,7 +1549,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
      * @param FunctionInterface $method
      * @param Node $node
      *
-     * @return null
+     * @return void
      */
     private function analyzeCallToMethod(
         CodeBase $code_base,
@@ -1902,7 +1904,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
      * @param string $issue_type
      * A message to emit if it's a no-op
      *
-     * @return null
+     * @return void
      */
     private function analyzeNoOp(Node $node, string $issue_type)
     {

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -207,7 +207,6 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
             // we already successfully parsed the code
             // base
             throw $exception;
-            return $this->context;
         }
 
         // Hunt for the alternate associated with the file we're

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -130,6 +130,7 @@ class CLI
                     foreach ($file_list as $file_name) {
                         $file_path = Config::projectPath($file_name);
                         if (is_file($file_path) && is_readable($file_path)) {
+                            /** @var string[] */
                             $this->file_list = array_merge(
                                 $this->file_list,
                                 file(Config::projectPath($file_name), FILE_IGNORE_NEW_LINES|FILE_SKIP_EMPTY_LINES)
@@ -288,6 +289,7 @@ class CLI
             );
 
             // Merge in any files given in the config
+            /** @var string[] */
             $this->file_list = array_merge(
                 $this->file_list,
                 Config::get()->file_list

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -53,31 +53,31 @@ use Phan\Library\Set;
 class CodeBase
 {
     /**
-     * @var Clazz[]|Map
+     * @var Map
      * A map from FQSEN to a class
      */
     private $fqsen_class_map;
 
     /**
-     * @var GlobalConstant[]|Map
+     * @var Map
      * A map from FQSEN to a global constant
      */
     private $fqsen_global_constant_map;
 
     /**
-     * @var Func[]|Map
+     * @var Map
      * A map from FQSEN to function
      */
     private $fqsen_func_map;
 
     /**
-     * @var Func[]|Method[]|Set
+     * @var Set
      * The set of all functions and methods
      */
     private $func_and_method_set;
 
     /**
-     * @var ClassMap[]|Map
+     * @var Map
      * A map from FullyQualifiedClassName to a ClassMap,
      * an object that holds properties, methods and class
      * constants.
@@ -135,7 +135,7 @@ class CodeBase
      * @param string[] $class_name_list
      * A list of class names to load type information for
      *
-     * @return null
+     * @return void
      */
     private function addClassesByNames(array $class_name_list)
     {

--- a/src/Phan/Debug/Breakpoint.php
+++ b/src/Phan/Debug/Breakpoint.php
@@ -13,6 +13,7 @@ readline_completion_function(function($input) {
 
 print "\n";
 do {
+    /** @var string|null */
     $input = readline("breakpoint> ");
 
     if (is_string($input)) {

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -316,7 +316,7 @@ class UnionType implements \Serializable
     /**
      * Add the given types to this type
      *
-     * @return null
+     * @return void
      */
     public function addUnionType(UnionType $union_type)
     {
@@ -336,20 +336,6 @@ class UnionType implements \Serializable
         return (false !==
             $this->type_set->find(function (Type $type) : bool {
                 return $type->isSelfType();
-            })
-        );
-    }
-
-    /**
-     * @return bool
-     * True if this union type has any types that are generic
-     * types.
-     */
-    private function hasGenericType() : bool
-    {
-        return (false !==
-            $this->type_set->find(function (Type $type) : bool {
-                return $type->hasTemplateParameterTypes();
             })
         );
     }
@@ -837,7 +823,8 @@ class UnionType implements \Serializable
      * The context in which we're resolving this union
      * type.
      *
-     * @return \Generator|Clazz[]
+     * @return \Generator
+     *
      * A list of classes representing the non-native types
      * associated with this UnionType
      *

--- a/src/Phan/Library/None.php
+++ b/src/Phan/Library/None.php
@@ -36,7 +36,6 @@ class None extends Option
     public function get()
     {
         throw new \Exception("Cannot call get on None");
-        return null;
     }
 
     /**

--- a/src/Phan/Profile.php
+++ b/src/Phan/Profile.php
@@ -3,7 +3,9 @@ namespace Phan;
 
 trait Profile
 {
-
+    /**
+     * @var int[][]
+     */
     private static $label_delta_map = [];
 
     /**


### PR DESCRIPTION
These are the last of the changes necessary to pass a [lenient](https://github.com/muglug/phan/blob/f9bab456ae79112b0489329a24982c187cd6e78f/psalm.xml) Psalm check.

Phan also runs without errors.

Feel free to close this if you don't think these changes are of value:
 - a lot of extra `assert`s, not needed by Phan
 - some unused code removed
 - a number of impossible property/return types changed

Whatever you do with this PR, thanks for creating phan. As well as the code & structures I've borrowed from phan, checking phan in Psalm has highlighted a bunch of issues in Psalm along the way, and pushed me to allow a greater amount of permissiveness than it had.