### PR TITLE
Ignore directories and hidden files in the phan test file lister

### DIFF
--- a/tests/Phan/AbstractPhanFileTest.php
+++ b/tests/Phan/AbstractPhanFileTest.php
@@ -35,7 +35,8 @@ abstract class AbstractPhanFileTest
             array_filter(
                 scandir($sourceDir),
                 function ($filename) {
-                    return !in_array($filename, ['.', '..'], true);
+                    // Ignore directories and hidden files.
+                    return !in_array($filename, ['.', '..'], true) && substr($filename, 0, 1) !== '.';
                 }
             )
         );


### PR DESCRIPTION
E.g. `tests/files/src/.01_something.php.swp` would be created by vim if
editing/viewing a file at the same time as running a test.

I'm aware the check for `.` and `..` is now redundant, but it makes the intent clearer.