### PR TITLE
Add magic property annotations to phan

### DIFF
--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -541,8 +541,9 @@ class ContextNode
                 $property_name
             )) {
                 // If there's a getter on properties then all
-                // bets are off.
-                if ($class->hasGetMethod($this->code_base)) {
+                // bets are off. However, @phan-forbid-undeclared-magic-properties
+                // will make this method analyze the code as if all properties were declared or had @property annotations.
+                if ($class->hasGetMethod($this->code_base) && !$class->getForbidUndeclaredMagicProperties($this->code_base)) {
                     throw new UnanalyzableException(
                         $this->node,
                         "Can't determine if property {$property_name} exists in class {$class->getFQSEN()} with __get defined"

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -170,6 +170,13 @@ class Config
         'dead_code_detection_prefer_false_negative' => true,
 
         // If disabled, Phan will not read docblock type
+        // annotation comments for @property.
+        // @property-read and @property-write are treated exactly the
+        // same as @property for now.
+        // Note: read_type_annotations must also be enabled.
+        'read_magic_property_annotations' => true,
+
+        // If disabled, Phan will not read docblock type
         // annotation comments (such as for @return, @param,
         // @var, @suppress, @deprecated) and only rely on
         // types expressed in code.

--- a/src/Phan/Language/Element/Flags.php
+++ b/src/Phan/Language/Element/Flags.php
@@ -15,6 +15,7 @@ class Flags
 
     const CLASS_HAS_DYNAMIC_PROPERTIES = (1 << 8);
     const IS_CLONE_OF_VARIADIC         = (1 << 9);
+    const CLASS_FORBID_UNDECLARED_MAGIC_PROPERTIES = (1 << 10);
 
     /**
      * Either enable or disable the given flag on

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -142,6 +142,18 @@ class ParseVisitor extends ScopeVisitor
         // accessible object
         $this->code_base->addClass($class);
 
+        // Depends on code_base for checking existence of __get and __set.
+        // TODO: Add a check in analyzeClasses phase that magic @property declarations
+        // are limited to classes with either __get or __set declared.
+        $class->setMagicPropertyMap(
+            $comment->getMagicPropertyMap(),
+            $this->code_base,
+            $this->context
+        );
+
+        // usually used together with magic @property annotations
+        $class->setForbidUndeclaredMagicProperties($comment->getForbidUndeclaredMagicProperties());
+
         // Look to see if we have a parent class
         if (!empty($node->children['extends'])) {
             $parent_class_name =

--- a/tests/files/expected/0271_property_declaration.php.expected
+++ b/tests/files/expected/0271_property_declaration.php.expected
@@ -1,0 +1,2 @@
+%s:15 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \stdClass but \intdiv() takes int
+%s:16 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \stdClass but \intdiv() takes int

--- a/tests/files/expected/0272_property_only_declarations.php.expected
+++ b/tests/files/expected/0272_property_only_declarations.php.expected
@@ -1,0 +1,3 @@
+%s:16 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \stdClass but \intdiv() takes int
+%s:17 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \stdClass but \intdiv() takes int
+%s:18 PhanUndeclaredProperty Reference to undeclared property \A272->y

--- a/tests/files/expected/0273_property_read_write_declarations.php.expected
+++ b/tests/files/expected/0273_property_read_write_declarations.php.expected
@@ -1,2 +1,2 @@
-%s:22 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \stdClass but \intdiv() takes int
-%s:23 PhanTypeMismatchProperty Assigning int to property but \A273::y is \stdClass
+%s:21 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \stdClass but \intdiv() takes int
+%s:22 PhanTypeMismatchProperty Assigning int to property but \A273::y is \stdClass

--- a/tests/files/expected/0273_property_read_write_declarations.php.expected
+++ b/tests/files/expected/0273_property_read_write_declarations.php.expected
@@ -1,0 +1,2 @@
+%s:22 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \stdClass but \intdiv() takes int
+%s:23 PhanTypeMismatchProperty Assigning int to property but \A273::y is \stdClass

--- a/tests/files/src/0271_property_declaration.php
+++ b/tests/files/src/0271_property_declaration.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @property \stdClass $x
+ */
+class A271 {
+    private $instances = [];
+    /** @return mixed */
+    public function __get($key) {
+        return $this->instances[$key];
+    }
+
+    public static function test() {
+        $x = new self();
+        echo intdiv($x->x, 2);
+        echo intdiv(new stdClass(), 2);
+        echo intdiv($x->y, 2);  // no error because we don't know property y's type
+    }
+}

--- a/tests/files/src/0272_property_only_declarations.php
+++ b/tests/files/src/0272_property_only_declarations.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @property \stdClass $x
+ * @phan-forbid-undeclared-magic-properties
+ */
+class A272 {
+    private $instances = [];
+    /** @return mixed */
+    public function __get($key) {
+        return $this->instances[$key];
+    }
+
+    public static function test() {
+        $x = new self();
+        echo intdiv($x->x, 2);
+        echo intdiv(new stdClass(), 2);
+        echo intdiv($x->y, 2);  // no error because we don't know property y's type
+    }
+}

--- a/tests/files/src/0273_property_read_write_declarations.php
+++ b/tests/files/src/0273_property_read_write_declarations.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @property-read  \stdClass $x
+ * @property-write \stdClass $y
+ */
+class A273 {
+    private $instances = [];
+    /** @return mixed */
+    public function __get($key) {
+        return $this->instances[$key];
+    }
+
+    public function __set($key, $value) {
+        $this->instances[$key] = $value;
+    }
+
+    public static function test() {
+        $x = new self();
+        $a = $x->x;  // read stdClass
+        echo intdiv($a, 2);  // use in wrong context
+        $x->y = 2;  // assign incompatible type to stdClass
+    }
+}


### PR DESCRIPTION
Currently, @property, @property-read, and @property-write are all
equivalent, due a to lack of checks if a context node is getting/setting a
property.

Also add annotation @PhanForbidUndeclaredMagicProperties
(Motivation: if a class is expected to have complete annotations for its
getters/setters, then it is useful to warn if something undeclared is used
in that class, to prevent typos and to ensure analysis maintains a
consistent quality)

Limitations:

- Does not warn if __get/__set don't exist.
- Not able to have a __get() shadow a property of the same name inside
  the current class (e.g. getter of private property, which does
  initialization). For best results, make them the same type.
  (not able to do it in a way that accounts for which type is used inside/outside the classes.)
- Possibly some edge cases if multiple classes have @property annotations. My use case doesn't involve inheritance.


Fixes #386

Taken from my fork, with the new @PhanForbidUndeclaredMagicProperties
annotation introduced.