### PR TITLE
Add PhanParamSignatureRealMismatch, which will completely ignore phpdoc types.

### DIFF
--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -4,9 +4,11 @@ namespace Phan\Analysis;
 use Phan\CodeBase;
 use Phan\Config;
 use Phan\Issue;
+use Phan\Language\Element\Clazz;
 use Phan\Language\Element\FunctionInterface;
 use Phan\Language\Element\Method;
 use Phan\Language\Element\Parameter;
+use Phan\Language\Type\IterableType;
 use Phan\Language\Type\MixedType;
 use Phan\Language\Type\TemplateType;
 
@@ -92,28 +94,37 @@ class ParameterTypesAnalyzer
         // $method->analyzeOverride($code_base);
 
         // Make sure we're actually overriding something
+        // TODO: check that signatures of magic methods are valid, if not done already (e.g. __get expects one param, most can't define return types, etc.)?
         if (!$method->getIsOverride()) {
-            return;
-        }
-
-        // Dont' worry about signatures lining up on
-        // constructors. We just want to make sure that
-        // calling a method on a subclass won't cause
-        // a runtime error. We usually know what we're
-        // constructing at instantiation time, so there
-        // is less of a risk.
-        if ($method->getName() == '__construct') {
             return;
         }
 
         // Get the method that is being overridden
         $o_method = $method->getOverriddenMethod($code_base);
 
+        // Unless it is an abstract constructor,
+        // don't worry about signatures lining up on
+        // constructors. We just want to make sure that
+        // calling a method on a subclass won't cause
+        // a runtime error. We usually know what we're
+        // constructing at instantiation time, so there
+        // is less of a risk.
+        if ($method->getName() == '__construct' && !$o_method->isAbstract()) {
+            return;
+        }
+
         // Get the class that the overridden method lives on
         $o_class = $o_method->getClass($code_base);
 
+        // A lot of analyzeOverrideRealSignature is redundant.
+        // However, phan should consistently emit both issue types if one of them is suppressed.
+        self::analyzeOverrideRealSignature($code_base, $method, $o_method, $o_class);
+
         // PHP doesn't complain about signature mismatches
         // with traits, so neither shall we
+        // TODO: it does, in some cases, such as a trait existing for an abstract method defined in the class.
+        //   (Wrong way around to analyze that, though)
+        // It also checks if a trait redefines a method in the class.
         if ($o_class->isTrait()) {
             return;
         }
