### PR TITLE
Smoother progress bar

### DIFF
--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -182,11 +182,14 @@ class Analysis
     public static function analyzeFunctions(CodeBase $code_base)
     {
         $function_count = count($code_base->getFunctionAndMethodSet());
+        $show_progress = CLI::shouldShowProgress();
         $i = 0;
+
+        if ($show_progress) { CLI::progress('method', 0.0); }
 
         foreach ($code_base->getFunctionAndMethodSet() as $function_or_method)
         {
-            CLI::progress('method', (++$i)/$function_count);
+            if ($show_progress) { CLI::progress('method', (++$i)/$function_count); }
 
             if ($function_or_method->isInternal()) {
                 continue;

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -91,6 +91,7 @@ class Phan implements IgnoredFilesFilterInterface {
         // This first pass parses code and populates the
         // global state we'll need for doing a second
         // analysis after.
+        CLI::progress('parse', 0.0);
         foreach ($file_path_list as $i => $file_path) {
             CLI::progress('parse', ($i + 1) / $file_count);
 
@@ -188,6 +189,7 @@ class Phan implements IgnoredFilesFilterInterface {
         assert($process_count > 0 && $process_count <= Config::get()->processes,
             "The process count must be between 1 and the given number of processes. After mapping files to cores, $process_count process were set to be used.");
 
+        CLI::progress('analyze', 0.0);
         // Check to see if we're running as multiple processes
         // or not
         if ($process_count > 1) {
@@ -262,6 +264,7 @@ class Phan implements IgnoredFilesFilterInterface {
         // want to run an analysis on
         $dependency_file_path_list = [];
 
+        CLI::progress('dependencies', 0.0);
         foreach ($file_path_list as $i => $file_path) {
             CLI::progress('dependencies', ($i + 1) / $file_count);
 


### PR DESCRIPTION
Call fwrite() once - hopefully less likely that hitting enter will split
this up in the middle of a progress bar, terminal should be refreshed
less often, etc.

Always refresh the progress bar at 0%, so that it's immediately clear what phase Phan is in.

In preparation for the daemon mode, cache the results of
shouldShowProgress() so that config instance isn't fetched once
times per function/method in the codebase in the method phase.