### PR TITLE
Fixes #613 : Check if conditional node is a scalar

### DIFF
--- a/tests/files/expected/0277_literal_conditional.php.expected
+++ b/tests/files/expected/0277_literal_conditional.php.expected
@@ -1,0 +1,8 @@
+%s:10 PhanTypeArraySuspicious Suspicious array access to int
+%s:11 PhanTypeArraySuspicious Suspicious array access to int
+%s:12 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is bool but \intdiv() takes int
+%s:13 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is bool but \intdiv() takes int
+%s:17 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is bool but \intdiv() takes int
+%s:18 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
+%s:19 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
+%s:22 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is float but \intdiv() takes int

--- a/tests/files/src/0277_literal_conditional.php
+++ b/tests/files/src/0277_literal_conditional.php
@@ -1,0 +1,26 @@
+<?php
+
+const FEATURE_FLAG = true;
+
+// A literal (instead of AST node) used in a conditional should not cause crashes.
+function check_literal_conditional() {
+    $x = 3;
+    intdiv(0 ? $x : 2, 2);
+    intdiv(0 ?: $x, 2);
+    intdiv(0 ?: $x[0], 2);
+    intdiv(1 ?: $x[0], 2);  // should warn about $x[0] being invalid, even if it's dead code?
+    intdiv(true ?: $x, 2);  // should warn about passing bool to intdiv
+    intdiv(\true ?: $x, 2);  // should warn about passing bool to intdiv
+    intdiv(false ?: $x, 2);  // should not warn
+    intdiv(\false ?: $x, 2);  // should not warn
+    intdiv(false ? true : $x, 2);  // should not warn
+    intdiv(TRUE ? true : $x, 2);  // should warn
+    intdiv('key' ?: $x, 2);  // should warn about passing string
+    intdiv('1' ?: $x, 2);  // should warn about passing string (or only in strict mode?)
+    intdiv('' ?: $x, 2);  // should not warn
+    intdiv('0' ?: $x, 2);  // should not warn
+    intdiv(4.2 ?: $x, 2);  // should warn about passing float
+    intdiv(0.0 ?: $x, 2);  // should not warn about passing float (still not great code)
+    intdiv(FEATURE_FLAG ? 'value' : $x, 2);  // In the **general** case, we're not sure about internal or external constants, so we assume both types are possible.
+    intdiv(FEATURE_FLAG ? $x : 'value', 2);  // also test the other way around.
+}


### PR DESCRIPTION
In addition to that, check for conditionals that are no-ops to cut down
on false positives. (e.g. `2 ?: $x` is always of the type `int`(2))