@@ -178,7 +189,7 @@ class ParameterTypesAnalyzer
 
         // If parameter counts match, check their types
         } else {
-            foreach($method->getParameterList() as $i => $parameter) {
+            foreach ($method->getParameterList() as $i => $parameter) {
 
                 if (!isset($o_parameter_list[$i])) {
                     continue;
@@ -194,11 +205,15 @@ class ParameterTypesAnalyzer
                 }
 
                 // A stricter type on an overriding method is cool
+                // TODO: This doesn't match the definition of LSP.
+                // - If you use a stricter param type, you can't call the subclass with args you could call the base class with.
                 if ($o_parameter->getUnionType()->isEmpty()
                     || $o_parameter->getUnionType()->isType(MixedType::instance(false))
                 ) {
                     continue;
                 }
+
+                // TODO: check variadic.
 
                 // Its not OK to have a more relaxed type on an
                 // overriding method
@@ -224,7 +239,8 @@ class ParameterTypesAnalyzer
             }
         }
 
-        // Return types should be mappable
+        // Return types should be mappable for LSP
+        // Note: PHP requires return types to be identical
         if (!$o_return_union_type->isEmpty()) {
 
             if (!$method->getUnionType()->asExpandedTypes($code_base)->canCastToUnionType(
@@ -311,7 +327,131 @@ class ParameterTypesAnalyzer
             }
 
         }
-
     }
 
+    /**
+     * Previously, Phan bases the analysis off of phpdoc.
+     * Keeping that around(e.g. to check that string[] is compatible with string[])
+     * and also checking the **real**(non-phpdoc) types.
+     *
+     * @return void
+     */
+    private static function analyzeOverrideRealSignature(
+        CodeBase $code_base,
+        Method $method,
+        Method $o_method,
+        Clazz $o_class
+    ) {
+        if ($o_class->isTrait()) {
+            return;  // TODO: properly analyze abstract methods overriding/overridden by traits.
+        }
+
+        // Get the parameters for that method
+        $o_parameter_list = $o_method->getRealParameterList();
+
+        // Map overridden method return type through any template
+        // type parameters we may have
+        $o_return_union_type = $o_method->getRealReturnType();
+
+        // Determine if the signatures match up
+        $signatures_match = true;
+
+        // Make sure the count of parameters matches
+        if ($method->getNumberOfRequiredParameters()
+            > $o_method->getNumberOfRequiredParameters()
+        ) {
+            $signatures_match = false;
+        } else if ($method->getNumberOfParameters()
+            < $o_method->getNumberOfParameters()
+        ) {
+            $signatures_match = false;
+
+        // If parameter counts match, check their types
+        } else {
+            foreach ($method->getRealParameterList() as $i => $parameter) {
+
+                // TODO: check if variadic
+                if (!isset($o_parameter_list[$i])) {
+                    continue;
+                }
+
+                // TODO: check that the variadic types match up?
+                $o_parameter = $o_parameter_list[$i];
+
+                // Changing pass by reference is not ok
+                // @see https://3v4l.org/Utuo8
+                if ($parameter->isPassByReference() != $o_parameter->isPassByReference()) {
+                    $signatures_match = false;
+                    break;
+                }
+
+                // Either 0 or both of the params must have types for the signatures to be compatible.
+                $o_parameter_union_type = $o_parameter->getUnionType();
+                $parameter_union_type = $parameter->getUnionType();
+                if ($parameter_union_type->isEmpty() != $o_parameter_union_type->isEmpty()) {
+                    $signatures_match = false;
+                    break;
+                }
+
+                // If both have types, make sure they are identical.
+                // Non-nullable param types can be substituted with the nullable equivalents.
+                if (!$parameter_union_type->isEmpty()) {
+                    if (!$o_parameter_union_type->isEqualTo($parameter_union_type) &&
+                        !($parameter_union_type->containsNullable() && !$o_parameter_union_type->isEqualTo($parameter_union_type->nonNullableClone()))
+                    ) {
+                        // There is one exception to this in php 7.1 - the pseudo-type "iterable" can replace ArrayAccess/array in a subclass
+                        // TODO: Traversable and array work, but Iterator doesn't. Check for those specific cases?
+                        $is_exception_to_rule = $parameter_union_type->hasIterable() &&
+                            $o_parameter_union_type->hasIterable() &&
+                            ($parameter_union_type->hasType(IterableType::instance(true)) ||
+                             $parameter_union_type->hasType(IterableType::instance(false)) && !$o_parameter_union_type->containsNullable());
+
+                        if (!$is_exception_to_rule) {
+                            $signatures_match = false;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        $return_union_type = $method->getRealReturnType();
+        // If the parent has a return type, then return types should be equal.
+        // A non-nullable return type can override a nullable return type of the same type.
+        if (!$o_return_union_type->isEmpty()) {
+            if (!($o_return_union_type->isEqualTo($return_union_type) || (
+                $o_return_union_type->containsNullable() && !($o_return_union_type->nonNullableClone()->isEqualTo($return_union_type)))
+                )) {
+                    $signatures_match = false;
+            }
+        }
+
+        if ($o_method->returnsRef() && !$method->returnsRef()) {
+            $signatures_match = false;
+        }
+
+        if (!$signatures_match) {
+            if ($o_method->isInternal()) {
+                Issue::maybeEmit(
+                    $code_base,
+                    $method->getContext(),
+                    Issue::ParamSignatureRealMismatchInternal,
+                    $method->getFileRef()->getLineNumberStart(),
+                    $method->toRealSignatureString(),
+                    $o_method->toRealSignatureString()
+                );
+            } else {
+                Issue::maybeEmit(
+                    $code_base,
+                    $method->getContext(),
+                    Issue::ParamSignatureRealMismatch,
+                    $method->getFileRef()->getLineNumberStart(),
+                    $method->toRealSignatureString(),
+                    $o_method->toRealSignatureString(),  // TODO: instead of __toString(), a version for the real signature.
+                    $o_method->getFileRef()->getFile(),
+                    $o_method->getFileRef()->getLineNumberStart()
+                );
+            }
+        }
+    }
 }

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -334,6 +334,10 @@ class ParameterTypesAnalyzer
      * Keeping that around(e.g. to check that string[] is compatible with string[])
      * and also checking the **real**(non-phpdoc) types.
      *
+     * @param $code_base
+     * @param $method - The overriding method
+     * @param $o_method - The overridden method. E.g. if a subclass overrid a base class implementation, then $o_method would be from the base class.
+     * @param $o_class the overridden class
      * @return void
      */
     private static function analyzeOverrideRealSignature(
@@ -401,9 +405,10 @@ class ParameterTypesAnalyzer
 
                 // If both have types, make sure they are identical.
                 // Non-nullable param types can be substituted with the nullable equivalents.
+                // E.g. A::foo(?int $x) can override BaseClass::foo(int $x)
                 if (!$parameter_union_type->isEmpty()) {
                     if (!$o_parameter_union_type->isEqualTo($parameter_union_type) &&
-                        !($parameter_union_type->containsNullable() && !$o_parameter_union_type->isEqualTo($parameter_union_type->nonNullableClone()))
+                        !($parameter_union_type->containsNullable() && $o_parameter_union_type->isEqualTo($parameter_union_type->nonNullableClone()))
                     ) {
                         // There is one exception to this in php 7.1 - the pseudo-type "iterable" can replace ArrayAccess/array in a subclass
                         // TODO: Traversable and array work, but Iterator doesn't. Check for those specific cases?

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -94,7 +94,7 @@ class ParameterTypesAnalyzer
         // $method->analyzeOverride($code_base);
 
         // Make sure we're actually overriding something
-        // TODO: check that signatures of magic methods are valid, if not done already (e.g. __get expects one param, most can't define return types, etc.)?
+        // TODO(in another PR): check that signatures of magic methods are valid, if not done already (e.g. __get expects one param, most can't define return types, etc.)?
         if (!$method->getIsOverride()) {
             return;
         }
@@ -385,6 +385,12 @@ class ParameterTypesAnalyzer
                     break;
                 }
 
+                // Changing variadic to/from non-variadic is not ok?
+                if ($parameter->isVariadic() != $o_parameter->isVariadic()) {
+                    $signatures_match = false;
+                    break;
+                }
+
                 // Either 0 or both of the params must have types for the signatures to be compatible.
                 $o_parameter_union_type = $o_parameter->getUnionType();
                 $parameter_union_type = $parameter->getUnionType();
@@ -447,7 +453,7 @@ class ParameterTypesAnalyzer
                     Issue::ParamSignatureRealMismatch,
                     $method->getFileRef()->getLineNumberStart(),
                     $method->toRealSignatureString(),
-                    $o_method->toRealSignatureString(),  // TODO: instead of __toString(), a version for the real signature.
+                    $o_method->toRealSignatureString(),
                     $o_method->getFileRef()->getFile(),
                     $o_method->getFileRef()->getLineNumberStart()
                 );

--- a/src/Phan/Exception/CodeBaseException.php
+++ b/src/Phan/Exception/CodeBaseException.php
@@ -18,7 +18,7 @@ class CodeBaseException extends \Exception
      */
     public function __construct(
         FQSEN $missing_fqsen = null,
-        string $message = null
+        string $message = ""
     ) {
         parent::__construct($message);
         $this->missing_fqsen = $missing_fqsen;

--- a/src/Phan/Exception/NodeException.php
+++ b/src/Phan/Exception/NodeException.php
@@ -20,7 +20,7 @@ class NodeException extends \Exception
      */
     public function __construct(
         Node $node,
-        string $message = null
+        string $message = ''
     ) {
         parent::__construct($message);
         $this->node = $node;

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -813,7 +813,7 @@ class Issue
                 self::REMEDIATION_B,
                 7012
             ),
-            // TODO: change the other message to say that it's based off of phpdoc and LSP?
+            // TODO: Optionally, change the other message to say that it's based off of phpdoc and LSP in a future PR.
             new Issue(
                 self::ParamSignatureRealMismatch,
                 self::CATEGORY_PARAMETER,

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -92,6 +92,8 @@ class Issue
     const ParamTypeMismatch         = 'PhanParamTypeMismatch';
     const ParamSignatureMismatch    = 'PhanParamSignatureMismatch';
     const ParamSignatureMismatchInternal = 'PhanParamSignatureMismatchInternal';
+    const ParamSignatureRealMismatch    = 'PhanParamSignatureRealMismatch';
+    const ParamSignatureRealMismatchInternal = 'PhanParamSignatureRealMismatchInternal';
     const ParamRedefined            = 'PhanParamRedefined';
 
     // Issue::CATEGORY_NOOP
@@ -810,6 +812,24 @@ class Issue
                 "Redefinition of parameter %s",
                 self::REMEDIATION_B,
                 7012
+            ),
+            // TODO: change the other message to say that it's based off of phpdoc and LSP?
+            new Issue(
+                self::ParamSignatureRealMismatch,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_CRITICAL,
+                "Declaration of %s should be compatible with %s defined in %s:%d",
+                self::REMEDIATION_B,
+                7013
+            ),
+            // NOTE: some extensions don't define arg info
+            new Issue(
+                self::ParamSignatureRealMismatchInternal,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_CRITICAL,
+                "Declaration of %s should be compatible with internal %s",
+                self::REMEDIATION_B,
+                7014
             ),
 
             // Issue::CATEGORY_NOOP

--- a/src/Phan/Language/Element/Comment/Parameter.php
+++ b/src/Phan/Language/Element/Comment/Parameter.php
@@ -4,6 +4,7 @@ namespace Phan\Language\Element\Comment;
 
 use Phan\Language\Context;
 use Phan\Language\Element\Variable;
+use Phan\Language\Type\NullType;
 use Phan\Language\UnionType;
 
 class Parameter

--- a/src/Phan/Language/Element/FunctionFactory.php
+++ b/src/Phan/Language/Element/FunctionFactory.php
@@ -186,9 +186,8 @@ class FunctionFactory {
                 $alternate_function->setUnionType($map['return_type']);
             }
 
-            // Load properties if defined
-            // TODO: should be 'parameter_name_type_map'?
-            foreach ($map['property_name_type_map'] ?? []
+            // Load parameter types if defined
+            foreach ($map['parameter_name_type_map'] ?? []
                 as $parameter_name => $parameter_type
             ) {
                 $flags = 0;
@@ -231,7 +230,9 @@ class FunctionFactory {
                 $alternate_function->appendParameter($parameter);
             }
 
-            // TODO: What do I do if this is out of sync with the extension's ReflectionMethod->getParameterList()?
+            // TODO: Store the "real" number of required parameters,
+            // if this is out of sync with the extension's ReflectionMethod->getParameterList()?
+            // (e.g. third party extensions may add more required parameters?)
             $alternate_function->setNumberOfRequiredParameters(
                 array_reduce($alternate_function->getParameterList(),
                     function(int $carry, Parameter $parameter) : int {

--- a/src/Phan/Language/Element/FunctionFactory.php
+++ b/src/Phan/Language/Element/FunctionFactory.php
@@ -136,6 +136,9 @@ class FunctionFactory {
             $method->setNumberOfOptionalParameters(999);
             $method->setNumberOfRequiredParameters(0);
         }
+        // FIXME: make this from ReflectionMethod->getReturnType
+        $method->setRealReturnType(UnionType::fromReflectionType($reflection_method->getReturnType()));
+        $method->setRealParameterList(Parameter::listFromReflectionParameterList($reflection_method->getParameters()));
 
         return self::functionListFromFunction($method, $code_base);
     }
@@ -184,6 +187,7 @@ class FunctionFactory {
             }
 
             // Load properties if defined
+            // TODO: should be 'parameter_name_type_map'?
             foreach ($map['property_name_type_map'] ?? []
                 as $parameter_name => $parameter_type
             ) {
@@ -216,6 +220,8 @@ class FunctionFactory {
                 );
 
                 if ($is_optional) {
+                    // TODO: could check isDefaultValueAvailable and getDefaultValue, for a better idea.
+                    // I don't see any cases where this will be used for internal types, though.
                     $parameter->setDefaultValueType(
                         NullType::instance(false)->asUnionType()
                     );
@@ -225,6 +231,7 @@ class FunctionFactory {
                 $alternate_function->appendParameter($parameter);
             }
 
+            // TODO: What do I do if this is out of sync with the extension's ReflectionMethod->getParameterList()?
             $alternate_function->setNumberOfRequiredParameters(
                 array_reduce($alternate_function->getParameterList(),
                     function(int $carry, Parameter $parameter) : int {

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -283,7 +283,6 @@ trait FunctionTrait {
         }
         // Clone the union type, to be certain it will remain immutable.
         $union_type = clone($this->real_return_type);
-        // TODO: is `static` ever going to be valid? if not, remove below code and warn about reserved keyword.
         return $union_type;
     }
 

--- a/src/Phan/Language/Element/TypedElement.php
+++ b/src/Phan/Language/Element/TypedElement.php
@@ -140,6 +140,19 @@ abstract class TypedElement implements TypedElementInterface
     }
 
     /**
+     * @return void
+     */
+    protected function convertToNullable()
+    {
+        // Avoid a redundant clone of nonNullableClone()
+        $type = $this->type;
+        if ($type->isEmpty() || $type->containsNullable()) {
+            return;
+        }
+        $this->type = $type->nullableClone();
+    }
+
+    /**
      * Variables can't be variadic. This is the same as getUnionType for
      * variables, but not necessarily for subclasses. Method will return
      * the element type (such as `DateTime`) for variadic parameters.

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -367,6 +367,17 @@ class Type
         return self::make($namespace, $type_name, [], $is_nullable, false);
     }
 
+    public static function fromReflectionType(
+        \ReflectionType $reflection_type
+    ) : Type {
+
+        return self::fromStringInContext(
+            (string)$reflection_type,
+            new Context(),
+            false
+        );
+    }
+
     /**
      * @param string $fully_qualified_string
      * A fully qualified type name

--- a/src/Phan/Language/Type/IterableType.php
+++ b/src/Phan/Language/Type/IterableType.php
@@ -19,6 +19,7 @@ class IterableType extends NativeType
      */
     public function isArrayLike() : bool
     {
+        // TODO: the base `iterable` isn't always array-like (no array access on Traversable)
         return true;
     }
 

--- a/src/Phan/Language/Type/IterableType.php
+++ b/src/Phan/Language/Type/IterableType.php
@@ -19,7 +19,8 @@ class IterableType extends NativeType
      */
     public function isArrayLike() : bool
     {
-        // TODO: the base `iterable` isn't always array-like (no array access on Traversable)
+        // TODO: the base `iterable` isn't always array-like (no array access on Traversable).
+        // In another PR, change `iterable` behavior?
         return true;
     }
 

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -38,7 +38,7 @@ class UnionType implements \Serializable
     private $type_set;
 
     /**
-     * @param Type[]|\Iterator $type_list
+     * @param Type[]|\Iterator|null $type_list
      * An optional list of types represented by this union
      */
     public function __construct($type_list = null)

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -267,17 +267,17 @@ class UnionType implements \Serializable
                 : null;
 
             $name_type_name_map = $type_name_struct;
-            $property_name_type_map = [];
+            $parameter_name_type_map = [];
 
             foreach ($name_type_name_map as $name => $type_name) {
-                $property_name_type_map[$name] = empty($type_name)
+                $parameter_name_type_map[$name] = empty($type_name)
                     ? new UnionType()
                     : UnionType::fromStringInContext($type_name, $context, false);
             }
 
             $configurations[] = [
                 'return_type' => $return_type,
-                'property_name_type_map' => $property_name_type_map,
+                'parameter_name_type_map' => $parameter_name_type_map,
             ];
 
             $function_name =

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -574,6 +574,20 @@ class UnionType implements \Serializable
         return $result;
     }
 
+    public function nullableClone() : UnionType
+    {
+        $result = new UnionType();
+        foreach ($this->getTypeSet() as $type) {
+            if ($type->getIsNullable()) {
+                $result->addType($type);
+                continue;
+            }
+
+            $result->addType($type->withIsNullable(true));
+        }
+        return $result;
+    }
+
     /**
      * @param UnionType $union_type
      * A union type to compare against

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -165,6 +165,20 @@ class UnionType implements \Serializable
     }
 
     /**
+     * @param ?\ReflectionType $reflection_type
+     *
+     * @return UnionType
+     * A UnionType with 0 or 1 nullable/non-nullable Types
+     */
+    public static function fromReflectionType($reflection_type) : UnionType
+    {
+        if ($reflection_type !== null) {
+            return Type::fromReflectionType($reflection_type)->asUnionType();
+        }
+        return new UnionType();
+    }
+
+    /**
      * @return string[]
      * Get a map from property name to its type for the given
      * class name.
@@ -627,6 +641,19 @@ class UnionType implements \Serializable
     public function hasAnyType(array $type_list) : bool
     {
         return $this->type_set->containsAny($type_list);
+    }
+
+    /**
+     * @return bool
+     * True if this type has any subtype of `iterable` type (e.g. Traversable, Array).
+     */
+    public function hasIterable() : bool
+    {
+        return (false !==
+            $this->type_set->find(function (Type $type) : bool {
+                return $type->isIterable();
+            })
+        );
     }
 
     /**

--- a/tests/files/expected/0124_override_signature.php.expected
+++ b/tests/files/expected/0124_override_signature.php.expected
@@ -1,10 +1,22 @@
 %s:6 PhanParamSignatureMismatch Declaration of function f() should be compatible with function f(int $a) defined in %s:3
+%s:6 PhanParamSignatureRealMismatch Declaration of function f() should be compatible with function f(int $a) defined in %s:3
 %s:12 PhanParamSignatureMismatch Declaration of function f(int $a, int $b) should be compatible with function f(int $a) defined in %s:3
+%s:12 PhanParamSignatureRealMismatch Declaration of function f(int $a, int $b) should be compatible with function f(int $a) defined in %s:3
 %s:15 PhanParamSignatureMismatch Declaration of function f(string $a) should be compatible with function f(int $a) defined in %s:3
+%s:15 PhanParamSignatureRealMismatch Declaration of function f(string $a) should be compatible with function f(int $a) defined in %s:3
 %s:18 PhanParamSignatureMismatch Declaration of function f($a) should be compatible with function f(int $a) defined in %s:3
+%s:18 PhanParamSignatureRealMismatch Declaration of function f($a) should be compatible with function f(int $a) defined in %s:3
 %s:25 PhanParamSignatureMismatch Declaration of function g() : int should be compatible with function g() : string defined in %s:22
+%s:25 PhanParamSignatureRealMismatch Declaration of function g() : int should be compatible with function g() : string defined in %s:22
+%s:28 PhanParamSignatureRealMismatch Declaration of function g() should be compatible with function g() : string defined in %s:22
+%s:35 PhanParamSignatureRealMismatch Declaration of function h(int $a) should be compatible with function h($a) defined in %s:32
 %s:50 PhanParamSignatureMismatch Declaration of function i($a) should be compatible with function i($a, mixed|string $b = default) defined in %s:46
+%s:50 PhanParamSignatureRealMismatch Declaration of function i($a) should be compatible with function i($a, $b = default) defined in %s:46
 %s:58 PhanParamSignatureMismatch Declaration of function j() should be compatible with function &j() defined in %s:54
+%s:58 PhanParamSignatureRealMismatch Declaration of function j() should be compatible with function &j() defined in %s:54
 %s:67 PhanParamSignatureMismatch Declaration of function k(&$a) should be compatible with function k($a) defined in %s:62
+%s:67 PhanParamSignatureRealMismatch Declaration of function k(&$a) should be compatible with function k($a) defined in %s:62
 %s:68 PhanParamSignatureMismatch Declaration of function l($b) should be compatible with function l(&$b) defined in %s:63
+%s:68 PhanParamSignatureRealMismatch Declaration of function l($b) should be compatible with function l(&$b) defined in %s:63
 %s:76 PhanParamSignatureMismatch Declaration of function m($a) should be compatible with function m(mixed|null $a = null) defined in %s:72
+%s:76 PhanParamSignatureRealMismatch Declaration of function m($a) should be compatible with function m($a = null) defined in %s:72

--- a/tests/files/expected/0124_override_signature.php.expected
+++ b/tests/files/expected/0124_override_signature.php.expected
@@ -18,5 +18,5 @@
 %s:67 PhanParamSignatureRealMismatch Declaration of function k(&$a) should be compatible with function k($a) defined in %s:62
 %s:68 PhanParamSignatureMismatch Declaration of function l($b) should be compatible with function l(&$b) defined in %s:63
 %s:68 PhanParamSignatureRealMismatch Declaration of function l($b) should be compatible with function l(&$b) defined in %s:63
-%s:76 PhanParamSignatureMismatch Declaration of function m($a) should be compatible with function m(mixed|null $a = null) defined in %s:72
+%s:76 PhanParamSignatureMismatch Declaration of function m($a) should be compatible with function m(?mixed $a = null) defined in %s:72
 %s:76 PhanParamSignatureRealMismatch Declaration of function m($a) should be compatible with function m($a = null) defined in %s:72

--- a/tests/files/expected/0126_override_signature.php.expected
+++ b/tests/files/expected/0126_override_signature.php.expected
@@ -1,4 +1,6 @@
 %s:12 PhanParamSignatureMismatch Declaration of function f($p) should be compatible with function f(\CB $p) defined in %s:8
+%s:12 PhanParamSignatureRealMismatch Declaration of function f($p) should be compatible with function f(\CB $p) defined in %s:8
 %s:16 PhanParamSignatureMismatch Declaration of function f(\CC $p) should be compatible with function f(\CB $p) defined in %s:8
+%s:16 PhanParamSignatureRealMismatch Declaration of function f(\CC $p) should be compatible with function f(\CB $p) defined in %s:8
 %s:20 PhanParamSignatureMismatch Declaration of function f(\CA $p) should be compatible with function f(\CB $p) defined in %s:8
-
+%s:20 PhanParamSignatureRealMismatch Declaration of function f(\CA $p) should be compatible with function f(\CB $p) defined in %s:8

--- a/tests/files/expected/0227_trait_class_interface.php.expected
+++ b/tests/files/expected/0227_trait_class_interface.php.expected
@@ -1,1 +1,2 @@
 %s:13 PhanParamSignatureMismatch Declaration of function f(array $a) should be compatible with function f(array $a, array $b) defined in %s:4
+%s:13 PhanParamSignatureRealMismatch Declaration of function f(array $a) should be compatible with function f(array $a, array $b) defined in %s:4

--- a/tests/files/expected/0266_nullable_guards.php.expected
+++ b/tests/files/expected/0266_nullable_guards.php.expected
@@ -1,1 +1,1 @@
-%s:8 PhanTypeMismatchArgument Argument 1 (x) is string but \expects_nullable_int266() takes int|null defined at %s:3
+%s:8 PhanTypeMismatchArgument Argument 1 (x) is string but \expects_nullable_int266() takes ?int defined at %s:3

--- a/tests/files/expected/0278_should_differentiate_phpdoc_return_type.php.expected
+++ b/tests/files/expected/0278_should_differentiate_phpdoc_return_type.php.expected
@@ -1,0 +1,1 @@
+%s:10 PhanParamSignatureRealMismatch Declaration of function foo() should be compatible with function foo() : void defined in %s:5

--- a/tests/files/expected/0279_should_check_variadic_mismatch.php.expected
+++ b/tests/files/expected/0279_should_check_variadic_mismatch.php.expected
@@ -1,0 +1,10 @@
+%s:21 PhanParamSignatureMismatch Declaration of function foo(int ...$args) should be compatible with function foo(int $args) defined in %s:4
+%s:21 PhanParamSignatureRealMismatch Declaration of function foo(int ...$args) should be compatible with function foo(int $args) defined in %s:4
+%s:23 PhanParamSignatureMismatch Declaration of function bar(int $args) should be compatible with function bar(int ...$args) defined in %s:6
+%s:23 PhanParamSignatureRealMismatch Declaration of function bar(int $args) should be compatible with function bar(int ...$args) defined in %s:6
+%s:27 PhanParamSignatureMismatch Declaration of function bag() should be compatible with function bag(int ...$args) defined in %s:10
+%s:27 PhanParamSignatureRealMismatch Declaration of function bag() should be compatible with function bag(int ...$args) defined in %s:10
+%s:32 PhanParamSignatureMismatch Declaration of function man(...$args) should be compatible with function man(array $args) defined in %s:15
+%s:32 PhanParamSignatureRealMismatch Declaration of function man(...$args) should be compatible with function man(array $args) defined in %s:15
+%s:34 PhanParamSignatureMismatch Declaration of function dog(array $args) should be compatible with function dog(...$args) defined in %s:17
+%s:34 PhanParamSignatureRealMismatch Declaration of function dog(array $args) should be compatible with function dog(...$args) defined in %s:17

--- a/tests/files/expected/0280_should_infer_nullable_from_default.php.expected
+++ b/tests/files/expected/0280_should_infer_nullable_from_default.php.expected
@@ -1,0 +1,4 @@
+%s:23 PhanParamSignatureMismatch Declaration of function foo(int $arg = 20) should be compatible with function foo(?int $arg = null) defined in %s:10
+%s:23 PhanParamSignatureRealMismatch Declaration of function foo(int $arg = 20) should be compatible with function foo(?int $arg = null) defined in %s:10
+%s:27 PhanTypeMismatchDefault Default value for ?int $x can't be float
+%s:34 PhanTypeMismatchArgument Argument 1 (arg) is null but \C280::foo() takes int defined at %s:23

--- a/tests/files/src/0278_should_differentiate_phpdoc_return_type.php
+++ b/tests/files/src/0278_should_differentiate_phpdoc_return_type.php
@@ -1,0 +1,11 @@
+<?php
+
+class A278 {
+    /** @return void */
+    public function foo() : void {}
+}
+
+class B278 extends A278 {
+    /** @return void */
+    public function foo() {}  // This is a bug, it must explicitly have a return type of void.
+}

--- a/tests/files/src/0279_should_check_variadic_mismatch.php
+++ b/tests/files/src/0279_should_check_variadic_mismatch.php
@@ -1,0 +1,35 @@
+<?php
+
+class A279 {
+    public function foo(int $args) { }
+
+    public function bar(int ...$args) { }
+
+    public function baz(int ...$args) { }
+
+    public function bag(int ...$args) { }
+
+    public function bat() { }
+
+    // check the way phan compares variadic types with non-variadic types
+    public function man(array $args) { }
+
+    public function dog(...$args) { }
+}
+
+class B279 extends A279 {
+    public function foo(int... $args) { }  // incompatible, according to php
+
+    public function bar(int $args) { } // incompatible, according to php
+
+    public function baz(int ...$args) { }  // compatible
+
+    public function bag() { }  // incompatible, according to php
+
+    public function bat(int ...$args) { }  // compatible?
+
+    // check the way phan compares variadic types with non-variadic types
+    public function man(...$args) { }  // incompatible
+
+    public function dog(array $args) { }  // incompatible
+}

--- a/tests/files/src/0280_should_infer_nullable_from_default.php
+++ b/tests/files/src/0280_should_infer_nullable_from_default.php
@@ -1,0 +1,37 @@
+<?php
+
+class A280 {
+    const NULLCONST = null;
+
+    public function bar(?int $arg = null) { }
+    public function bat(int $arg = 20) { }
+    public function baz(?int $arg = 20) { }
+    public function fee(int $arg = self::NULLCONST) { }
+    public function foo(int $arg = null) { }
+}
+
+// No issues
+class B280 extends A280{
+    public function bar(int $arg = null) { }
+    public function foo(?int $arg = null) { }
+}
+
+// No issues, but foo()
+class C280 extends A280 {
+    public function bat(int $arg = null) { } // fine
+    public function fee(int $arg = 2) { }
+    public function foo(int $arg = 20) {}  // invalid, it used to be nullable.
+}
+
+class D280 {
+    public function mismatch(?int $x = 2.0) {}
+}
+function test280() {
+    $a = new A280();
+    $a->foo(null);
+    $a->fee(2);
+    $c = new C280();
+    $c->foo(null);
+    $c->fee(2);  // Sadly, this line does throw.
+}
+test280();


### PR DESCRIPTION
For issue #374

Use real signature types for the PhanSignatureReal* issues.
This ensures that we will catch more fatal errors - The php interpreter
completely ignores phpdoc types.

(E.g. something with only `/** @return void */` and no return type
is incompatible with a base class with a return type (` : void`), but PhanParamSignatureMismatch doesn't catch that)

TODO: test this on a codebase larger than Phan
EDIT: tested, didn't see any false positive errors (no issues saying there was a mismatch where there wasn't)
TODO: benchmark this
EDIT: self-analysis increased from 5.64s to 5.84s (single-threaded), which looks acceptable

- Change rules for that the checks of *real* signatures to be closer
  to what Zend/zend_inheritance.c checks in php-src
- Add tests, similar to those of Zend/zend_inheritance.c in php 7.1 
  (e.g. the tests of return type compatibility)
- In error messages, use the real types, not the phpdoc types.
- Test edge cases of inheriting traits (different PR?)
- Test edge cases of abstract methods (different PR?)
- Limit checks of `iterable` to `Traversable` and `array` to match
  PHP's checks for return types exactly.
- TODO: in another PR, separate the function signatures' minimum required args, and optional arg count? (Third-party modules are usually inaccurate here, but this is useful when extending)