### PR TITLE
Add SolrObject and V8Js to list of classes with dynamic properties

### DIFF
--- a/src/Phan/Language/Internal/DynamicPropertyMap.php
+++ b/src/Phan/Language/Internal/DynamicPropertyMap.php
@@ -8,4 +8,6 @@ namespace Phan\Language\Internal;
 return [
     'stdclass',
     'simplexmlelement',
+    'solrobject',
+    'v8js',
 ];


### PR DESCRIPTION
v8js was mentioned in #404

Also helps with #539 (doesn't make this configurable in .phan/config.php, though)