### PR TITLE
Prefer phan's documented types over the default types in the internal property map of various classes

### DIFF
--- a/src/Phan/Language/Internal/PropertyMap.php
+++ b/src/Phan/Language/Internal/PropertyMap.php
@@ -397,4 +397,19 @@ return [
         'file' => 'string',
         'line' => 'int'
     ],
+    'ast\node' => [
+        'kind' => 'int',
+        'flags' => 'int',
+        'lineno' => 'int',
+        'children' => 'array|null',
+    ],
+    'ast\node\decl' => [
+        'kind' => 'int',
+        'flags' => 'int',
+        'lineno' => 'int',
+        'children' => 'array|null',
+        'endLineno' => 'int',
+        'name' => 'string',
+        'docComment' => 'string|null',
+    ],
 ];


### PR DESCRIPTION
Don't use the type of the default value, it isn't always accurate or
complete (e.g. for \ast\Node)

Using `array|null` over `?array` because phan's codebase would trigger a
lot of warnings for the latter