### PR TITLE
Update `./phan --version`

### DIFF
--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -13,7 +13,10 @@ use Symfony\Component\Console\Output\StreamOutput;
 
 class CLI
 {
-    const PHAN_VERSION = '0.9.1-dev';
+    /**
+     * This should be updated to x.y.z-dev after every release, and x.y.z before a release.
+     */
+    const PHAN_VERSION = '0.9.2-dev';
 
     /**
      * @var OutputInterface


### PR DESCRIPTION
Aside: as part of release procedures, future releases should update
CLI::PHAN_VERSION before and after creating a release tag.