### PR TITLE
Fix casting types to/from nullable - use static::, not self::

### DIFF
--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -667,7 +667,10 @@ class Type
      */
     public function withIsNullable(bool $is_nullable) : Type
     {
-        return self::make(
+        if ($is_nullable === $this->is_nullable) {
+            return $this;
+        }
+        return static::make(
             $this->getNamespace(),
             $this->getName(),
             $this->getTemplateParameterTypeList(),

--- a/tests/files/expected/0274_nullable_to_non_nullable.php.expected
+++ b/tests/files/expected/0274_nullable_to_non_nullable.php.expected
@@ -1,0 +1,1 @@
+%s:12 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is array but \intdiv() takes int

--- a/tests/files/src/0274_nullable_to_non_nullable.php
+++ b/tests/files/src/0274_nullable_to_non_nullable.php
@@ -1,0 +1,13 @@
+<?php
+
+function foo() : ?array
+{
+    return ['a'];
+}
+
+$result = foo();
+if (!is_null($result))
+{
+    echo $result[0];
+    echo intdiv($result, 2);
+}


### PR DESCRIPTION
For #567 and #582

self::make() returns an instance of the class Type (or a generic array),
but we instead need the same subclass as the original.
static::make() returns an instance of **the same** subclass of Type, e.g.
ArrayType.

$nullableArrayType->withIsNullable(false) was returning a non-ArrayType, since it called Type::make, not ArrayType::make.

Also, add a small optimization and check if is_nullable would be
the same as before (e.g. for plugins)

Also, add tests.