### PR TITLE
Small optimizations on frequently called functions

### DIFF
--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1110,18 +1110,14 @@ class Type
     /**
      * @return string
      * A human readable representation of this type
+     * (This is frequently called, so prefer efficient operations)
      */
     public function __toString()
     {
         $string = $this->asFQSENString();
 
-        $template_parameter_string =
-            implode(',', array_map(function (UnionType $type) {
-                return (string)$type;
-            }, $this->template_parameter_type_list));
-
-        if (!empty($template_parameter_string)) {
-            $string .= '<' . $template_parameter_string . '>';
+        if (count($this->template_parameter_type_list) > 0) {
+            $string .= $this->templateParameterTypeListAsString();
         }
 
         if ($this->getIsNullable()) {
@@ -1129,6 +1125,17 @@ class Type
         }
 
         return $string;
+    }
+
+    /**
+     * Gets the part of the Type string for the template parameters.
+     * Precondition: $this->template_parameter_string is not null.
+     */
+    private function templateParameterTypeListAsString() : string {
+        return '<' .
+            implode(',', array_map(function (UnionType $type) {
+                return (string)$type;
+            }, $this->template_parameter_type_list)) . '>';
     }
 
     /**


### PR DESCRIPTION
Cache ConfigPluginSet methods efficiently, in the same way Config::get() is cached. It's (and getPlugins() is) called for almost every node analyzed, so it takes up a fair amount of time.

Speed up Type::__toString base implementation. Almost all of the time, the template list is empty, so don't bother with function call, space for temporary variables, etc (Called to cache instances, etc.)

Speed up shouldVisit() - make the check if all nodes need to be analyzed faster. (used to be a function call and property fetch, twice, on pretty much any analyzed node)

`time ./phan` dropped from 19.5 seconds to around 18.5 seconds when analyzing phan itself(5%). Similar improvements should be seen in other projects.

- these were pointed out by xdebug and kcachegrind.