### PR TITLE
Allow phan to analyze conditionals with `&&` and `and`

### DIFF
--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -70,7 +70,26 @@ class ConditionVisitor extends KindVisitorImplementation
      */
     public function visitBinaryOp(Node $node) : Context
     {
+        $flags = ($node->flags ?? 0);
+        if ($flags === \ast\flags\BINARY_BOOL_AND) {
+            $this->context = $this($node->children['left']);
+            return $this($node->children['right']);
+        }
         return $this->context;
+    }
+
+    /**
+     * @param Node $node
+     * A node to parse
+     *
+     * @return Context
+     * A new or an unchanged context resulting from
+     * parsing the node
+     */
+    public function visitAnd(Node $node) : Context
+    {
+        $this->context = $this($node->children['left']);
+        return $this($node->children['right']);
     }
 
     /**

--- a/tests/files/expected/0267_and.php.expected
+++ b/tests/files/expected/0267_and.php.expected
@@ -1,0 +1,4 @@
+%s:11 PhanTypeMismatchArgument Argument 1 (x) is int but \expect_string267() takes string defined at %s:6
+%s:14 PhanTypeMismatchArgument Argument 1 (x) is string but \expect_int267() takes int defined at %s:3
+%s:18 PhanTypeMismatchArgument Argument 1 (x) is string but \expect_int267() takes int defined at %s:3
+%s:21 PhanTypeMismatchArgument Argument 1 (x) is int but \expect_string267() takes string defined at %s:6

--- a/tests/files/src/0267_and.php
+++ b/tests/files/src/0267_and.php
@@ -1,0 +1,24 @@
+<?php
+
+function expect_int267(int $x) {
+}
+
+function expect_string267(string $x) {
+}
+
+function foo267($x, $y) {
+    if (is_int($x) && is_string($y)) {
+        expect_string267($x);
+        expect_int267($x);
+        expect_string267($y);
+        expect_int267($y);
+    }
+    if (is_string($x) && strlen($x) > 5) {
+        expect_string267($x);
+        expect_int267($x);
+    }
+    if (is_int($x) and ($x < 0)) {
+        expect_string267($x);
+        expect_int267($x);
+    }
+}


### PR DESCRIPTION
This is naive - E.g. it won't emit a warning for statements such as
`is_int($x) && is_string($x)` (Would treat it like a string)
The statements are applied left to right.

The impact on performance hasn't been checked yet (EDIT: didn't seem to significantly increase)