### PR TITLE
Fix issue #610 : Emit different issue types for undeclared static and instance properties

### DIFF
--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -474,6 +474,10 @@ class ContextNode
      * @param string|Node $property_name
      * The name of the property we're looking up
      *
+     * @param bool $is_static
+     * True if we're looking for a static property,
+     * false if we're looking for an instance property.
+     *
      * @return Property
      * A variable in scope or a new variable
      *
@@ -663,6 +667,10 @@ class ContextNode
      * @throws NodeException
      * An exception is thrown if we can't understand the node
      *
+     * @throws UnanalyzableException
+     * An exception is thrown if we can't find the given
+     * class
+     *
      * @throws CodeBaseExtension
      * An exception is thrown if we can't find the given
      * class
@@ -670,6 +678,9 @@ class ContextNode
      * @throws TypeException
      * An exception may be thrown if the only viable candidate
      * is a non-class type.
+     *
+     * @throws IssueException
+     * An exception is thrown if $is_static, but the property doesn't exist.
      */
     public function getOrCreateProperty(
         string $property_name,
@@ -679,14 +690,20 @@ class ContextNode
         try {
             return $this->getProperty($property_name, $is_static);
         } catch (IssueException $exception) {
-            // Ignore it, because we'll create our own property
-            // (for instance properties)
             if ($is_static) {
                 throw $exception;
             }
+            // TODO: log types of IssueException that aren't for undeclared properties?
+            // (in another PR)
+
+            // For instance properties, ignore it,
+            // because we'll create our own property
         } catch (UnanalyzableException $exception) {
-            // Ignore it, because we'll create our own
-            // property
+            if ($is_static) {
+                throw $exception;
+            }
+            // For instance properties, ignore it,
+            // because we'll create our own property
         }
 
         assert(

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1172,6 +1172,20 @@ class UnionTypeVisitor extends AnalysisVisitor
         return $this->analyzeProp($node, false);
     }
 
+    /**
+     * Analyzes a node with kind `\ast\AST_PROP` or `\ast\AST_STATIC_PROP`
+     *
+     * @param Node $node
+     * The instance/static property access node.
+     *
+     * @param bool $is_static
+     * True if this is a static property fetch,
+     * false if this is an instance property fetch.
+     *
+     * @return UnionType
+     * The set of types that are possibly produced by the
+     * given node
+     */
     private function analyzeProp(Node $node, bool $is_static) : UnionType
     {
         try {

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1169,12 +1169,17 @@ class UnionTypeVisitor extends AnalysisVisitor
      */
     public function visitProp(Node $node) : UnionType
     {
+        return $this->analyzeProp($node, false);
+    }
+
+    private function analyzeProp(Node $node, bool $is_static) : UnionType
+    {
         try {
             $property = (new ContextNode(
                 $this->code_base,
                 $this->context,
                 $node
-            ))->getProperty($node->children['prop']);
+            ))->getProperty($node->children['prop'], $is_static);
 
             // Map template types to concrete types
             if ($property->getUnionType()->hasTemplateType()) {
@@ -1231,7 +1236,7 @@ class UnionTypeVisitor extends AnalysisVisitor
      */
     public function visitStaticProp(Node $node) : UnionType
     {
-        return $this->visitProp($node);
+        return $this->analyzeProp($node, true);
     }
 
 

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1479,21 +1479,29 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
 
     public function visitStaticProp(Node $node) : Context
     {
-        return $this->visitProp($node);
+        return $this->analyzeProp($node, true);
+    }
+
+    public function visitProp(Node $node) : Context
+    {
+        return $this->analyzeProp($node, false);
     }
 
     /**
-     * Visit a node with kind `\ast\AST_PROP`
+     * Analyze a node with kind `\ast\AST_PROP` or `\ast\AST_STATIC_PROP`
      *
      * @param Node $node
      * A node of the type indicated by the method name that we'd
      * like to figure out the type that it produces.
      *
+     * @param bool $is_static
+     * True if fetching a static property.
+     *
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitProp(Node $node) : Context
+    public function analyzeProp(Node $node, bool $is_static) : Context
     {
         $exception_or_null = null;
 
@@ -1502,7 +1510,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 $this->code_base,
                 $this->context,
                 $node
-            ))->getProperty($node->children['prop']);
+            ))->getProperty($node->children['prop'], $is_static);
 
             // Mark that this property has been referenced from
             // this context
@@ -1539,25 +1547,28 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 );
             }
 
-            // Find out of any of them have a __get magic method
-            $has_getter =
-                array_reduce($class_list, function($carry, $class) {
-                    return (
-                        $carry ||
-                        $class->hasGetMethod($this->code_base)
-                    );
-                }, false);
+            if (!$is_static) {
+                // Find out of any of them have a __get magic method
+                // (Only check if looking for instance properties)
+                $has_getter =
+                    array_reduce($class_list, function($carry, $class) {
+                        return (
+                            $carry ||
+                            $class->hasGetMethod($this->code_base)
+                        );
+                    }, false);
 
-            // If they don't, then analyze for Noops.
-            if (!$has_getter) {
-                $this->analyzeNoOp($node, Issue::NoopProperty);
+                // If they don't, then analyze for Noops.
+                if (!$has_getter) {
+                    $this->analyzeNoOp($node, Issue::NoopProperty);
 
-                if ($exception_or_null instanceof IssueException) {
-                    Issue::maybeEmitInstance(
-                        $this->code_base,
-                        $this->context,
-                        $exception_or_null->getIssueInstance()
-                    );
+                    if ($exception_or_null instanceof IssueException) {
+                        Issue::maybeEmitInstance(
+                            $this->code_base,
+                            $this->context,
+                            $exception_or_null->getIssueInstance()
+                        );
+                    }
                 }
             }
         }
@@ -1620,7 +1631,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                                 $this->code_base,
                                 $this->context,
                                 $argument
-                            ))->getOrCreateProperty($argument->children['prop']);
+                            ))->getOrCreateProperty($argument->children['prop'], $argument->kind == \ast\AST_STATIC_PROP);
                         } catch (IssueException $exception) {
                             Issue::maybeEmitInstance(
                                 $this->code_base,
@@ -1690,7 +1701,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                                 $this->code_base,
                                 $this->context,
                                 $argument
-                            ))->getOrCreateProperty($argument->children['prop']);
+                            ))->getOrCreateProperty($argument->children['prop'], $argument->kind == \ast\AST_STATIC_PROP);
 
                         } catch (IssueException $exception) {
                             Issue::maybeEmitInstance(
@@ -1909,6 +1920,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             ))->getOrCreateVariable();
         } else if ($argument->kind == \ast\AST_STATIC_PROP) {
             try {
+                // TODO: shouldn't call getOrCreateProperty for a static property. You can't create a static property.
                 $variable = (new ContextNode(
                     $this->code_base,
                     $this->context,

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1926,7 +1926,8 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                     $this->context,
                     $argument
                 ))->getOrCreateProperty(
-                    $argument->children['prop'] ?? ''
+                    $argument->children['prop'] ?? '',
+                    true
                 );
             } catch (UnanalyzableException $exception) {
                 // Ignore it. There's nothing we can do. (E.g. the class name for the static property fetch couldn't be determined.

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -124,6 +124,7 @@ class Issue
     const AccessNonStaticToStatic   = 'PhanAccessNonStaticToStatic';
     const AccessClassConstantPrivate     = 'PhanAccessClassConstantPrivate';
     const AccessClassConstantProtected   = 'PhanAccessClassConstantProtected';
+    const AccessPropertyStaticAsNonStatic = 'PhanAccessPropertyStaticAsNonStatic';
 
     // Issue::CATEGORY_COMPATIBLE
     const CompatibleExpressionPHP7  = 'PhanCompatibleExpressionPHP7';
@@ -425,7 +426,7 @@ class Issue
             new Issue(
                 self::UndeclaredStaticProperty,
                 self::CATEGORY_UNDEFINED,
-                self::SEVERITY_NORMAL,
+                self::SEVERITY_CRITICAL,
                 "Static property '{PROPERTY}' on {CLASS} is undeclared",
                 self::REMEDIATION_B,
                 1016
@@ -1058,6 +1059,15 @@ class Issue
                 self::REMEDIATION_B,
                 1009
             ),
+            new Issue(
+                self::AccessPropertyStaticAsNonStatic,
+                self::CATEGORY_ACCESS,
+                self::SEVERITY_CRITICAL,
+                "Accessing static property %s as non static",
+                self::REMEDIATION_B,
+                1010
+            ),
+
 
             // Issue::CATEGORY_COMPATIBLE
             new Issue(

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -55,6 +55,10 @@ class Property extends ClassElement
             $string .= 'private ';
         }
 
+        if ($this->isStatic()) {
+            $string .= 'static ';
+        }
+
         // Since the UnionType can be a future, and that
         // can throw an exception, we catch it and ignore it
         try {

--- a/tests/files/expected/0014_parent_property.php.expected
+++ b/tests/files/expected/0014_parent_property.php.expected
@@ -1,0 +1,1 @@
+%s:11 PhanUndeclaredStaticProperty Static property 'beta' on \A is undeclared

--- a/tests/files/expected/0066_abstract_properties.php.expected
+++ b/tests/files/expected/0066_abstract_properties.php.expected
@@ -1,2 +1,1 @@
-%s:7 PhanUndeclaredProperty Reference to undeclared property \AbstractProperties->things2
-
+%s:7 PhanUndeclaredStaticProperty Static property 'things2' on \AbstractProperties is undeclared

--- a/tests/files/expected/0101_one_of_each.php.expected
+++ b/tests/files/expected/0101_one_of_each.php.expected
@@ -45,7 +45,6 @@
 %s:198 PhanUndeclaredInterface Class implements undeclared interface \C18
 %s:206 PhanUndeclaredProperty Reference to undeclared property \C14->undef
 %s:210 PhanUndeclaredStaticMethod Static call to undeclared method \C21::f
-%s:214 PhanUndeclaredProperty Reference to undeclared property \C22->p
+%s:214 PhanUndeclaredStaticProperty Static property 'p' on \C22 is undeclared
 %s:217 PhanUndeclaredTrait Class uses undeclared trait \T2
 %s:220 PhanUndeclaredVariable Variable $v10 is undeclared
-

--- a/tests/files/expected/0276_assign_and_missing_static_property.php.expected
+++ b/tests/files/expected/0276_assign_and_missing_static_property.php.expected
@@ -1,0 +1,5 @@
+%s:7 PhanUndeclaredStaticProperty Static property 'prop' on \ClassMissingStaticProps is undeclared
+%s:8 PhanUndeclaredStaticProperty Static property 'prop' on \ClassMissingStaticProps is undeclared
+%s:11 PhanUndeclaredStaticProperty Static property 'firstProp' on \stdClass is undeclared
+%s:12 PhanUndeclaredStaticProperty Static property 'secondProp' on \stdClass is undeclared
+%s:13 PhanUndeclaredStaticProperty Static property 'thirdProp' on \stdClass is undeclared

--- a/tests/files/src/0014_parent_property.php
+++ b/tests/files/src/0014_parent_property.php
@@ -7,7 +7,8 @@ class A {
 }
 
 class B extends A {
-    public static $gamma = parent::$alpha;
-    public $delta = parent::$beta;
+    public static $gamma = parent::$alpha;  // FIXME: PHP Fatal error: Constant expression contains invalid operations, but this test expects no Issues.
+    public $delta = parent::$beta;  // Note: This is not a valid way to fetch a parent instance property. Emit an issue here as well.
     public $epsilon = parent::FOURTY_TWO;
 }
+// FIXME: this test should access parent properties within functions. Property declaration defaults expect constant expressions.

--- a/tests/files/src/0276_assign_and_missing_static_property.php
+++ b/tests/files/src/0276_assign_and_missing_static_property.php
@@ -1,0 +1,14 @@
+<?php
+class ClassMissingStaticProps {
+    public function __get($name) { return 42; }  // __get should have no impact on analyzing static properties
+    public function __set($name, $value) { return 42; }  // __set should have no impact on analyzing static properties.
+}
+function checkMissingStaticProps() {
+    ClassMissingStaticProps::$prop = 2;  // Causes Error to be thrown if executed.
+    var_export(ClassMissingStaticProps::$prop);
+    // Instances of the built in stdClass are permitted to have any instance property.
+    // But stdClass has no static properties.
+    stdClass::$firstProp = true;
+    $b = stdClass::$secondProp;
+    var_export(stdClass::$thirdProp);
+}


### PR DESCRIPTION
Phan already has an issue type for UndeclaredStaticProperty - Code just wasn't using it yet.

- Update existing tests to use the new issue type. Note that 0014_parent_property.php.expected would throw an error if it were actually run. Also, the snippet `parent::$prop` fetches a static property, ignoring instance properties.
- Fix bugs in the way static properties were analyzed on the left hand side of AssignmentVisitor
- Fix bug: The presence of __get and __set should not affect the way static property fetches are analyzed
- Fix bug: allow_undeclared_properties config should only apply to instance properties (That seems to be a reasonable interpretation)

TODOs listed in this PR will be addressed in a different PR, this PR is fairly large (E.g. checking for static/non-static property mismatch in subclass, checking private in subclass, but public in base class)

Also, should the message for UndeclaredStaticProperty be changed to be more like UndeclaredProperty? It hasn't been emitted in recent releases (existing code emits UndeclaredProperty), so changing the message shouldn't matter.