### PR TITLE
Add a daemon mode to memoize parse state, fork off workers to analyze single files quickly

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -19,6 +19,10 @@ New Features (Analysis)
 + Make conditionals such as `is_string` start applying to the condition in ternary operators (`$a ? $b : $c`)
 
 New Features (CLI, Configs)
++ (Linux/Unix only) Add Experimental Phan Daemon mode (PR #563 for Issue #22), which allows phan to run in the background, and accept TCP requests to analyze single files.
+  (The implementation currently requires the `pcntl` extension, which does not in Windows)
+  Server usage: `path/to/phan --daemonize-tcp-port 4846` (In the root directory of the project being analyzed)
+  Client usage: `path/to/phan_client --daemonize-tcp-port 4846 -l src/file1.php [ -l src/file2.php ]`
 + Add `--color` CLI flag, with rudimentary unix terminal coloring for the plain text output formatter. (Issue #363)
   Color schemes are customizable with `color_scheme`, in the config file.
 + Add a config to excludes file paths from a regular expression (e.g. tests or example files mixed with the codebase) (#635)

--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,5 @@
     "autoload-dev": {
         "psr-4": {"Phan\\Tests\\": "tests/Phan"}
     },
-    "bin": ["phan", "tocheckstyle"]
+    "bin": ["phan", "phan_client", "tocheckstyle"]
 }

--- a/phan_client
+++ b/phan_client
@@ -149,7 +149,7 @@ class PhanPHPLinter {
      * @param string[] $file_mapping
      */
     private static function dumpJSONIssues(array $response, array $file_mapping) {
-        $didDebug = false;
+        $did_debug = false;
         // if ($response['issue_count'] > 0)
         foreach ($response['issues'] as $issue) {
             if ($issue['type'] !== 'issue') {
@@ -157,10 +157,10 @@ class PhanPHPLinter {
             }
             $pathInProject = $issue['location']['path'];  // relative path
             if (!isset($file_mapping[$pathInProject])) {
-                if (!$didDebug) {
+                if (!$did_debug) {
                     self::debugInfo(sprintf("Unexpected path for issue (expected %s): %s\n", json_encode($file_mapping), json_encode($issue)));
                 }
-                $didDebug = true;
+                $did_debug = true;
                 continue;
             }
             $line = $issue['location']['lines']['begin'];
@@ -257,7 +257,6 @@ EOB;
                     $this->usage('Can specify --daemonize-socket or --daemonize-tcp-port only once', 1);
                 }
                 // Check if the socket is valid after parsing the file list.
-                $socketPath = $value;
                 $socket_dirname = realpath(dirname($value));
                 if (!file_exists($socket_dirname) || !is_dir($socket_dirname)) {
                     // The client doesn't require that the file exists if the daemon isn't running, but we do require that the folder exists.

--- a/phan_client
+++ b/phan_client
@@ -73,7 +73,8 @@ class PhanPHPLinter {
         $old_dirname = null;
         unset($real);
 
-        // TODO: not tested on windows
+        // TODO: In another PR, have an alternative way to run the daemon/server on Windows (Serialize and unserialize global state?
+        // The server side is unsupported on Windows, due to the `pcntl` extension not being supported.
         $found_phan_config = false;
         while ($dirname !== $old_dirname) {
             if (file_exists($dirname . '/.phan/config.php')) {

--- a/phan_client
+++ b/phan_client
@@ -1,0 +1,320 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Usage: phan_client -l path/to/file.php
+ *
+ * See plugins/vim/snippet.vim for an example of a use of this program.
+ *
+ * Analyzes a single php file.
+ * - If it is syntactically valid, scans it with phan, and emits lines beginning with "phan error:"
+ * - If it is invalid, emits the output of the PHP syntax checker
+ *
+ * This is meant to be a self-contained script with no file dependencies.
+ *
+ * Not tested on windows, probably won't work, but should be easy to add.
+ * Enhanced substitute for php -l, when phan daemon is running in the background for that folder.
+ *
+ * Note: if the daemon is run inside of Docker, one would probably need to change the URL in src/Phan/Daemon/Request.php from 127.0.0.1 to 0.0.0.0,
+ * and docker run -p 127.0.0.1:4846:4846 path/to/phan --daemonize-tcp-port 4846 --quick (second port is the docker one)
+ *
+ * See one of the many dockerized phan instructions, such as https://github.com/cloudflare/docker-phan
+ * e.g. https://github.com/cloudflare/docker-phan/blob/master/builder/scripts/mkimage-phan.bash
+ * mentions how it installed php-ast, similar steps could be used for other modules.
+ * (Install phpVERSION-dev/pecl to install extensions from source/pecl (phpize, configure, make install/pecl install))
+ *
+ * TODO: tutorial or repo.
+ */
+class PhanPHPLinter {
+    // Wait at most 3 seconds to lint a file.
+    const TIMEOUT_MS = 3000;
+
+    /** @var bool - Whether or not this is verbose */
+    public static $verbose = false;
+
+    private static function debugError(string $msg) {
+        error_log($msg);
+    }
+
+    private static function debugInfo(string $msg) {
+        if (self::$verbose) {
+            self::debugError($msg);
+        }
+    }
+
+    public static function run() {
+        error_reporting(E_ALL);
+        // TODO: check for .phan/lock to see if daemon is running?
+
+        $opts = new PhanPHPLinterOpts();  // parse options, exit on failure.
+        self::$verbose = $opts->verbose;
+
+        $failure_code = 0;
+        foreach ($opts->file_list as $path) {
+            // TODO: use popen instead
+            // TODO: add option to capture output, suppress "No syntax error"?
+            // --no-php-ini is a faster way to parse since php doesn't need to load multiple extensions. Assumes none of the extensions change the way php is parsed.
+            system("php -l --no-php-ini " . escapeshellarg($path), $exit_code);
+            if ($exit_code !== 0) {
+                // The file is syntactically invalid. Or php somehow isn't able to be invoked from this script.
+                $failure_code = $exit_code;
+            }
+        }
+        // Exit if any of the requested files are syntactically invalid.
+        if ($failure_code !== 0) {
+			self::debugError("Files were syntactically invalid\n");
+            exit($failure_code);
+        }
+
+        $real = realpath($path);
+        if (!$real) {
+            self::debugError("Could not resolve $path\n");
+        }
+        $dirname = dirname($real);
+        $old_dirname = null;
+		unset($real);
+
+        // TODO: not tested on windows
+        $found_phan_config = false;
+        while ($dirname !== $old_dirname) {
+            if (file_exists($dirname . '/.phan/config.php')) {
+                $found_phan_config = true;
+                break;
+            }
+            $old_dirname = $dirname;
+            $dirname = dirname($dirname);
+        }
+        if (!$found_phan_config) {
+            self::debugInfo("Not in a Phan project, nothing to do.");
+            exit(0);
+        }
+
+        $file_mapping = [];
+        foreach ($opts->file_list as $path) {
+            $real = realpath($path);
+            if (!$real) {
+                self::debugInfo("could not find real path to '$path'");
+                continue;
+            }
+            // Convert this to a relative path
+            if (strncmp($dirname . '/', $real, strlen($dirname . '/')) === 0) {
+                $real = substr($real, strlen($dirname . '/'));
+                $file_mapping[$real] = $path;
+            }
+        }
+        if (count($file_mapping) == 0) {
+            self::debugInfo("Not in a real project");
+        }
+        // The file is syntactically valid. Run phan.
+
+        // TODO: Make TCP port configurable
+        // TODO: check if the folder is within a folder with subdirectory .phan/config.php
+        // TODO: Check if there is a lock before attempting to connect?
+        $client = @stream_socket_client($opts->url, $errno, $errstr, 20.0);
+        if (!is_resource($client)) {
+            // TODO: This should attempt to start up the phan daemon for the given folder?
+            self::debugError("Phan daemon not running on port 4846");
+            exit(0);
+        }
+        $request = [
+            'method' => 'analyze_files',
+            'files' => $real_files,
+            'format' => 'json',
+        ];
+
+        // This used to use the 'phplike' format, but it doesn't work well with filtering files.
+        fwrite($client, json_encode($request));
+        stream_set_timeout($client, (int)floor(self::TIMEOUT_MS / 1000), 1000 * (self::TIMEOUT_MS % 1000));
+        stream_socket_shutdown($client, STREAM_SHUT_WR);
+        $response_lines = [];
+        while (!feof($client)) {
+            $response_lines[] = fgets($client);
+        }
+        stream_socket_shutdown($client, STREAM_SHUT_RD);
+        fclose($client);
+        $client = null;
+        $response_bytes = implode('', $response_lines);
+        // This uses the 'phplike' format imitating php's error format. "%s in %s on line %d"
+        $response = json_decode($response_bytes, true);
+        $status = ($response['status'] ?? null);
+        if ($status === 'ok') {
+            self::dumpJSONIssues($response, $file_mapping);
+        } else {
+            self::debugError(sprintf("Invalid response from phan for %s: %s\n", $response_bytes));
+        }
+    }
+
+    /**
+     * @param array[] $response
+     * @param string[] $file_mapping
+     */
+    private static function dumpJSONIssues(array $response, array $file_mapping) {
+        $didDebug = false;
+        // if ($response['issue_count'] > 0)
+        foreach ($response['issues'] as $issue) {
+            if ($issue['type'] !== 'issue') {
+                continue;
+            }
+            $pathInProject = $issue['location']['path'];  // relative path
+            if (!isset($file_mapping[$pathInProject])) {
+                if (!$didDebug) {
+                    self::debugInfo(sprintf("Unexpected path for issue (expected %s): %s\n", json_encode($file_mapping), json_encode($issue)));
+                }
+                $didDebug = true;
+                continue;
+            }
+            $line = $issue['location']['lines']['begin'];
+            $description = $issue['description'];
+            $parts = explode(' ', $description, 3);
+            if (count($parts) === 3 && $parts[1] === $issue['check_name']) {
+                $description = implode(': ', $parts);
+            }
+            printf("Phan error: %s in %s on line %d\n", $description, $file_mapping[$pathInProject], $line);
+        }
+    }
+}
+
+class PhanPHPLinterOpts {
+    /** @var string tcp:// or unix:// socket URL of the daemon. */
+    public $url;
+
+    /** @var string[] - file list */
+    public $file_list = [];
+
+    /** @var bool - unused. */
+    public $verbose = false;
+
+    /**
+     * @param string $msg - optional message
+     * @param int $exit_code - process exit code.
+     * @return void - exits with $exit_code
+     */
+    public function usage(string $msg = '', int $exit_code = 0) {
+        global $argv;
+        if (!empty($msg)) {
+            echo "$msg\n";
+        }
+
+        // TODO: Add an option to autostart the daemon if user also has global configuration to allow it for a given project folder. ($HOME/.phanconfig)
+        // TODO: Allow changing (adding/removing) issue suppression types for the analysis phase (would not affect the parse phase)
+
+        echo <<<EOB
+Usage: {$argv[0]} [options] -l file.php [ -l file2.php]
+ --daemonize-socket </path/to/file.sock>
+  Unix socket which a Phan daemon is listening for requests on.
+
+ --daemonize-tcp-port <1024-65535>
+  TCP port for Phan to listen for JSON requests on, in daemon mode. (E.g. 4846)
+
+ -l, --syntax-check <file.php>
+  Syntax check, and if the Phan daemon is running, analyze the following file (absolute path or relative to current working ditectory)
+  This will only analyze the file if a full phan check (with .phan/config.php) would analyze the file.
+
+ -v, --verbose
+  Whether to emit debugging output of this client.
+
+ -h,--help
+  This help information
+EOB;
+        exit($exit_code);
+    }
+
+    public function __construct()  {
+        global $argv;
+
+        // Parse command line args
+        $optind = 0;
+        $shortopts = "s:p:l:v";
+        $longopts = [
+			'daemonize-socket:',
+			'daemonize-tcp-port:',
+			'syntax-check:',
+			'verbose',
+        ];
+        if (PHP_VERSION_ID >= 70100) {
+            // optind support is only in php 7.1+.
+            $opts = getopt($shortopts, $longopts, $optind);
+        } else {
+            $opts = getopt($shortopts, $longopts);
+        }
+        if (PHP_VERSION_ID >= 70100 && $optind < count($argv)) {
+            $this->usage(sprintf("Unexpected parameter %s", json_encode($argv[$optind])));
+        }
+
+        // Check for this first, since the option parser may also emit debug output in the future.
+        if (in_array('-v', $argv) || in_array('--verbose', $argv)) {
+            PhanPHPLinter::$verbose = true;
+            $this->verbose = true;
+        }
+
+        $url = null;
+        foreach ($opts ?? [] as $key => $value) {
+            switch($key) {
+            case 's':
+            case 'daemonize-socket':
+                $this->checkCanConnectToDaemon('unix');
+                if ($this->url !== null) {
+                    $this->usage('Can specify --daemonize-socket or --daemonize-tcp-port only once', 1);
+                }
+                // Check if the socket is valid after parsing the file list.
+                $socketPath = $value;
+                $socket_dirname = realpath(dirname($value));
+                if (!file_exists($socket_dirname) || !is_dir($socket_dirname)) {
+                    // The client doesn't require that the file exists if the daemon isn't running, but we do require that the folder exists.
+                    $msg = sprintf('Configured to connect to unix socket server at socket %s, but folder %s does not exist', json_encode($value), json_encode($socket_dirname));
+                    $this->usage($msg, 1);
+                } else {
+                    $this->url = sprintf('unix://%s/%s', $socket_dirname, basename($value));
+                }
+                break;
+            case 'p':
+            case 'daemonize-tcp-port':
+                $this->checkCanConnectToDaemon('tcp');
+                $port = filter_var($value, FILTER_VALIDATE_INT);
+                if ($port >= 1024 && $port <= 65535) {
+                    $this->url = sprintf('tcp://127.0.0.1:%d', $port);
+                } else {
+                    $this->usage("daemonize-tcp-port must be between 1024 and 65535, got '$value'", 1);
+                }
+                break;
+            case 'l':
+            case 'syntax-check':
+                $path = $value;
+                if (!file_exists($path)) {
+                    $this->usage(sprintf("Error: asked to analyze file %s which does not exist", json_encode($path)), 1);
+                    exit(1);
+                }
+                $this->file_list[] = $path;
+                break;
+            case 'h':
+            case 'help':
+                $this->usage();
+                break;
+            default:
+                $this->usage("Unknown option '-$key'", 1);
+                break;
+            }
+
+        }
+        if (count($this->file_list) === 0) {
+            $this->usage("This requires at least one file to analyze (with -l path/to/file", 1);
+        }
+        if ($this->url === null) {
+            $this->url = 'tcp://127.0.0.1:4846';
+        }
+    }
+
+    /**
+     * prints error message if php doesn't support connecting to a daemon with a given protocol.
+     * @return void
+     */
+    private function checkCanConnectToDaemon(string $protocol) {
+        $opt = $protocol === 'unix' ? '--daemonize-socket' : '--daemonize-tcp-port';
+        if (!in_array($protocol, stream_get_transports())) {
+            $this->usage("The $protocol:///path/to/file schema is not supported on this system, cannot connect to a daemon with $opt", 1);
+        }
+        if ($this->url !== null) {
+            $this->usage('Can specify --daemonize-socket or --daemonize-tcp-port only once', 1);
+        }
+    }
+}
+PhanPHPLinter::run();

--- a/phan_client
+++ b/phan_client
@@ -118,7 +118,7 @@ class PhanPHPLinter {
         }
         $request = [
             'method' => 'analyze_files',
-            'files' => $real_files,
+            'files' => $file_mapping,
             'format' => 'json',
         ];
 
@@ -140,7 +140,7 @@ class PhanPHPLinter {
         if ($status === 'ok') {
             self::dumpJSONIssues($response, $file_mapping);
         } else {
-            self::debugError(sprintf("Invalid response from phan for %s: %s\n", $response_bytes));
+            self::debugError(sprintf("Invalid response from phan for %s: %s\n", json_encode($file_mapping), $response_bytes));
         }
     }
 

--- a/phan_client
+++ b/phan_client
@@ -61,7 +61,7 @@ class PhanPHPLinter {
         }
         // Exit if any of the requested files are syntactically invalid.
         if ($failure_code !== 0) {
-			self::debugError("Files were syntactically invalid\n");
+            self::debugError("Files were syntactically invalid\n");
             exit($failure_code);
         }
 
@@ -71,7 +71,7 @@ class PhanPHPLinter {
         }
         $dirname = dirname($real);
         $old_dirname = null;
-		unset($real);
+        unset($real);
 
         // TODO: not tested on windows
         $found_phan_config = false;
@@ -225,10 +225,10 @@ EOB;
         $optind = 0;
         $shortopts = "s:p:l:v";
         $longopts = [
-			'daemonize-socket:',
-			'daemonize-tcp-port:',
-			'syntax-check:',
-			'verbose',
+            'daemonize-socket:',
+            'daemonize-tcp-port:',
+            'syntax-check:',
+            'verbose',
         ];
         if (PHP_VERSION_ID >= 70100) {
             // optind support is only in php 7.1+.

--- a/plugins/vim/phansnippet.vim
+++ b/plugins/vim/phansnippet.vim
@@ -1,0 +1,19 @@
+" Standalone vim snippet for php and html files.
+" Add this to your home directory's .vimrc
+"
+" May conflict with other syntax checking plugins.
+" Need to use absolute path to smart_php_check, or put it in your path (E.g. $HOME/bin/smart_php_check.php)
+" This is based off of a snippet mentioned on http://vim.wikia.com/wiki/Runtime_syntax_check_for_php
+au FileType php,html setlocal makeprg=smart_php_check.php
+au FileType php,html setlocal errorformat=%m\ in\ %f\ on\ line\ %l,%-GErrors\ parsing\ %f,%-G
+
+au! BufWritePost  *.php,*.html    call PHPsynCHK()
+
+function! PHPsynCHK()
+  let winnum =winnr() " get current window number
+  silent make -l %
+  cw " open the error window if it contains an error. Don't limit the number of lines.
+  " return to the window with cursor set on the line of the first error (if any)
+  execute winnum . "wincmd w"
+  :redraw!
+endfunction

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -185,8 +185,8 @@ class Analysis
      */
     public static function analyzeFunctions(CodeBase $code_base, array $file_filter = null)
     {
-        $pluginSet = ConfigPluginSet::instance();
-        $hasPlugins = $pluginSet->hasPlugins();
+        $plugin_set = ConfigPluginSet::instance();
+        $has_plugins = $plugin_set->hasPlugins();
         $function_count = count($code_base->getFunctionAndMethodSet());
         $show_progress = CLI::shouldShowProgress();
         $i = 0;
@@ -219,13 +219,13 @@ class Analysis
             // Assumes that the given plugins will emit an issue in the same file as the function/method,
             // which isn't necessarily the case.
             // 0.06
-            if ($hasPlugins) {
+            if ($has_plugins) {
                 if ($function_or_method instanceof Func) {
-                    $pluginSet->analyzeFunction(
+                    $plugin_set->analyzeFunction(
                         $code_base, $function_or_method
                     );
                 } else if ($function_or_method instanceof Method) {
-                    $pluginSet->analyzeMethod(
+                    $plugin_set->analyzeMethod(
                         $code_base, $function_or_method
                     );
                 }

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -31,8 +31,9 @@ class Analysis
      *
      * @return Context
      */
-    public static function parseFile(CodeBase $code_base, string $file_path) : Context
+    public static function parseFile(CodeBase $code_base, string $file_path, bool $suppress_parse_errors = false) : Context
     {
+        $code_base->setCurrentParsedFile($file_path);
         $context = (new Context)->withFile($file_path);
 
         // Convert the file to an Abstract Syntax Tree
@@ -44,6 +45,9 @@ class Analysis
                 Config::get()->ast_version
             );
         } catch (\ParseError $parse_error) {
+            if ($suppress_parse_errors) {
+                return $context;
+            }
             Issue::maybeEmit(
                 $code_base,
                 $context,
@@ -117,7 +121,7 @@ class Analysis
     /**
      * @see self::parseNodeInContext
      *
-     * @param $shouldVisitEverything - Whether or not all AST nodes should be parsed.
+     * @param bool $shouldVisitEverything - Whether or not all AST nodes should be parsed.
      */
     private static function parseNodeInContextInner(CodeBase $code_base, Context $context, Node $node, bool $should_visit_everything) {
         // Save a reference to the outer context
@@ -179,8 +183,10 @@ class Analysis
      *
      * @return void
      */
-    public static function analyzeFunctions(CodeBase $code_base)
+    public static function analyzeFunctions(CodeBase $code_base, array $file_filter = null)
     {
+        $pluginSet = ConfigPluginSet::instance();
+        $hasPlugins = $pluginSet->hasPlugins();
         $function_count = count($code_base->getFunctionAndMethodSet());
         $show_progress = CLI::shouldShowProgress();
         $i = 0;
@@ -195,25 +201,34 @@ class Analysis
                 continue;
             }
 
-            DuplicateFunctionAnalyzer::analyzeDuplicateFunction(
-                $code_base, $function_or_method
-            );
-
-            ParameterTypesAnalyzer::analyzeParameterTypes(
-                $code_base, $function_or_method
-            );
-
-            // Let any plugins analyze the methods or functions
-            if ($function_or_method instanceof Func) {
-                ConfigPluginSet::instance()->analyzeFunction(
+            // 0.03
+            if (is_null($file_filter) || isset($file_filter[$function_or_method->getContext()->getFile()])) {
+                DuplicateFunctionAnalyzer::analyzeDuplicateFunction(
                     $code_base, $function_or_method
                 );
-            } else if ($function_or_method instanceof Method) {
-                ConfigPluginSet::instance()->analyzeMethod(
+
+                // This is the most time consuming step.
+                // Can probably apply this to other functions, but this was the slowest.
+                ParameterTypesAnalyzer::analyzeParameterTypes(
                     $code_base, $function_or_method
                 );
+                // Let any plugins analyze the methods or functions
+                // XXX: Add a way to run plugins on all functions/methods, this was limited for speed.
+                // Assumes that the given plugins will emit an issue in the same file as the function/method,
+                // which isn't necessarily the case.
+                // 0.06
+                if ($hasPlugins) {
+                    if ($function_or_method instanceof Func) {
+                        $pluginSet->analyzeFunction(
+                            $code_base, $function_or_method
+                        );
+                    } else if ($function_or_method instanceof Method) {
+                        $pluginSet->analyzeMethod(
+                            $code_base, $function_or_method
+                        );
+                    }
+                }
             }
-
         }
     }
 
@@ -223,9 +238,20 @@ class Analysis
      *
      * @return void
      */
-    public static function analyzeClasses($code_base)
+    public static function analyzeClasses($code_base, array $path_filter = null)
     {
-        foreach ($code_base->getClassMap() as $class) {
+        $classes = $code_base->getClassMap();
+        if (is_array($path_filter)) {
+            // Convert Map to array. Both are iterable.
+            $old_classes = $classes;
+            $classes = [];
+            foreach ($old_classes as $class) {
+                if (!$class->isInternal() && isset($path_filter[$class->getContext()->getFile()])) {
+                    $classes[] = $class;
+                }
+            }
+        }
+        foreach ($classes as $class) {
             $class->analyze($code_base);
         }
     }

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -201,32 +201,33 @@ class Analysis
                 continue;
             }
 
-            // 0.03
-            if (is_null($file_filter) || isset($file_filter[$function_or_method->getContext()->getFile()])) {
-                DuplicateFunctionAnalyzer::analyzeDuplicateFunction(
-                    $code_base, $function_or_method
-                );
+            // If there is an array limiting the set of files, skip this file if it's not in the list,
+            if (is_array($file_filter) && !isset($file_filter[$function_or_method->getContext()->getFile()])) {
+                continue;
+            }
+            DuplicateFunctionAnalyzer::analyzeDuplicateFunction(
+                $code_base, $function_or_method
+            );
 
-                // This is the most time consuming step.
-                // Can probably apply this to other functions, but this was the slowest.
-                ParameterTypesAnalyzer::analyzeParameterTypes(
-                    $code_base, $function_or_method
-                );
-                // Let any plugins analyze the methods or functions
-                // XXX: Add a way to run plugins on all functions/methods, this was limited for speed.
-                // Assumes that the given plugins will emit an issue in the same file as the function/method,
-                // which isn't necessarily the case.
-                // 0.06
-                if ($hasPlugins) {
-                    if ($function_or_method instanceof Func) {
-                        $pluginSet->analyzeFunction(
-                            $code_base, $function_or_method
-                        );
-                    } else if ($function_or_method instanceof Method) {
-                        $pluginSet->analyzeMethod(
-                            $code_base, $function_or_method
-                        );
-                    }
+            // This is the most time consuming step.
+            // Can probably apply this to other functions, but this was the slowest.
+            ParameterTypesAnalyzer::analyzeParameterTypes(
+                $code_base, $function_or_method
+            );
+            // Let any plugins analyze the methods or functions
+            // XXX: Add a way to run plugins on all functions/methods, this was limited for speed.
+            // Assumes that the given plugins will emit an issue in the same file as the function/method,
+            // which isn't necessarily the case.
+            // 0.06
+            if ($hasPlugins) {
+                if ($function_or_method instanceof Func) {
+                    $pluginSet->analyzeFunction(
+                        $code_base, $function_or_method
+                    );
+                } else if ($function_or_method instanceof Method) {
+                    $pluginSet->analyzeMethod(
+                        $code_base, $function_or_method
+                    );
                 }
             }
         }

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -247,7 +247,7 @@ class Analysis
             $old_classes = $classes;
             $classes = [];
             foreach ($old_classes as $class) {
-                if (!$class->isInternal() && isset($path_filter[$class->getContext()->getFile()])) {
+                if (!$class->isPHPInternal() && isset($path_filter[$class->getContext()->getFile()])) {
                     $classes[] = $class;
                 }
             }

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -2,6 +2,7 @@
 namespace Phan;
 
 use Phan\CodeBase\ClassMap;
+use Phan\CodeBase\UndoTracker;
 use Phan\Language\Element\ClassConstant;
 use Phan\Language\Element\Clazz;
 use Phan\Language\Element\Func;
@@ -49,6 +50,9 @@ use Phan\Library\Set;
  *
  *  // Do stuff ...
  * ```
+ *
+ * This supports undoing some operations in the parse phase,
+ * for a background daemon analyzing single files. (Phan\CodeBase\UndoTracker)
  */
 class CodeBase
 {
@@ -99,6 +103,16 @@ class CodeBase
     private $should_hydrate_requested_elements = false;
 
     /**
+     * @var UndoTracker|null - undoes the addition of global constants, classes, functions, and methods.
+     */
+    private $undo_tracker;
+
+    /**
+     * @var bool
+     */
+    private $has_enabled_undo_tracker = false;
+
+    /**
      * Initialize a new CodeBase
      */
     public function __construct(
@@ -124,11 +138,82 @@ class CodeBase
     /**
      * @return void
      */
+    public function enableUndoTracking() {
+        if ($this->has_enabled_undo_tracker) {
+            throw new \RuntimeException("Undo tracking already enabled");
+        }
+        $this->has_enabled_undo_tracker = true;
+        $this->undo_tracker = new UndoTracker();
+    }
+
+    /**
+     * @return void
+     */
+    public function disableUndoTracking() {
+        if (!$this->has_enabled_undo_tracker) {
+            throw new \RuntimeException("Undo tracking was never enabled");
+        }
+        $this->undo_tracker = null;
+    }
+
+    public function isUndoTrackingEnabled() : bool {
+        return $this->undo_tracker !== null;
+    }
+
+    /**
+     * @return void
+     */
     public function setShouldHydrateRequestedElements(
         bool $should_hydrate_requested_elements
     ) {
         $this->should_hydrate_requested_elements =
             $should_hydrate_requested_elements;
+    }
+
+    /**
+     * @return string[] - The list of files which are successfully parsed.
+     * This changes whenever the file list is reloaded from disk.
+     * This also includes files which don't declare classes or functions or globals,
+     * because those files use classes/functions/constants.
+     *
+     * (This is the list prior to any analysis exclusion or whitelisting steps)
+     */
+    public function getParsedFilePathList() : array {
+        if ($this->undo_tracker) {
+            return $this->undo_tracker->getParsedFilePathList();
+        }
+        throw new \RuntimeException("Calling getParsedFilePathList without an undo tracker");
+    }
+
+    /**
+     * @return string[] - The size of $this->getParsedFilePathList()
+     */
+    public function getParsedFilePathCount() : int {
+        if ($this->undo_tracker) {
+            return $this->undo_tracker->getParsedFilePathCount();
+        }
+        throw new \RuntimeException("Calling getParsedFilePathCount without an undo tracker");
+    }
+
+    /**
+     * @param string|null $current_parsed_file
+     * @return void
+     */
+    public function setCurrentParsedFile($current_parsed_file) {
+        if ($this->undo_tracker) {
+            $this->undo_tracker->setCurrentParsedFile($current_parsed_file);
+        }
+    }
+
+    /**
+     * Called when a file is unparseable.
+     * Removes the classes and functions, etc. from an older version of the file, if one exists.
+     * @return void
+     */
+    public function recordUnparseableFile(string $current_parsed_file) {
+        if ($this->undo_tracker) {
+            $this->undo_tracker->recordUnparseableFile($this, $current_parsed_file);
+        }
     }
 
     /**
@@ -142,6 +227,17 @@ class CodeBase
         foreach ($class_name_list as $i => $class_name) {
             $this->addClass(Clazz::fromClassName($this, $class_name));
         }
+    }
+
+    /**
+     * @param string[] $new_file_list
+     * @return string[] - Subset of $new_file_list which changed on disk and has to be parsed again. Automatically unparses the old versions of files which were modified.
+     */
+    public function updateFileList(array $new_file_list) {
+        if ($this->undo_tracker) {
+            return $this->undo_tracker->updateFileList($this, $new_file_list);
+        }
+        throw new \RuntimeException("Calling updateFileList without undo tracker");
     }
 
     /**
@@ -223,6 +319,14 @@ class CodeBase
     {
         // Map the FQSEN to the class
         $this->fqsen_class_map[$class->getFQSEN()] = $class;
+        if ($this->undo_tracker) {
+            $this->undo_tracker->recordUndo(function(CodeBase $inner) use($class) {
+                $fqsen = $class->getFQSEN();
+                Daemon::debugf("Undoing addClass %s\n", $fqsen);
+                unset($inner->fqsen_class_map[$fqsen]);
+                unset($inner->class_fqsen_class_map_map[$fqsen]);
+            });
+        }
     }
 
     /**
@@ -295,6 +399,12 @@ class CodeBase
                 $this->name_method_map[$method->getFQSEN()->getNameWithAlternateId()] = new Set;
             }
             $this->name_method_map[$method->getFQSEN()->getNameWithAlternateId()]->attach($method);
+        }
+        if ($this->undo_tracker) {
+            // The addClass's recordUndo should remove the class map. Only need to remove it from func_and_method_set
+            $this->undo_tracker->recordUndo(function(CodeBase $inner) use($method) {
+                $inner->func_and_method_set->detach($method);
+            });
         }
     }
 
@@ -407,6 +517,14 @@ class CodeBase
 
         // Add it to the set of functions and methods
         $this->func_and_method_set->attach($function);
+
+        if ($this->undo_tracker) {
+            $this->undo_tracker->recordUndo(function(CodeBase $inner) use($function) {
+                Daemon::debugf("Undoing addFunction on %s\n", $function->getFQSEN());
+                unset($inner->fqsen_func_map[$function->getFQSEN()]);
+                $inner->func_and_method_set->detach($function);
+            });
+        }
     }
 
     /**
@@ -515,6 +633,12 @@ class CodeBase
         $this->fqsen_global_constant_map[
             $global_constant->getFQSEN()
         ] = $global_constant;
+        if ($this->undo_tracker) {
+            $this->undo_tracker->recordUndo(function(CodeBase $inner) use ($global_constant) {
+                Daemon::debugf("Undoing addGlobalConstant on %s\n", $global_constant->getFQSEN());
+                unset($inner->fqsen_global_constant_map[$global_constant->getFQSEN()]);
+            });
+        }
     }
 
     /**

--- a/src/Phan/CodeBase/UndoTracker.php
+++ b/src/Phan/CodeBase/UndoTracker.php
@@ -1,0 +1,157 @@
+<?php declare(strict_types=1);
+namespace Phan\CodeBase;
+
+use Phan\CodeBase;
+use Phan\Daemon;
+
+/**
+ *
+ * (We don't garbage collect reference cycles, so this attempts to work in a way that avoids cycles.
+ *  Haven't verified that it does that as expected, yet)
+ */
+class UndoTracker {
+
+    /**
+     * @var string|null absolute path to currently parsed file, when in parse phase.
+     * TODO: Does the Context->getFile() make keeping this redundant?
+     */
+    private $current_parsed_file;
+
+    /**
+     * @var \Closure[][] operations to undo for a current path
+     */
+    private $undoOperationsForPath = [];
+
+    /**
+     * @var string[] Maps file paths to the modification dates and file size of the paths. - On ext4, milliseconds are available, but php APIs all return seconds.
+     */
+    private $fileModificationState = [];
+
+    public function __construct() {
+    }
+
+    /**
+     * @return string[] - The list of files which are successfully parsed.
+     * This changes whenever the file list is reloaded from disk.
+     * This also includes files which don't declare classes or functions or globals,
+     * because those files use classes/functions/constants.
+     *
+     * (This is the list prior to any analysis exclusion or whitelisting steps)
+     */
+    public function getParsedFilePathList() : array {
+        return array_keys($this->fileModificationState);
+    }
+
+    /**
+     * @return string[] - The size of $this->getParsedFilePathList()
+     */
+    public function getParsedFilePathCount() : int {
+
+        return count($this->fileModificationState);
+    }
+
+    /**
+     * @param string|null $current_parsed_file
+     * @return void
+     */
+    public function setCurrentParsedFile($current_parsed_file) {
+        if (is_string($current_parsed_file)) {
+            Daemon::debugf("Recording file modification state for %s", $current_parsed_file);
+            $this->fileModificationState[$current_parsed_file] = self::getFileState($current_parsed_file);
+        }
+        $this->current_parsed_file = $current_parsed_file;
+    }
+
+
+    /**
+     * @return string|null - This string should change when the file is modified. Returns null if the file somehow doesn't exist
+     */
+    public static function getFileState(string $path) {
+        clearstatcache(true, $path);  // TODO: does this work properly with symlinks? seems to.
+        $real = realpath($path);
+        if (!$real) {
+            return null;
+        }
+        $stat = @stat($real);  // suppress notices because phan's error_handler terminates on error.
+        if (!$stat) {
+            return null;  // It was missing or unreadable.
+        }
+        return sprintf('%d_%d', $stat['mtime'], $stat['size']);
+    }
+
+    /**
+     * Called when a file is unparseable.
+     * Removes the classes and functions, etc. from an older version of the file, if one exists.
+     * @return void
+     */
+    public function recordUnparseableFile(CodeBase $code_base, string $current_parsed_file) {
+        Daemon::debugf("%s was unparseable, had a syntax error", $current_parsed_file);
+        $this->undoFileChanges($code_base, $current_parsed_file);
+        unset($this->fileModificationState[$current_parsed_file]);
+    }
+
+    /**
+     * Undoes all of the changes for the relative path at $path
+     * @return void
+     */
+    private function undoFileChanges(CodeBase $code_base, string $path) {
+        Daemon::debugf("Undoing file changes for $path");
+        foreach ($this->undoOperationsForPath[$path] ?? [] as $undo_operation) {
+            $undo_operation($code_base);
+        }
+        unset($this->undoOperationsForPath[$path]);
+    }
+
+    /**
+     * @param \Closure $undo_operation - a closure expecting 1 param - inner. It undoes a change caused by a parsed file.
+     * Ideally, this would extend to all changes. (e.g. including dead code detection)
+     *
+     * @return void
+     */
+    public function recordUndo(\Closure $undo_operation) {
+        $file = $this->current_parsed_file;
+        if (!is_string($file)) {
+            debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+            throw new \Error("Called recordUndo in CodeBaseMutable, but not parsing a file");
+        }
+        if (!isset($this->undoOperationsForPath[$file])) {
+            $this->undoOperationsForPath[$file] = [];
+        }
+        $this->undoOperationsForPath[$file][] = $undo_operation;
+    }
+
+    /**
+     * @param CodeBase $code_base - code base owning this tracker
+     * @param string[] $new_file_list
+     * @return string[] - Subset of $new_file_list which changed on disk and has to be parsed again. Automatically unparses the old versions of files which were modified.
+     */
+    public function updateFileList(CodeBase $code_base, array $new_file_list) {
+        $new_file_set = [];
+        foreach ($new_file_list as $path) {
+            $new_file_set[$path] = true;
+        }
+        $changed_or_added_file_list = [];
+        foreach ($new_file_list as $path) {
+            if (!isset($this->fileModificationState[$path])) {
+                $changed_or_added_file_list[] = $path;
+            }
+        }
+        foreach ($this->fileModificationState as $path => $state) {
+            if (!isset($new_file_set[$path])) {
+                $this->undoFileChanges($code_base, $path);
+                unset($this->fileModificationState[$path]);
+                continue;
+            }
+            $newState = self::getFileState($path);
+            if ($newState !== $state) {
+                $this->undoFileChanges($code_base, $path);
+                // TODO: This will call stat() twice as much as necessary for the modified files. Not important.
+                unset($this->fileModificationState[$path]);
+                if ($newState !== null) {
+                    $changed_or_added_file_list[] = $path;
+                }
+            }
+        }
+        return $changed_or_added_file_list;
+    }
+}

--- a/src/Phan/CodeBase/UndoTracker.php
+++ b/src/Phan/CodeBase/UndoTracker.php
@@ -5,6 +5,13 @@ use Phan\CodeBase;
 use Phan\Daemon;
 
 /**
+ * UndoTracker maps a file path to a list of operations(e.g. Closures) that must be executed to
+ * remove all traces of a file from the CodeBase, etc. if a file was removed or edited.
+ * This is done to support running phan in daemon mode.
+ * - Files will have to be re-parsed to get the new function signatures, check for new parse/analysis errors,
+ *   and to update the class/function/method/property/constant/etc. definitions that would have to be created.
+ *
+ * If a file is edited, its contributions are undone, then it is parsed yet again.
  *
  * (We don't garbage collect reference cycles, so this attempts to work in a way that avoids cycles.
  *  Haven't verified that it does that as expected, yet)

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -370,6 +370,12 @@ class Config
         // (use when the number of files is much larger than the process count)
         'consistent_hashing_file_order' => false,
 
+        // Path to a unix socket for a daemon to listen to files to analyze. Use command line option instead.
+        'daemonize_socket' => false,
+
+        // TCP port(from 1024 to 65535) for a daemon to listen to files to analyze. Use command line option instead.
+        'daemonize_tcp_port' => false,
+
         // A list of plugin files to execute
         'plugins' => [
         ],

--- a/src/Phan/Daemon.php
+++ b/src/Phan/Daemon.php
@@ -98,10 +98,10 @@ class Daemon {
         }
         // Unless debugging Phan itself, these two configurations are unnecessarily adding slowness.
         if (PHP_DEBUG) {
-            echo "Warning: This daemon is slower when php is compiled with --enable-debug\n";
+            fwrite(STDERR, "Warning: This daemon is slower when php is compiled with --enable-debug\n");
         }
         if (extension_loaded('xdebug')) {
-            echo "Warning: This daemon is slower when xdebug is installed\n";
+            fwrite(STDERR, "Warning: This daemon is slower when xdebug is installed");
         }
         echo "Listening for Phan analysis requests at $listen_url\n";
         $socket_server = stream_socket_server($listen_url, $errno, $errstr);

--- a/src/Phan/Daemon.php
+++ b/src/Phan/Daemon.php
@@ -1,0 +1,133 @@
+<?php declare(strict_types=1);
+namespace Phan;
+
+use Phan\Daemon\Request;
+
+/**
+ * an analyzing daemon, to be used by IDEs.
+ * Accepts requests (Currently only JSON blobs) over a unix socket or TCP sockets.
+ * TODO: HTTP support, or open language protocol support
+ */
+class Daemon {
+    /**
+     * This creates an analyzing daemon, to be used by IDEs.
+     * Format:
+     *
+     * - Read over TCP socket, e.g. with JSON
+     * - Respond over TCP socket, e.g. with JSON
+     *
+     * @param CodeBase $code_base (Must have undo tracker enabled)
+     *
+     * @param \Closure $file_path_lister
+     * Returns string[] - A list of files to scan. This may be different from the previous contents.
+     *
+     * @return Request|null - A writeable request, which has been fully read from.
+     * Callers should close after they are finished writing.
+     */
+    public static function run(CodeBase $code_base, \Closure $file_path_lister) {
+        assert($code_base->isUndoTrackingEnabled());
+
+        $receivedSignal = false;
+        // example requests over TCP
+        // Assumes that clients send and close the their requests quickly, then wait for a response.
+
+        // {"method":"analyze","files":["/path/to/file1.php","/path/to/file2.php"]}
+
+        $socket_server = self::createDaemonStreamSocketServer();
+        // TODO: Limit the maximum number of active processes to a small number(4?)
+        // TODO: accept SIGCHLD when child terminates, somehow?
+        try {
+            $gotSignal = false;
+            pcntl_signal(SIGCHLD, function(...$args) use(&$gotSignal) {
+                $gotSignal = true;
+                Request::childSignalHandler(...$args);
+            });
+            while (true) {
+                $gotSignal = false;  // reset this.
+                // We get an error from stream_socket_accept. After the RuntimeException is thrown, pcntl_signal is called.
+				$previousErrorHandler = set_error_handler(function ($severity, $message, $file, $line) use (&$previousErrorHandler) {
+                    self::debugf("In new error handler '$message'");
+					if (!preg_match('/stream_socket_accept/i', $message)) {
+						return $previousErrorHandler($severity, $message, $file, $line);
+					}
+                    throw new \RuntimeException("Got signal");
+				});
+
+                $conn = false;
+                try {
+                    $conn = stream_socket_accept($socket_server, -1);
+                } catch(\RuntimeException $e) {
+                    self::debugf("Got signal");
+                    pcntl_signal_dispatch();
+                    self::debugf("done processing signals");
+                    if ($gotSignal) {
+                        continue;  // Ignore notices from stream_socket_accept if it's due to being interrupted by a child process terminating.
+                    }
+                } finally {
+                    restore_error_handler();
+                }
+
+                if (!is_resource($conn)) {
+                    // If we didn't get a connection, and it wasn't due
+                    break;
+                }
+                assert(is_resource($conn));
+                $request = Request::accept($code_base, $file_path_lister, $conn);
+                if ($request instanceof Request) {
+                    return $request;  // We forked off a worker process successfully, and this is the worker process
+                }
+            }
+            error_log("Stopped accepting connections");
+        } finally {
+            restore_error_handler();
+        }
+        return null;
+    }
+
+    /**
+     * @return resource (resource is not a reserved keyword)
+     */
+    private static function createDaemonStreamSocketServer() {
+        $listen_url = null;
+        if (Config::get()->daemonize_socket) {
+            $listen_url = 'unix://' . Config::get()->daemonize_socket;
+        } else if (Config::get()->daemonize_tcp_port) {
+            $listen_url = sprintf('tcp://127.0.0.1:%d', Config::get()->daemonize_tcp_port);
+        } else {
+            throw new \InvalidArgumentException("Should not happen, no port/socket for daemon to listen on.");
+        }
+        // Unless debugging Phan itself, these two configurations are unnecessarily adding slowness.
+        if (PHP_DEBUG) {
+            echo "Warning: This daemon is slower when php is compiled with --enable-debug\n";
+        }
+        if (extension_loaded('xdebug')) {
+            echo "Warning: This daemon is slower when xdebug is installed\n";
+        }
+        echo "Listening for Phan analysis requests at $listen_url\n";
+        $socket_server = stream_socket_server($listen_url, $errno, $errstr);
+        if (!$socket_server) {
+            error_log("Failed to create unix socket server $listen_url: $errstr ($errno)\n");
+            exit(1);
+        }
+        return $socket_server;
+    }
+
+    /**
+     * Debug (non-error) statement related to the daemon.
+     * Uncomment this when debugging issues (E.g. changes not being picked up)
+     *
+     * @param string $format - printf style format string
+     * @param mixed ...$args - printf args
+     */
+    public static function debugf(string $format, ...$args) {
+        /*
+        if (count($args) > 0) {
+            $message = sprintf($format, ...$args);
+        } else {
+            $message = $format;
+        }
+        error_log($message);
+        */
+    }
+
+}

--- a/src/Phan/Daemon/Request.php
+++ b/src/Phan/Daemon/Request.php
@@ -1,0 +1,364 @@
+<?php declare(strict_types=1);
+namespace Phan\Daemon;
+
+use Phan\Analysis;
+use Phan\CodeBase;
+use Phan\Config;
+use Phan\Daemon;
+use Phan\Language\FileRef;
+use Phan\Language\Type;
+use Phan\Output\IssuePrinterInterface;
+use Phan\Output\PrinterFactory;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * Represents the state of a client request to a daemon, and contains methods for sending formatted responses.
+ */
+class Request {
+    const METHOD_ANALYZE_FILES = 'analyze_files';  // has shorthand analyze_file with param 'file'
+
+    const PARAM_METHOD = 'method';
+    const PARAM_FILES  = 'files';
+    const PARAM_FORMAT = 'format';
+
+    // success codes
+    const STATUS_OK = 'ok';  // unrecognized output format
+    const STATUS_NO_FILES = 'no_files';  // none of the requested files were in this project's config directories
+
+    // failure codes
+    const STATUS_INVALID_FORMAT = 'invalid_format';  // unrecognized requested output "format"
+    const STATUS_ERROR_UNKNOWN = 'error_unknown';
+    const STATUS_INVALID_FILES = 'invalid_files';  // expected a valid string for 'files'/'file'
+    const STATUS_INVALID_METHOD = 'invalid_method';  // expected 'method' to be analyze_files or
+    const STATUS_INVALID_REQUEST = 'invalid_request';  // expected a valid string for 'files'/'file'
+
+    /** @var resource|null - Null after the response is sent. */
+    private $conn;
+
+    /** @var array */
+    private $config;
+
+    /** @var BufferedOutput */
+    private $bufferedOutput;
+
+    /** @var string */
+    private $method;
+
+    /** @var string[]|null */
+    private $files = null;
+
+    private static $child_pids = [];
+
+    private static $exited_pid_status = [];
+
+    /**
+     * @param resource $conn
+     * @param array $config
+     */
+    private function __construct($conn, array $config) {
+        $this->conn = $conn;
+        $this->config = $config;
+        $this->bufferedOutput = new BufferedOutput();
+        $this->method = $config[self::PARAM_METHOD];
+        // TODO: constants.
+        if ($this->method === self::METHOD_ANALYZE_FILES) {
+            $this->files = $config[self::PARAM_FILES];
+        }
+    }
+
+    public function getPrinter() : IssuePrinterInterface {
+        // TODO: check $this->config['format']
+        $factory = new PrinterFactory();
+        $format = $this->config['format'] ?? 'json';
+        if (!in_array($format, $factory->getTypes())) {
+            $this->sendJSONResponse([
+                "status" => self::STATUS_INVALID_FORMAT,
+            ]);
+            exit(0);
+        }
+        return $factory->getPrinter($format, $this->bufferedOutput);
+    }
+
+    /**
+     * Respond with issues in the requested format
+     */
+    public function respondWithIssues(int $issueCount) {
+        $rawIssues = $this->bufferedOutput->fetch();
+        if (($this->config[self::PARAM_FORMAT] ?? null) === 'json') {
+            $issues = json_decode($rawIssues, true);
+            if (!is_array($issues)) {
+                $issues = "(Failed to decode) " . $rawIssues;
+            }
+        } else {
+            $issues = $rawIssues;
+        }
+        $this->sendJSONResponse([
+            "status" => self::STATUS_OK,
+            "issue_count" => $issueCount,
+            "issues" => $issues,
+        ]);
+    }
+
+    public function respondWithNoFilesToAnalyze() {
+        // The mentioned file wasn't in .phan/config.php's list of files to analyze.
+        // TODO: Send the client that list of files.
+        $this->sendJSONResponse([
+            "status" => self::STATUS_NO_FILES,
+        ]);
+    }
+
+
+    /**
+     * @param string[] $analyze_file_path_list
+     * @return string[]
+     */
+    public function filterFilesToAnalyze(array $analyze_file_path_list) : array {
+
+        if (is_null($this->files)) {
+            Daemon::debugf("No files to filter in filterFilesToAnalyze");
+            return $analyze_file_path_list;
+        }
+
+        $analyze_file_path_set = array_flip($analyze_file_path_list);
+        $filteredFiles = [];
+        foreach ($this->files as $file) {
+            // Must be relative to project, allow absolute paths to be passed in.
+            $file = FileRef::getProjectRelativePathForPath($file);
+
+            if (array_key_exists($file, $analyze_file_path_set)) {
+                $filteredFiles[] = $file;
+            } else {
+                // TODO: Reload file list once before processing request?
+                // TODO: Make this override blacklists of folders in src/Phan/Phan
+                Daemon::debugf("Failed to find requested file '%s' in parsed file list", $file, json_encode($analyze_file_path_list));
+            }
+        }
+        Daemon::debugf("Returning file set: %s", json_encode($filteredFiles));
+        return $filteredFiles;
+    }
+
+    /**
+     * Send a response and close the connection, for the given socket's protocol.
+     * Currently supports only JSON.
+     * TODO: HTTP protocol.
+     *
+     * @param resource $conn
+     * @param array $response
+     * @return void
+     */
+    public function sendJSONResponse(array $response) {
+        self::sendJSONResponseOverSocket($this->conn, $response);
+        $this->conn = null;
+    }
+
+    /**
+     * @param resource $conn
+     * @param array $response
+     * @return void
+     */
+    public static function sendJSONResponseOverSocket($conn, array $response) {
+        if (!$conn) {
+            Daemon::debugf("Already sent response");
+            return;
+        }
+        fwrite($conn, json_encode($response) . "\n");
+        // disable further receptions and transmissions
+        // Note: This is likely a giant hack,
+        // and pcntl and sockets may break in the future if used together. (multiple processes owning a single resource).
+        // Not sure how to do that safely.
+        stream_socket_shutdown($conn, STREAM_SHUT_RDWR);
+        fclose($conn);
+    }
+
+    public function __destruct() {
+        if (isset($this->conn)) {
+            $this->sendJSONResponse([
+                'status' => self::STATUS_ERROR_UNKNOWN,
+                'message' => 'failed to send a response - Possibly encountered an exception. See daemon output.',
+            ]);
+        }
+    }
+
+    /**
+     * @param int $signo
+     * @param array|null $status
+     * @param int|null $pid
+     * @return void
+     * @suppress PhanTypeMismatchArgumentInternal - bad function signature map - status is really an array
+     */
+    public static function childSignalHandler($signo, $status = null, $pid = null) {
+        if ($signo !== SIGCHLD) {
+            return;
+        }
+        if (!$pid) {
+            $pid = pcntl_waitpid(-1, $status, WNOHANG);
+        }
+        Daemon::debugf("Got signal pid=%s", json_encode($pid));
+
+        while ($pid > 0) {
+            if (array_key_exists($pid, self::$child_pids)) {
+                $exit_code = pcntl_wexitstatus($status);
+                if ($exit_code != 0) {
+                    error_log(sprintf("child process %d exited with status %d\n", $pid, $exit_code));
+                } else {
+                    Daemon::debugf("child process %d completed successfully", $pid);
+                }
+                unset(self::$child_pids[$pid]);
+            } else if ($pid > 0) {
+                self::$exited_pid_status[$pid] = $status;
+            }
+            $pid = pcntl_waitpid(-1, $status, WNOHANG);
+        }
+
+    }
+
+    /**
+     * @param CodeBase $code_base
+     * @param \Closure $file_path_list
+     * @param resource $conn
+     * @return Request|null - non-null if this is a worker process with work to do. null if request failed or this is the master.
+     */
+    public static function accept(CodeBase $code_base, \Closure $file_path_lister, $conn) {
+        Daemon::debugf("Got a connection");  // debugging code
+        // Efficient for large strings, e.g. long file lists.
+        $data = [];
+        while (!feof($conn)) {
+            $data[] = fgets($conn);
+        }
+        $request_bytes = implode('', $data);
+        $request = json_decode($request_bytes, true);
+        if (!is_array($request)) {
+            Daemon::debugf("Received invalid request, expected JSON: %s", json_encode($request_bytes));
+            self::sendJSONResponseOverSocket($conn, [
+                'status'  => self::STATUS_INVALID_REQUEST,
+                'message' => 'malformed JSON',
+            ]);
+            return null;
+        }
+        $method = $request['method'] ?? null;
+        switch($method) {
+        case 'analyze_all':
+            // Analyze the default list of files. No expected params.
+            break;
+        case 'analyze_file':
+            $method = 'analyze_files';
+            $request = [
+                self::PARAM_METHOD => $method,
+                self::PARAM_FILES => [$request['file']],
+                self::PARAM_FORMAT => $request[self::PARAM_FORMAT] ?? 'json',
+            ];
+            // Fall through, this is an alias of analyze_files
+        case 'analyze_files':
+            // Analyze the list of strings provided in "files"
+            // TODO: Actually do that.
+            $files = $request[self::PARAM_FILES] ?? null;
+            $request[self::PARAM_FORMAT] = $request[self::PARAM_FORMAT] ?? 'json';
+            $error_message = null;
+            if (is_array($files) && count($files)) {
+                foreach ($files as $file) {
+                    if (!is_string($file)) {
+                        $error_message = 'Passed non-string in list of files';
+                        break;
+                    }
+                }
+            } else {
+                $error_message = 'Must pass a non-empty array of file paths for field files';
+            }
+            if ($error_message !== null) {
+                Daemon::debugf($error_message);
+                self::sendJSONResponseOverSocket($conn, [
+                    'status'  => self::STATUS_INVALID_FILES,
+                    'message' => $error_message,
+                ]);
+                return null;
+            }
+            break;
+        // TODO(optional): add APIs to resolve types of variables/properties/etc (e.g. accept byte offset or line/column offset)
+        default:
+            $message = sprintf("expected method to be analyze_all or analyze_files, got %s", json_encode($method));
+            Daemon::debugf($message);
+            self::sendJSONResponseOverSocket($conn, [
+                'status'  => self::STATUS_INVALID_METHOD,
+                'message' => $message,
+            ]);
+            return null;
+        }
+
+        self::reloadFilePathListForDaemon($code_base, $file_path_lister);
+        $receivedSignal = false;
+
+        $fork_result = pcntl_fork();
+        if ($fork_result < 0) {
+            error_log("The daemon failed to fork. Going to terminate");
+        } else if ($fork_result == 0) {
+            Daemon::debugf("This is the fork");
+            self::$child_pids = [];
+            // TODO: Re-parse the file list.
+            return new self($conn, $request);;
+        } else {
+            $pid = $fork_result;
+            $status = self::$exited_pid_status[$pid] ?? null;
+            if (isset($status)) {
+                Daemon::debugf("child process %d already exited", $pid);
+                self::childSignalHandler(SIGCHLD, $status, $pid);
+                unset(self::$exited_pid_status[$pid]);
+            } else {
+                self::$child_pids[$pid] = true;
+            }
+
+            // TODO: Parse the new file list **before forking**, not after forking.
+            // TODO: Use http://php.net/manual/en/book.inotify.php if available, watch all directories if available.
+            // Daemon continues to execute.
+            self::$child_pids[] = $fork_result;
+            Daemon::debugf("Created a child pid %d", $fork_result);
+        }
+        return null;
+    }
+
+    /**
+     * Reloads the file path list.
+     * @return void
+     */
+    private static function reloadFilePathListForDaemon(CodeBase $code_base, \Closure $file_path_lister) {
+        $oldCount = $code_base->getParsedFilePathCount();
+
+        $file_list = $file_path_lister();
+
+        if (Config::get()->consistent_hashing_file_order) {
+            // Parse the files in lexicographic order.
+            // If there are duplicate class/function definitions,
+            // this ensures they are added to the maps in the same order.
+            sort($file_list, SORT_STRING);
+        }
+
+        $changed_or_added_files = $code_base->updateFileList($file_list);
+        Daemon::debugf("Parsing modified files: New files = %s", json_encode($changed_or_added_files));
+        if (count($changed_or_added_files) > 0 || $code_base->getParsedFilePathCount() !== $oldCount) {
+            // Only clear memoizations if it is determined at least one file to parse was added/removed/modified.
+            // - file path count changes if files were deleted or added
+            // - changed_or_added_files has an entry for every added/modified file.
+            // (would be 0 if a client analyzes one file, then analyzes a different file)
+            Type::clearAllMemoizations();
+        }
+        // A progress bar doesn't make sense in a daemon which can theoretically process multiple requests at once.
+        foreach ($changed_or_added_files as $file_path) {
+            // Kick out anything we read from the former version
+            // of this file
+            $code_base->flushDependenciesForFile($file_path);
+
+            // If the file is gone, no need to continue
+            if (($real = realpath($file_path)) === false || !file_exists($real)) {
+                Daemon::debugf("file $file_path does not exist");
+                continue;
+            }
+            Daemon::debugf("Parsing %s yet again", $file_path);
+            try {
+                // Parse the file
+                Analysis::parseFile($code_base, $file_path);
+            } catch (\Throwable $throwable) {
+                error_log(sprintf("Analysis::parseFile threw %s for %s: %s\n%s", get_class($throwable), $file_path, $throwable->getMessage(), $throwable->getTraceAsString()));
+            }
+        }
+        Daemon::debugf("Done parsing modified files");
+    }
+}

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -1411,6 +1411,9 @@ class Issue
         Context $context,
         IssueInstance $issue_instance
     ) {
+        // TODO: In daemonize mode, associate the issue with the file's modification date/contents, and clear issues when the file is modified.
+        // Some issues are emitted while still in parse(ParseVisitor) phase.
+
         // If this issue type has been suppressed in
         // the config, ignore it
         if (!Config::get()->disable_suppression

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -573,7 +573,7 @@ class Clazz extends AddressableElement
         if ($this->hasPropertyWithName($code_base, $property_name)) {
             // original_property is the one that the class is using.
             // We added $property after that (so it likely in a base class, or a trait's property added after this property was added)
-            $overriding_property = $this->getPropertyMap($code_base)[$property_name];;
+            // $overriding_property = $this->getPropertyMap($code_base)[$property_name];;
             // TODO: implement https://github.com/etsy/phan/issues/615 in another PR, see below comment
             /**
             if ($overriding_property->isStatic() != $property->isStatic()) {
@@ -592,6 +592,7 @@ class Clazz extends AddressableElement
             $property_name
         );
 
+        // TODO: defer template properties until the analysis phase? They might not be parsed or resolved yet.
         if ($property->getFQSEN() !== $property_fqsen) {
             $property = clone($property);
             $property->setDefiningFQSEN($property->getFQSEN());

--- a/src/Phan/Language/FileRef.php
+++ b/src/Phan/Language/FileRef.php
@@ -59,8 +59,16 @@ class FileRef implements \Serializable
      */
     public function getProjectRelativePath() : string
     {
-        $cwd_relative_path = $this->file;
+        return self::getProjectRelativePathForPath($this->file);
+    }
 
+    /**
+     * @param string $cwd_relative_path (relative or absolute path)
+     * @return string
+     * The path of the file relative to the project
+     * root directory
+     */
+    public static function getProjectRelativePathForPath($cwd_relative_path) {
         // Get a path relative to the project root
         $path = str_replace(
             Config::get()->getProjectRootDirectory(),

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -10,8 +10,7 @@ abstract class NativeType extends Type
 
     /**
      * @param bool $is_nullable
-     * An optional parameter, which if true returns a
-     * nullable instance of this native type
+     * If true, returns a nullable instance of this native type
      *
      * @return static
      */
@@ -263,5 +262,10 @@ abstract class NativeType extends Type
         }
 
         return $string;
+    }
+
+    public function asFQSENString() : string
+    {
+        return $this->name;
     }
 }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -381,6 +381,8 @@ class UnionType implements \Serializable
      * @param CodeBase $code_base
      * The code base to look up classes against
      *
+     * TODO: Defer resolving the template parameters until parse ends. Low priority.
+     *
      * @return UnionType[]
      * A map from template type identifiers to the UnionType
      * to replace it with
@@ -700,6 +702,8 @@ class UnionType implements \Serializable
      * Test to see if this type can be cast to the
      * given type after expanding both union types
      * to include all ancestor types
+     *
+     * TODO: ensure that this is only called after the parse phase is over.
      */
     public function canCastToExpandedUnionType(
         UnionType $target,

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -163,6 +163,11 @@ class ConfigPluginSet extends Plugin {
         }
     }
 
+    // Micro-optimization in tight loops: check for plugins before calling config plugin set
+    public function hasPlugins() : bool {
+        return count($this->getPlugins()) > 0;
+    }
+
     /**
      * @return Plugin[]
      */

--- a/src/phan.php
+++ b/src/phan.php
@@ -40,13 +40,11 @@ try {
 // Create our CLI interface and load arguments
 $cli = new CLI();
 
-$file_list = $cli->getFileList();
-
 // Analyze the file list provided via the CLI
 $is_issue_found =
     Phan::analyzeFileList(
         $code_base,
-        $file_list
+        function() use($cli) { return $cli->getFileList(); }  // Daemon mode will reload the file list.
     );
 
 // Provide an exit status code based on if

--- a/tests/Phan/AbstractPhanFileTest.php
+++ b/tests/Phan/AbstractPhanFileTest.php
@@ -78,7 +78,7 @@ abstract class AbstractPhanFileTest
         Phan::setPrinter($printer);
         Phan::setIssueCollector(new BufferingCollector());
 
-        Phan::analyzeFileList($this->code_base, $test_file_list);
+        Phan::analyzeFileList($this->code_base, function() use($test_file_list) { return $test_file_list; });
 
         $output = $stream->fetch();
 


### PR DESCRIPTION
Related to https://github.com/etsy/phan/issues/22 and https://github.com/TysonAndre/phan/issues/14
Mostly stable, but there's still some bugs when switching between git branches.

Intermediate work on the squashed commits can be seen on https://github.com/TysonAndre/phan/commits/daemonize-and-analyze-individual-files

This depends on the pcntl extension.

Because there isn't a database, it is less likely that code changes will
break this. However, this will keep using RAM in the background (Around the
same amount of ram to analyse a project in single process mode)

Server implementation

`./phan --daemonize-tcp-port 4846 --quick`

Client implementation

```bash
./phan_client --daemonize-tcp-port 4846 -l src/Phan/Phan.php
```

(Similar to `php -l src/Phan/Phan.php`, and can be used as a substitute
for syntax check in some scripts)

This will parse every single file, but will only analyze a small subset
of those files.

When the daemon receives a request

1. Check for modified files (it would be slightly faster if we did this
   for all files except the requested file(s) ahead of time, e.g. with
   inotify PECL)
   This requires stat()ing all files
2. Remove classes, methods, functions, and constants from the files that
   were deleted or modified, and in the config..
3. Add classes, methods, functions, and constants from the files that
   were added or modified, and in the config.
4. Fork, and run the remaining method checks and analysis parse steps.
   The forked process doesn't affect the state of the daemon.
   (The memory(state) of the fork is a copy of the original,
   but doesn't affect the original)

Commit Details:

- exit(1) if the command line parameters of phan_client are invalid.
- Listen on a TCP port or unix socket for requests as JSON blobs(unix in progress)
  ("method" can probable be translated to POSTs to the path /analyze_files, etc,
  if HTTP is supported in the future)
- nit: Show 0% progress bar as well, make animation smoother
- Depends on pcntl extension and assumes unix-like OS. (folder, path
  names)
- The functionality to undo parse steps into CodeBase. An alternative would be to make
  CodeBase and the undoable CodeBase be classes implementing the same
  interface, but that would require changing all code using CodeBase,
  and is prone to braking.
- Added micro-optimizations that affect only daemon mode
  (This script is invoked from an editor on file save/change,
  so it's desirable to be as fast as possible on large as possible.
  Outside of daemon mode, the pre-analyze steps (analyzeFunctions)
  don't take up a large fraction of the time.)
- misc optimizations
- misc TODOs, noting bugs that would happen in code that is part of
  parse mode.
- Add debugging logs for things which would affect daemon mode (e.g.
  accidental duplicate classes).
  Disable this by default. Once this is stable, debugging logs can be
  removed
- change analyzing file list to take a closure to generate the file list.
  This allows daemon mode to process any files that were added, deleted,
  or removed since the last time files were passed
- make `phan_client` Print the requested relative/absolute path,
  not the relative path within the project
  (and only print the paths if they are requested)
  (so that editors open error view with the correct file name)

Optimization steps and reasons:

1. Without daemon mode, phan analysis of phan in debug mode took 11 seconds
  (would have been faster if php wasn't using --enable-debug mode)
2. After keeping the parse state and memory, and forking off new
   processes to execute the remaining steps, steps took 2 seconds.
3. Cut out analyzing files which aren't in the set of requested files.
   (Some steps after parse are applied to the whole codebase, not just
   the files to analyze).
   (takes 0.1 seconds on phan)

   At the current point in time, all issues I saw are with
   getContext()->getFile(). Some plugins may emit issues in a different
   file from the one being checked, but I'm not aware of any.

Add partial documentation on using the plugin

Full documentation is pending (Step by step on setting up a VM)
Building php on the host should be much faster.

Work for later PRs:

- make the example plugin able to automatically start the daemon.
  - automatically stop after 30 minutes without new requests or so
- rate limit
- Plugins in other languages

  - I wasn't familiar with how to install/develop a syntastic plugin, so that
    plugin was wasn't revived
- Investigate and fix exceptions for classes which are suddenly missing from `use` statements when switching between checkouts
- etc.

# Examples

Simple Vim and emacs plugins exist to analyze a single file on file save. (aside: Vim output became slightly more verbose)

![screenshot from 2017-02-23 22-29-21](https://cloud.githubusercontent.com/assets/1904430/23336381/4210f212-fb83-11e6-9c55-79e0995307b1.png)

![flycheck_phan_example](https://cloud.githubusercontent.com/assets/1904430/23347092/85da0322-fc54-11e6-8fae-48b7a30d623b.png)

- See https://github.com/TysonAndre/flycheck-phanclient/tree/2f4638f0c35d91ad973adfbb77e8e98a9a8b9283 for an older version using the changes in this PR (New features were added, but this PR is large)

1. Invoking the server (While --quick isn't mandatory, that option significantly reduces the duration of `phan_client` requests)

```bash
~/phan $ ./phan --daemonize-tcp-port 4849 --quick
Listening for Phan analysis requests at tcp://127.0.0.1:4849
```

2. Invoking the client, after server indicates it is listening for requests

```bash
~/phan $ echo '{"method":"analyze_files","files":["src/Phan/Phan.php"]}' | nc 127.0.0.1 4849
{"status":"ok","issue_count":0,"issues":[]}
~/phan $ ./phan_client --daemonize-tcp-port 4849 -l src/Phan.php
No syntax errors detected in src/Phan/Phan.php
~/phan $ vim src/Phan/Phan.php # add  buggy, unused function to test out the daemon
~/phan $ echo '{"method":"analyze_files","files":["src/Phan/Phan.php"]}' | nc 127.0.0.1 4849
{"status":"ok","issue_count":2,"issues":[{"type":"issue","check_name":"PhanUndeclaredMethod","description":"UndefError PhanUndeclaredMethod Call to undeclared method \\Phan\\Config::thismethodisundefined","severity":5,"location":{"path":"src\/Phan\/Phan.php","lines":{"begin":417,"end":417}}},{"type":"issue","check_name":"PhanTypeMismatchReturn","description":"TypeError PhanTypeMismatchReturn Returning type null but examplefn() is declared to return string","severity":5,"location":{"path":"src\/Phan\/Phan.php","lines":{"begin":418,"end":418}}}]

~/phan $ time ./phan_client --daemonize-tcp-port 4849 -l src/Phan/Phan.php
No syntax errors detected in src/Phan/Phan.php
Phan error: UndefError: PhanUndeclaredMethod: Call to undeclared method \Phan\Config::thismethodisundefined in src/Phan/Phan.php on line 417
Phan error: TypeError: PhanTypeMismatchReturn: Returning type null but examplefn() is declared to return string in src/Phan/Phan.php on line 418
./phan_client --daemonize-tcp-port 4849 -l src/Phan/Phan.php  0.03s user 0.01s system 40% cpu 0.089 total
```