### PR TITLE
Fix inferences for `new static()` and `static::CONST`

### DIFF
--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -733,7 +733,7 @@ class Type
      *
      * @return bool
      * True if the given type references the class context
-     * in which it exists such as 'static' or 'self'.
+     * in which it exists such as 'self' or 'parent'
      */
     public static function isSelfTypeString(
         string $type_string
@@ -741,6 +741,22 @@ class Type
         // Note: While 'self' and 'parent' are case insensitive, '$this' is case sensitive
         // Not sure if that should extend to phpdoc.
         return preg_match('/^\\\\?([sS][eE][lL][fF]|[pP][aA][rR][eE][nN][tT]|\\$this)$/', $type_string) > 0;
+    }
+
+    /**
+     * @param string $type_string
+     * A string defining a type such as 'static' or 'int'.
+     *
+     * @return bool
+     * True if the given type references the class context
+     * in which it exists is '$this' or 'static'
+     */
+    public static function isStaticTypeString(
+        string $type_string
+    ) : bool {
+        // Note: While 'self' and 'parent' are case insensitive, '$this' is case sensitive
+        // Not sure if that should extend to phpdoc.
+        return preg_match('/^\\\\?([sS][tT][aA][tT][iI][cC]|\\$this)$/', $type_string) > 0;
     }
 
     /**

--- a/tests/files/expected/0276_static_uses.php.expected
+++ b/tests/files/expected/0276_static_uses.php.expected
@@ -1,0 +1,3 @@
+%s:27 PhanTypeMismatchArgument Argument 1 (arg) is \A276|\I276|static but \A276::baz() takes \B276 defined at %s:19
+%s:28 PhanTypeMismatchArgument Argument 1 (arg) is \A276|\I276|static but \A276::baz() takes \B276 defined at %s:19
+%s:32 PhanTypeMismatchArgument Argument 1 (arg) is \B276|\I276 but \A276::foo() takes \A276 defined at %s:15

--- a/tests/files/src/0276_static_uses.php
+++ b/tests/files/src/0276_static_uses.php
@@ -1,0 +1,36 @@
+<?php
+
+interface I276 {
+
+}
+
+class B276 implements I276 {
+    /** @return static */
+    public function instance() {
+        return new static();
+    }
+}
+
+class A276 implements I276 {
+    public function foo(A276 $arg) { }
+
+    public function bar(I276 $arg) { }
+
+    public function baz(B276 $arg) { }
+
+    public function test() {
+        $foo = new static();
+        $this->foo($foo);
+        $foo->foo($foo);
+        $this->bar($foo);
+        $foo->bar($foo);
+        $this->baz($foo);  // should warn
+        $foo->baz($foo);  // should warn
+        $foo->foo($this);
+        // and check other classes
+        $b = B276::instance();
+        $this->foo($b);  // should warn
+        $this->bar($b);
+    }
+}
+(new A276())->test();


### PR DESCRIPTION
Related to 193c8b9f4c6acb5dbbbdc092fbbfed25ed7c4268 , when phan removed
`static` from `Type::isSelfTypeString()`

Fixes issue #632

visitClassNode is called by UnionTypeVisitor::visitNew and
visitClassConst