### PR TITLE
Support basic usage of class_alias

### DIFF
--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 namespace Phan;
 
+use Phan\Analysis\AliasAnalyzer;
 use Phan\Analysis\DuplicateFunctionAnalyzer;
 use Phan\Analysis\ParameterTypesAnalyzer;
 use Phan\Analysis\ReferenceCountsAnalyzer;
@@ -171,6 +172,33 @@ class Analysis
 
         // Pass the context back up to our parent
         return $context;
+    }
+
+    /**
+     * Take a pass over all provided files to find top-level
+     * class_alias calls and add them to $code_base.
+     *
+     * @param CodeBase $code_base
+     * The global code base in which we store all
+     * state
+     *
+     * @param string[] $file_path_list
+     * A list of file paths to look for class_alias calls in.
+     *
+     * @return void
+     */
+    public static function analyzeAliases(
+        CodeBase $code_base,
+        array $file_path_list
+    ) {
+        foreach ($file_path_list as $i => $file_path) {
+            try {
+                AliasAnalyzer::parseFile($code_base, $file_path);
+
+            } catch (\Throwable $throwable) {
+                error_log($file_path . ' ' . $throwable->getMessage() . "\n");
+            }
+        }
     }
 
     /**

--- a/src/Phan/Analysis/AliasAnalyzer.php
+++ b/src/Phan/Analysis/AliasAnalyzer.php
@@ -1,0 +1,135 @@
+<?php declare(strict_types=1);
+namespace Phan\Analysis;
+
+use Phan\CodeBase;
+use Phan\Config;
+use Phan\Language\Context;
+use ast\Node;
+
+/**
+ * Analyze files looking for top-level class_alias calls to
+ * add into the CodeBase. Does not handle conditional calls,
+ * or calls that happen inside functions/methods/closures/etc.
+ */
+class AliasAnalyzer
+{
+    /**
+     * This pass parses code and looks for top level
+     * class_alias calls.
+     *
+     * @param CodeBase $code_base
+     * The CodeBase represents state across the entire
+     * code base. This is a mutable object which is
+     * populated as we parse files
+     *
+     * @param string $file_path
+     * The full path to a file we'd like to parse
+     *
+     * @return Context
+     */
+    public static function parseFile(CodeBase $code_base, string $file_path) : Context
+    {
+        $context = (new Context)->withFile($file_path);
+
+        // Convert the file to an Abstract Syntax Tree
+        // before passing it on to the recursive version
+        // of this method
+        try {
+            $node = \ast\parse_file(
+                Config::projectPath($file_path),
+                Config::get()->ast_version
+            );
+        } catch (\ParseError $parse_error) {
+            // Previously handled by Analysis::parseFile
+            return $context;
+        }
+
+        if (empty($node)) {
+            // Previously handled by Analysis::parseFile
+            return $context;
+        }
+
+        return self::parseNodeInContext(
+            $code_base,
+            $context,
+            $node
+        );
+    }
+
+    /**
+     * Parse the given node in the given context populating
+     * the code base within the context as a side effect. The
+     * returned context is the new context from within the
+     * given node.
+     *
+     * @param CodeBase $code_base
+     * The global code base in which we store all
+     * state
+     *
+     * @param Context $context
+     * The context in which this node exists
+     *
+     * @param Node $node
+     * A node to parse and scan for errors
+     *
+     * @return Context
+     * The context from within the node is returned
+     */
+    public static function parseNodeInContext(CodeBase $code_base, Context $context, Node $node) : Context
+    {
+        // Visit the given node populating the code base
+        // with anything we learn and get a new context
+        // indicating the state of the world within the
+        // given node
+        $context = (new AliasVisitor(
+            $code_base,
+            $context->withLineNumberStart($node->lineno ?? 0)
+        ))($node);
+
+        assert(!empty($context), 'Context cannot be null');
+
+        // Recurse into each child node
+        $child_context = $context;
+        foreach ($node->children ?? [] as $child_node) {
+
+            // Skip any non Node children.
+            if (!($child_node instanceof Node)) {
+                continue;
+            }
+
+            if (!self::shouldVisitNode($child_node)) {
+                $child_context->withLineNumberStart(
+                    $child_node->lineno ?? 0
+                );
+                continue;
+            }
+
+            // Step into each child node and get an
+            // updated context for the node
+            $child_context = self::parseNodeInContext($code_base, $child_context, $child_node);
+
+            assert(!empty($child_context), 'Context cannot be null');
+        }
+
+        // Pass the context back up to our parent
+        return $context;
+    }
+
+    /**
+     * Only recurse into the set of nodes that are executed
+     * at the top level, when the file is initially parsed
+     * by php.
+     *
+     * @return bool - true if a node should be visited
+     */
+    public static function shouldVisitNode(Node $node) : bool {
+        switch ($node->kind) {
+            case \ast\AST_CALL:
+            case \ast\AST_NAMESPACE:
+            case \ast\AST_STMT_LIST:
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Phan/Analysis/AliasVisitor.php
+++ b/src/Phan/Analysis/AliasVisitor.php
@@ -1,0 +1,115 @@
+<?php declare(strict_types=1);
+namespace Phan\Analysis;
+
+use Phan\AST\ContextNode;
+use Phan\Exception\IssueException;
+use Phan\Issue;
+use Phan\Language\Context;
+use Phan\Language\FQSEN\FullyQualifiedClassName;
+use ast\Node;
+
+/**
+ * The class is a visitor for AST nodes that tracks class
+ * aliases. Each visitor populates the $code_base with any
+ * top-level class aliases.
+ */
+class AliasVisitor extends ScopeVisitor
+{
+    /**
+     * Visit a node with kind `\ast\AST_CALL`
+     *
+     * @param Node $node
+     * A node to parse
+     *
+     * @return Context
+     * A new or an unchanged context resulting from
+     * parsing the node
+     */
+    public function visitCall(Node $node) : Context
+    {
+        $expression = $node->children['expr'];
+
+        if ($expression->kind !== \ast\AST_NAME
+            || $expression->children['name'] !== 'class_alias'
+            || !$this->context->isInGlobalScope()
+        ) {
+            return $this->context;
+        }
+
+        $args = $node->children['args'];
+        if ($args->kind !== \ast\AST_ARG_LIST
+            || !isset($args->children[0])
+            || !isset($args->children[1])
+        ) {
+            return $this->context;
+        }
+
+        try {
+            $original_fqsen = $this->resolveArgument($args->children[0]);
+            $alias_fqsen = $this->resolveArgument($args->children[1]);
+        } catch (IssueException $exception) {
+            Issue::maybeEmitInstance(
+                $this->code_base,
+                $this->context,
+                $exception->getIssueInstance()
+            );
+            return $this->context;
+        }
+
+        if ($original_fqsen === null || $alias_fqsen === null) {
+            return $this->context;
+        }
+
+        if (!$this->code_base->hasClassWithFQSEN($original_fqsen)) {
+            $this->emitIssue(
+                Issue::UndeclaredClass,
+                $node->lineno ?? 0,
+                $args->children[0]
+            );
+        } else if ($this->code_base->hasClassWithFQSEN($alias_fqsen)) {
+            $clazz = $this->code_base->getClassByFQSEN($alias_fqsen);
+            $this->emitIssue(
+                Issue::RedefineClass,
+                $node->lineno ?? 0,
+                $args->children[1],
+                $this->context->getFile(),
+                $node->lineno ?? 0,
+                (string)$clazz,
+                $clazz->getFileRef()->getFile(),
+                $clazz->getFileRef()->getLineNumberStart()
+            );
+        } else {
+            $this->code_base->addClassAlias($original_fqsen, $alias_fqsen);
+        }
+
+        return $this->context;
+    }
+
+    /**
+     * @param mixed $arg
+     * A function argument to resolve into an FQSEN
+     *
+     * @return ?FullyQualifiedClassName
+     */
+    private function resolveArgument($arg)
+    {
+        if (is_string($arg)) {
+            return FullyQualifiedClassName::fromFullyQualifiedString($arg);
+        }
+        if ($arg instanceof Node
+            && $arg->kind === \ast\AST_CLASS_CONST
+        ) {
+            $constant = (new ContextNode(
+                $this->code_base,
+                $this->context,
+                $arg
+            ))->getClassConst();
+
+            if (strtolower($constant->getName()) === 'class') {
+                return $constant->getClassFQSEN();
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -60,6 +60,12 @@ class CodeBase
 
     /**
      * @var Map
+     * A map from FQSEN to list of aliases
+     */
+    private $fqsen_alias_map;
+
+    /**
+     * @var Map
      * A map from FQSEN to a global constant
      */
     private $fqsen_global_constant_map;
@@ -108,6 +114,7 @@ class CodeBase
         array $internal_function_name_list
     ) {
         $this->fqsen_class_map = new Map;
+        $this->fqsen_alias_map = new Map;
         $this->fqsen_global_constant_map = new Map;
         $this->fqsen_func_map = new Map;
         $this->class_fqsen_class_map_map = new Map;
@@ -167,6 +174,9 @@ class CodeBase
         $this->fqsen_class_map =
             $this->fqsen_class_map->deepCopy();
 
+        $this->fqsen_alias_map =
+            $this->fqsen_alias_map->deepCopy();
+
         $this->fqsen_global_constant_map =
             $this->fqsen_global_constant_map->deepCopy();
 
@@ -202,6 +212,8 @@ class CodeBase
         $code_base = new CodeBase([], [], [], []);
         $code_base->fqsen_class_map =
             clone($this->fqsen_class_map);
+        $code_base->fqsen_alias_map =
+            clone($this->fqsen_alias_map);
         $code_base->fqsen_global_constant_map =
             clone($this->fqsen_global_constant_map);
         $code_base->fqsen_func_map =
@@ -223,6 +235,28 @@ class CodeBase
     {
         // Map the FQSEN to the class
         $this->fqsen_class_map[$class->getFQSEN()] = $class;
+    }
+
+    /**
+     * @param FullyQualifiedClassName $original
+     *  an existing class to alias to
+     *
+     * @param FullyQualifiedClassName $alias
+     *  a name to alias $original to
+     *
+     * @return void
+     */
+    public function addClassAlias(
+        FullyQualifiedClassName $original,
+        FullyQualifiedClassName $alias
+    ) {
+        $class = $this->getClassByFQSEN($original);
+        $this->fqsen_class_map[$alias] = $class;
+
+        if (!isset($this->fqsen_alias_map[$original])) {
+            $this->fqsen_alias_map[$original] = new Set();
+        }
+        $this->fqsen_alias_map[$original]->attach($alias);
     }
 
     /**
@@ -262,6 +296,24 @@ class CodeBase
 
         return $clazz;
     }
+
+    /**
+     * @param FullyQualifiedClassName $original
+     * The FQSEN of class to get aliases of
+     *
+     * @return FullyQualifiedClassName[]
+     * A list of all aliases of $original
+     */
+    public function getClassAliasesByFQSEN(
+        FullyQualifiedClassName $original
+    ) : array {
+        if (isset($this->fqsen_alias_map[$original])) {
+            return $this->fqsen_alias_map[$original]->toArray();
+        }
+
+        return [];
+    }
+
 
     /**
      * @return Map

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1011,6 +1011,16 @@ class Type
                 }
             }
 
+            // Add in aliases
+            $fqsenAliases = $code_base->getClassAliasesByFQSEN($class_fqsen);
+            foreach ($fqsenAliases as $aliasFQSEN) {
+                $recursive_union_type->addUnionType(
+                    $this->isGenericArray()
+                        ? $aliasFQSEN->asUnionType()->asGenericArrayTypes()
+                        : $aliasFQSEN->asUnionType()
+                );
+            }
+
             return $recursive_union_type;
         });
     }

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -138,6 +138,9 @@ class Phan implements IgnoredFilesFilterInterface {
         // lets us only need to do hydrate a subset of classes.
         $code_base->setShouldHydrateRequestedElements(true);
 
+        // Find any class aliases and tie them together to the source class
+        Analysis::analyzeAliases($code_base, $analyze_file_path_list);
+
         // Take a pass over all functions verifying
         // various states now that we have the whole
         // state in memory

--- a/tests/files/expected/0278_class_alias.php.expected
+++ b/tests/files/expected/0278_class_alias.php.expected
@@ -1,0 +1,5 @@
+%s:34 PhanUndeclaredClass Reference to undeclared class DoesNotExist
+%s:36 PhanRedefineClass \Foo278\Dupe defined at %s:36 was previously defined as Class \Foo278\Dupe at %s:29
+%s:38 PhanRedefineClass \Foo278\Dupe2 defined at %s:38 was previously defined as Class \Foo278\Dupe2 at %s:51
+%s:44 PhanUndeclaredClassMethod Call to method __construct from undeclared class \Foo278\AliasedFromNonExisting
+%s:46 PhanUndeclaredClassMethod Call to method __construct from undeclared class \Foo278\DoesNotExist

--- a/tests/files/src/0278_class_alias.php
+++ b/tests/files/src/0278_class_alias.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace {
+    class Original278 {}
+    class ExtendsAliased278 extends Aliased278 {}
+    class ExtendsTwiceAliased278 extends TwiceAliased278 {}
+
+    function testOriginal278(Original278 $x) {}
+    function testAliased278(Aliased278 $x) {}
+
+    class_alias('Original278', 'Aliased278');
+    class_alias('Aliased278', 'TwiceAliased278');
+
+    testOriginal278(new Original278());
+    testOriginal278(new Aliased278());
+    testOriginal278(new TwiceAliased278());
+    testOriginal278(new ExtendsAliased278());
+    testOriginal278(new ExtendsTwiceAliased278());
+    testAliased278(new Original278());
+    testAliased278(new Aliased278());
+    testAliased278(new TwiceAliased278());
+    testAliased278(new ExtendsAliased278());
+    testAliased278(new ExtendsTwiceAliased278());
+}
+
+namespace Foo278 {
+
+    class NamespacedOriginal {}
+    class Dupe {}
+    trait OriginalTrait {}
+
+    class_alias('\Foo278\NamespacedOriginal', 'AliasedFromNamespace278');
+    class_alias(\Original278::class, '\Foo278\AliasedFromRootNamespace');
+    class_alias('DoesNotExist', '\Foo278\AliasedFromNonExisting');
+    // Dupe was defined above this line
+    class_alias('\Foo278\NamespacedOriginal', '\Foo278\Dupe');
+    // Dupe2 was defined below  this line
+    class_alias('\Foo278\NamespacedOriginal', '\Foo278\Dupe2');
+    class_alias('\Foo278\OriginalTrait', '\Foo278\AliasedTrait');
+    $w = new \Aliased278();
+    $x = new \AliasedFromNamespace278();
+    $y = new AliasedFromRootNamespace();
+    // does not exist, was aliased from non-existent class
+    $z = new AliasedFromNonExisting();
+    // does not exist, was never attempted to be created
+    $z = new DoesNotExist();
+
+    class UsesAliasedTrait extends \Original278 {
+        use AliasedTrait;
+    }
+    class Dupe2 {}
+}


### PR DESCRIPTION
This supports the most basic form of class_alias, which probably
covers most use cases. It adds aliases for class_alias used in the
global scope with constant string arguments.

Fixes #521