### PR TITLE
Detect undefined variables in calls to functions, outside quick mode

### DIFF
--- a/tests/files/expected/0275_warn_extra_undef.php.expected
+++ b/tests/files/expected/0275_warn_extra_undef.php.expected
@@ -1,0 +1,1 @@
+%s:5 PhanUndeclaredVariable Variable $undefVar is undeclared

--- a/tests/files/src/0274_default_of_null.php
+++ b/tests/files/src/0274_default_of_null.php
@@ -1,0 +1,24 @@
+<?php
+
+class DefaultNullCheck{
+    public function foo() {
+        return "In A\n";
+    }
+    public static function expects_nullable_1(string $tag, DefaultNullCheck $a = null) {
+        $isDefined = $a != null;
+        if ($isDefined) {
+            echo $a->foo();
+        }
+    }
+
+    public static function expects_nullable_2(string $tag, DefaultNullCheck $a = null) {
+        $isDefined = $a != null;
+        if ($isDefined) {
+            echo $a->foo();
+        }
+    }
+}
+DefaultNullCheck::expects_nullable_1('tag', new DefaultNullCheck());  // This alone won't cause an error
+DefaultNullCheck::expects_nullable_1('tag', null);  // won't cause an error when analyzed. This may change
+DefaultNullCheck::expects_nullable_2('tag', new DefaultNullCheck());  // This alone won't cause an error
+DefaultNullCheck::expects_nullable_2('tag');        // should be consistent with expect_nullable_1 now and in the future.

--- a/tests/files/src/0275_warn_extra_undef.php
+++ b/tests/files/src/0275_warn_extra_undef.php
@@ -1,0 +1,12 @@
+<?php
+
+class UndefAndUndeclaredParam {
+    public static function foo($targetId) {
+        return self::_private_method($targetId, $undefVar);
+    }
+
+    private static function _private_method($targetId) : string {
+        func_get_args();  // func_get_args means this can have any number of arguments, but none are declared parameters.
+        return 'hi';
+    }
+}


### PR DESCRIPTION
Fixes #583

Also detects other problems with those arguments, e.g. bad property
accesses

Also fixes #518
(Analyzes passing null into the function closer to how it is analyzed
if null was the parameter default.
Null is a special case, because there's usually some other types)