### PR TITLE
Fixed ext-ast version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "php": "~7.1.0",
-        "ext-ast": "*",
+        "ext-ast": "^0.1.4",
         "symfony/console": "~2.3|~3.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "07a626091af6664988d0b1d02466b0f6",
-    "content-hash": "307132c611c37a8b031b423a0013c312",
+    "hash": "a1bd2e7d03cade422d8d201f5f520673",
+    "content-hash": "5f186b8e45fa3871463a10f84e8e060c",
     "packages": [
         {
             "name": "psr/log",
@@ -1551,7 +1551,7 @@
     "prefer-lowest": false,
     "platform": {
         "php": "~7.1.0",
-        "ext-ast": "*"
+        "ext-ast": "^0.1.4"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
Changed ext-ast version constraint from "*" to "^0.1.4".
Firstly I've installed ext-ast version "0.1.2"(the constraint allowed me) and tried to test simple code snippets. As result, i've found that phan didn't work on optional arrays.
```
function acceptsOptionalArray(?array $array) {}
```
the result
```
/.../.../vendor/etsy/phan/src/Phan/AST/UnionTypeVisitor.php:488 () All flags must match. Found
#0  {closure}()
#1  assert() called at [/.../.../vendor/etsy/phan/src/Phan/AST/UnionTypeVisitor.php:488]
#2  Phan\AST\UnionTypeVisitor->visitType() called at [/.../.../vendor/etsy/phan/src/Phan/AST/Visitor/Element.php:162]
#3  Phan\AST\Visitor\Element->acceptKindVisitor() called at [/.../.../vendor/etsy/phan/src/Phan/AST/Visitor/KindVisitorImplementation.php:22]
...
...
```
After some investigation  I found out that ext-ast had made wrong AST for this case. The problem were fixed in 0.1.4(https://github.com/nikic/php-ast/commit/b815e10fed3bea70d1ace33ff7bbec5ceba874b6).
It would be nice to have correctly restricted dependencies :)