### PR TITLE
Speed up travis: Prefer dist installations over source installations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - composer validate
 
 install:
-  - composer --prefer-source install
+  - composer --prefer-dist install
 
 script:
   - ./vendor/bin/phpunit --colors --testsuite "$TEST_SUITE"


### PR DESCRIPTION
- The git checkouts can't be cached as easily, and take longer.
  They are also must larger than the distributed releases,
  so if a git checkout (src), were to be cached, it would take up a lot
  of space in the cache.

Looking at the git history, I'm not sure why `--prefer-src` was used.
Phan self-tests and `./phan` seems to work properly even if
--prefer-dist  is passed to a composer install command.