### PR TITLE
Use an absolute path to src/phan.php

### DIFF
--- a/phan
+++ b/phan
@@ -1,2 +1,2 @@
 #!/usr/bin/env php
-<?php require_once 'src/phan.php';
+<?php require_once __DIR__ . '/src/phan.php';


### PR DESCRIPTION
Otherwise, it would run src/phan.php in the project being analyzed,
if that existed (include_path may include '.' and current working
directory)

(E.g. if you're using the command `../phan_stable/phan` to analyze a
unstable branch of phan which has type errors)