### PR TITLE
Implement partial support for analyzing static and instance "@method" annotations

### DIFF
--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -297,9 +297,9 @@ class ContextNode
                     $method_name,
                     $this->context
                 );
-            } else if (!$is_static && $class->hasCallMethod($this->code_base)) {
+            } else if (!$is_static && $class->allowsCallingUndeclaredInstanceMethod($this->code_base)) {
                 return $class->getCallMethod($this->code_base);
-            } else if ($is_static && $class->hasCallStaticMethod($this->code_base)) {
+            } else if ($is_static && $class->allowsCallingUndeclaredStaticMethod($this->code_base)) {
                 return $class->getCallStaticMethod($this->code_base);
             }
         }

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -177,6 +177,11 @@ class Config
         'read_magic_property_annotations' => true,
 
         // If disabled, Phan will not read docblock type
+        // annotation comments for @method.
+        // Note: read_type_annotations must also be enabled.
+        'read_magic_method_annotations' => true,
+
+        // If disabled, Phan will not read docblock type
         // annotation comments (such as for @return, @param,
         // @var, @suppress, @deprecated) and only rely on
         // types expressed in code.

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -1221,9 +1221,24 @@ class Clazz extends AddressableElement
      * @return bool
      * True if this class has a magic '__call' method
      */
-    public function hasCallMethod(CodeBase $code_base)
+    public function hasCallMethod(CodeBase $code_base) : bool
     {
         return $this->hasMethodWithName($code_base, '__call');
+    }
+
+    /**
+     * @param CodeBase $code_base
+     * The entire code base from which we'll find ancestor
+     * details
+     *
+     * @return bool
+     * True if this class has a magic '__call' method,
+     * and (at)phan-forbid-undeclared-magic-methods doesn't exist on this class or ancestors
+     */
+    public function allowsCallingUndeclaredInstanceMethod(CodeBase $code_base)
+    {
+        return $this->hasCallMethod($code_base) &&
+            !$this->getForbidUndeclaredMagicMethods($code_base);
     }
 
     /**
@@ -1246,9 +1261,24 @@ class Clazz extends AddressableElement
      * @return bool
      * True if this class has a magic '__callStatic' method
      */
-    public function hasCallStaticMethod(CodeBase $code_base)
+    public function hasCallStaticMethod(CodeBase $code_base) : bool
     {
         return $this->hasMethodWithName($code_base, '__callStatic');
+    }
+
+    /**
+     * @param CodeBase $code_base
+     * The entire code base from which we'll find ancestor
+     * details
+     *
+     * @return bool
+     * True if this class has a magic '__callStatic' method,
+     * and (at)phan-forbid-undeclared-magic-methods doesn't exist on this class or ancestors.
+     */
+    public function allowsCallingUndeclaredStaticMethod(CodeBase $code_base)
+    {
+        return $this->hasCallStaticMethod($code_base) &&
+            !$this->getForbidUndeclaredMagicMethods($code_base);
     }
 
     /**
@@ -1288,7 +1318,7 @@ class Clazz extends AddressableElement
      * @return bool
      * True if this class has a magic '__get' method
      */
-    public function hasGetMethod(CodeBase $code_base)
+    public function hasGetMethod(CodeBase $code_base) : bool
     {
         return $this->hasMethodWithName($code_base, '__get');
     }
@@ -1301,7 +1331,7 @@ class Clazz extends AddressableElement
      * @return bool
      * True if this class has a magic '__set' method
      */
-    public function hasSetMethod(CodeBase $code_base)
+    public function hasSetMethod(CodeBase $code_base) : bool
     {
         return $this->hasMethodWithName($code_base, '__set');
     }

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -5,22 +5,28 @@ namespace Phan\Language\Element;
 use Phan\Config;
 use Phan\Language\Context;
 use Phan\Language\Element\Comment\Parameter as CommentParameter;
+use Phan\Language\Element\Comment\Method as CommentMethod;
 use Phan\Language\Element\Flags;
 use Phan\Language\Type;
 use Phan\Language\Type\TemplateType;
+use Phan\Language\Type\VoidType;
 use Phan\Language\UnionType;
 use Phan\Library\None;
 use Phan\Library\Option;
 use Phan\Library\Some;
 
 /**
+ * Handles extracting information(param types, return types, magic methods/properties, etc.) from phpdoc comments.
+ * Instances of Comment contain the extracted information.
  */
 class Comment
 {
+    const word_regex = '([a-zA-Z_\x7f-\xff\\\][a-zA-Z0-9_\x7f-\xff\\\]*)';
 
     /**
      * @var int - contains a subset of flags to set on elements
      * Flags::CLASS_FORBID_UNDECLARED_MAGIC_PROPERTIES
+     * Flags::CLASS_FORBID_UNDECLARED_MAGIC_METHODS
      * Flags::IS_DEPRECATED
      */
     private $comment_flags = 0;
@@ -76,6 +82,12 @@ class Comment
     private $magic_property_map = [];
 
     /**
+     * @var CommentMethod[]
+     * A mapping from magic methods to parsed parameters, name, and return types.
+     */
+    private $magic_method_map = [];
+
+    /**
      * @var Option<Type>
      * An optional class name defined by a @PhanClosureScope directive.
      * (overrides the class in which it is analyzed)
@@ -83,20 +95,15 @@ class Comment
     private $closure_scope;
 
     /**
-     * @var bool
-     * Set to true if the comment forbids classes from having
-     * undeclared magic properties.
-     */
-    private $forbid_undeclared_dynamic_properties = false;
-
-    /**
      * A private constructor meant to ingest a parsed comment
      * docblock.
      *
-     * @param int $comment_flags
-     * uses Flags::IS_DEPRECATED and Flags::CLASS_FORBID_UNDECLARED_MAGIC_PROPERTIES
-     * Set to true if the comment contains a 'deprecated'
-     * directive.
+     * @param int $comment_flags uses the following flags
+     * - Flags::IS_DEPRECATED
+     *   Set to true if the comment contains a 'deprecated'
+     *   directive.
+     * - Flags::CLASS_FORBID_UNDECLARED_MAGIC_PROPERTIES
+     * - Flags::CLASS_FORBID_UNDECLARED_MAGIC_METHODS
      *
      * @param CommentParameter[] $variable_list
      *
@@ -115,6 +122,8 @@ class Comment
      *
      * @param CommentParameter[] $magic_property_list
      *
+     * @param CommentMethod[] $magic_method_list
+     *
      * @param Option<Type> $closure_scope
      * For closures: Allows us to document the class of the object
      * to which a closure will be bound.
@@ -128,6 +137,7 @@ class Comment
         UnionType $return_union_type,
         array $suppress_issue_list,
         array $magic_property_list,
+        array $magic_method_list,
         Option $closure_scope
     ) {
         $this->comment_flags = $comment_flags;
@@ -159,6 +169,14 @@ class Comment
                 $this->magic_property_map[$name] = $property;
             }
         }
+        foreach ($magic_method_list as $method) {
+            $name = $method->getName();
+            if (!empty($name)) {
+                // Add it to the named map
+                // TODO: Detect duplicates, emit warning for duplicates.
+                $this->magic_method_map[$name] = $method;
+            }
+        }
     }
 
     /**
@@ -173,7 +191,7 @@ class Comment
 
         if (!Config::get()->read_type_annotations) {
             return new Comment(
-                0, [], [], [], new None, new UnionType(), [], [], new None
+                0, [], [], [], new None, new UnionType(), [], [], [], new None
             );
         }
 
@@ -184,6 +202,7 @@ class Comment
         $return_union_type = new UnionType();
         $suppress_issue_list = [];
         $magic_property_list = [];
+        $magic_method_list = [];
         $closure_scope = new None;
         $comment_flags = 0;
 
@@ -227,10 +246,20 @@ class Comment
                         $magic_property_list[] = $magic_property;
                     }
                 }
+            } elseif (strpos($line, '@method') !== false) {
+                // Make sure support for magic methods is enabled.
+                if (Config::get()->read_magic_method_annotations) {
+                    $magic_method = self::magicMethodFromCommentLine($context, $line);
+                    if ($magic_method !== null) {
+                        $magic_method_list[] = $magic_method;
+                    }
+                }
             } elseif (stripos($line, '@PhanClosureScope') !== false) {
                 $closure_scope = self::getPhanClosureScopeFromCommentLine($context, $line);
             } elseif (stripos($line, '@phan-forbid-undeclared-magic-properties') !== false) {
                 $comment_flags |= Flags::CLASS_FORBID_UNDECLARED_MAGIC_PROPERTIES;
+            } elseif (stripos($line, '@phan-forbid-undeclared-magic-methods') !== false) {
+                $comment_flags |= Flags::CLASS_FORBID_UNDECLARED_MAGIC_METHODS;
             }
 
             if (stripos($line, '@deprecated') !== false) {
@@ -249,6 +278,7 @@ class Comment
             $return_union_type,
             $suppress_issue_list,
             $magic_property_list,
+            $magic_method_list,
             $closure_scope
         );
     }
@@ -410,6 +440,110 @@ class Comment
     }
 
     /**
+     * Parses a magic method based on https://phpdoc.org/docs/latest/references/phpdoc/tags/method.html
+     * @return ?CommentParameter - if null, the phpdoc magic method was invalid.
+     */
+    private static function magicParamFromMagicMethodParamString(
+        Context $context,
+        string $param_string,
+        int $param_index
+    ) {
+        $param_string = trim($param_string);
+        // Don't support trailing commas, or omitted params. Provide at least one of [type] or [parameter]
+        if ($param_string === '') {
+            return null;
+        }
+        // Parse an entry for [type] [parameter] - Assume both of those are optional.
+        // https://github.com/phpDocumentor/phpDocumentor2/pull/1271/files - phpdoc allows passing an default value.
+        // Phan allows `=.*`, to indicate that a parameter is optional
+        // TODO: in another PR, check that optional parameters aren't before required parameters.
+        if (preg_match('/^(' . UnionType::union_type_regex . ')?\s*((\.\.\.)\s*)?(\$' . self::word_regex . ')?((\s*=.*)?)$/', $param_string, $param_match)) {
+            // Note: a magic method parameter can be variadic, but it can't be pass-by-reference? (No support in __call)
+            $union_type_string = $param_match[1];
+            $union_type = UnionType::fromStringInContext(
+                $union_type_string,
+                $context,
+                true
+            );
+            $is_variadic = $param_match[28] === '...';
+            $default_str = $param_match[31];
+            $has_default_value = $default_str !== '';
+            if ($has_default_value) {
+                $default_value_repr = trim(explode('=', $default_str, 2)[1]);
+                if (strcasecmp($default_value_repr, 'null') === 0) {
+                    $union_type = $union_type->nullableClone();
+                }
+            }
+            $var_name = $param_match[30];
+            if ($var_name === '') {
+                // placeholder names are p1, p2, ...
+                $var_name = 'p' . ($param_index + 1);
+            }
+            return new CommentParameter($var_name, $union_type, $is_variadic, $has_default_value);
+        }
+        return null;
+    }
+
+    /**
+     * @param Context $context
+     * @param string $line
+     * An individual line of a comment
+     *
+     * @return ?CommentMethod
+     * magic method with the parameter types, return types, and name.
+     */
+    private static function magicMethodFromCommentLine(
+        Context $context,
+        string $line
+    ) {
+        // Note that the type of a property can be left out (@property $myVar) - This is equivalent to @property mixed $myVar
+        // TODO: properly handle duplicates...
+        // https://phpdoc.org/docs/latest/references/phpdoc/tags/method.html
+        // > Going to assume "static" is a magic keyword, based on https://github.com/phpDocumentor/phpDocumentor2/issues/822
+        // > TODO: forbid in trait?
+        // TODO: finish writing the regex.
+        // Syntax:
+        //    @method [return type] [name]([[type] [parameter]<, ...>]) [<description>]
+        //    Assumes the parameters end at the first ")" after "("
+        if (preg_match('/@method(\s+(static))?((\s+(' . UnionType::union_type_regex . '))?)\s+' . self::word_regex . '\s*\(([^()]*)\)\s*(.*)/', $line, $match)) {
+            $is_static = $match[2] === 'static';
+            $return_union_type_string = $match[4];
+            if ($return_union_type_string !== '') {
+                $return_union_type =
+                    UnionType::fromStringInContext(
+                        $return_union_type_string,
+                        $context,
+                        true
+                    );
+            } else {
+                // From https://phpdoc.org/docs/latest/references/phpdoc/tags/method.html
+                // > When the intended method does not have a return value then the return type MAY be omitted; in which case 'void' is implied.
+                $return_union_type = VoidType::instance(false)->asUnionType();
+            }
+            $method_name = $match[31];
+
+            $arg_list = trim($match[32]);
+            $comment_params = [];
+            // Special check if param list has 0 params.
+            if ($arg_list !== '') {
+                // TODO: Would need to use a different approach if templates were ever supported
+                $params_strings = explode(',', $arg_list);
+                foreach ($params_strings as $i => $param_string) {
+                    $param = self::magicParamFromMagicMethodParamString($context, $param_string, $i);
+                    if ($param === null) {
+                        return null;
+                    }
+                    $comment_params[] = $param;
+                }
+            }
+
+            return new CommentMethod($method_name, $return_union_type, $comment_params, $is_static);
+        }
+
+        return null;
+    }
+
+    /**
      * @param Context $context
      * @param string $line
      * An individual line of a comment
@@ -510,6 +644,16 @@ class Comment
     public function getForbidUndeclaredMagicProperties() : bool
     {
         return ($this->comment_flags & Flags::CLASS_FORBID_UNDECLARED_MAGIC_PROPERTIES) != 0;
+    }
+
+    /**
+     * @return bool
+     * Set to true if the comment contains a 'phan-forbid-undeclared-magic-methods'
+     * directive.
+     */
+    public function getForbidUndeclaredMagicMethods() : bool
+    {
+        return ($this->comment_flags & Flags::CLASS_FORBID_UNDECLARED_MAGIC_METHODS) != 0;
     }
 
     /**
@@ -638,6 +782,13 @@ class Comment
     }
 
     /**
+     * @return CommentMethod[] map from method name to method info
+     */
+    public function getMagicMethodMap() : array {
+        return $this->magic_method_map;
+    }
+
+    /**
      * @return CommentParameter[]
      */
     public function getVariableList() : array
@@ -648,6 +799,7 @@ class Comment
     public function __toString() : string
     {
         // TODO: add new properties of Comment to this method
+        // (magic methods, magic properties, custom @phan directives, etc.))
         $string = "/**\n";
 
         if (($this->comment_flags & Flags::IS_DEPRECATED) != 0) {

--- a/src/Phan/Language/Element/Comment/Method.php
+++ b/src/Phan/Language/Element/Comment/Method.php
@@ -1,0 +1,136 @@
+<?php
+declare(strict_types=1);
+namespace Phan\Language\Element\Comment;
+
+use Phan\Language\Context;
+use Phan\Language\Element\Variable;
+use Phan\Language\UnionType;
+
+class Method
+{
+
+    /**
+     * @var string
+     * The name of the method
+     */
+    private $name;
+
+    /**
+     * @var UnionType
+     * The return type of the magic method
+     */
+    private $type;
+
+    /**
+     * @var Parameter[]
+     * A list of phpdoc parameters
+     */
+    private $parameters;
+
+    /**
+     * @var bool
+     * Whether or not this is a static magic method
+     */
+    private $is_static;
+
+    /**
+     * @param string $name
+     * The name of the method
+     *
+     * @param UnionType $type
+     * The return type of the method
+     *
+     * @param Parameter[] $parameters
+     * 0 or more comment parameters for this magic method
+     *
+     * @param bool $is_static
+     * Whether this method is static
+     */
+    public function __construct(
+        string $name,
+        UnionType $type,
+        array $parameters,
+        bool $is_static
+    ) {
+        $this->name = $name;
+        $this->type = $type;
+        $this->parameters = $parameters;
+        $this->is_static = $is_static;
+    }
+
+    /**
+     * @return string
+     * The name of the magic method
+     */
+    public function getName() : string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return UnionType
+     * The return type of the magic method
+     */
+    public function getUnionType() : UnionType
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return Parameter[] - comment parameters of magic method, from phpdoc.
+     */
+    public function getParameterList() : array
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * @return bool
+     * Whether or not the magic method is static
+     */
+    public function isStatic() : bool
+    {
+        return $this->is_static;
+    }
+
+    /**
+     * @return int
+     * Number of required parameters of this method
+     */
+    public function getNumberOfRequiredParameters() : int
+    {
+        return array_reduce(
+            $this->parameters,
+            function (int $carry, Parameter $parameter) : int {
+                return ($carry + ($parameter->isRequired() ? 1 : 0));
+            }, 0);
+    }
+
+    /**
+     * @return int
+     * Number of optional parameters of this method
+     */
+    public function getNumberOfOptionalParameters() : int
+    {
+        return array_reduce(
+            $this->parameters,
+            function (int $carry, Parameter $parameter) : int {
+                return ($carry + ($parameter->isOptional() ? 1 : 0));
+            }, 0);
+    }
+
+    public function __toString() : string
+    {
+        $string = 'function ';
+        // Magic methods can't be by ref?
+        $string .= $this->getName();
+
+        $string .= '(' . implode(', ', $this->getParameterList()) . ')';
+
+        if (!$this->getUnionType()->isEmpty()) {
+            $string .= ' : ' . (string)$this->getUnionType();
+        }
+
+        return $string;
+    }
+}

--- a/src/Phan/Language/Element/Comment/Parameter.php
+++ b/src/Phan/Language/Element/Comment/Parameter.php
@@ -28,6 +28,12 @@ class Parameter
     private $is_variadic;
 
     /**
+     * @var bool
+     * Whether or not the parameter is optional (Note: only applies to the comment for (at)method.
+     */
+    private $has_default_value;
+
+    /**
      * @param string $name
      * The name of the parameter
      *
@@ -37,11 +43,13 @@ class Parameter
     public function __construct(
         string $name,
         UnionType $type,
-        bool $is_variadic = false
+        bool $is_variadic = false,
+        bool $has_default_value = false
     ) {
         $this->name = $name;
         $this->type = $type;
         $this->is_variadic = $is_variadic;
+        $this->has_default_value = $has_default_value;
     }
 
     /**
@@ -58,6 +66,33 @@ class Parameter
             $this->getUnionType(),
             $flags
         );
+    }
+
+    /**
+     *
+     */
+    public function asRealParameter(
+        Context $context
+    ) : \Phan\Language\Element\Parameter
+    {
+        $flags = 0;
+        if ($this->isVariadic()) {
+            $flags |= \ast\flags\PARAM_VARIADIC;
+        }
+        $union_type = $this->getUnionType();
+        $param = new \Phan\Language\Element\Parameter(
+            $context,
+            $this->getName(),
+            $union_type,
+            $flags
+        );
+        if ($this->has_default_value) {
+            $param->setDefaultValueType(clone($union_type));
+            // TODO: could setDefaultValue in a future PR. Would have to run \ast\parse_code on the default value, catch ParseError if necessary.
+            // If given '= "Default"', then extract the default from '<?php ("Default");'
+            // Then get the type from UnionTypeVisitor, for defaults such as SomeClass::CONST.
+        }
+        return $param;
     }
 
     /**
@@ -87,6 +122,24 @@ class Parameter
         return $this->is_variadic;
     }
 
+    /**
+     * @return bool
+     * Whether or not the parameter is required
+     */
+    public function isRequired() : bool
+    {
+        return !$this->isOptional();
+    }
+
+    /**
+     * @return bool
+     * Whether or not the parameter is optional
+     */
+    public function isOptional() : bool
+    {
+        return $this->has_default_value || $this->is_variadic;
+    }
+
     public function __toString() : string
     {
         $string = '';
@@ -99,6 +152,10 @@ class Parameter
         }
 
         $string .= $this->name;
+
+        if ($this->has_default_value) {
+            $string .= ' = default';
+        }
 
         return $string;
     }

--- a/src/Phan/Language/Element/Flags.php
+++ b/src/Phan/Language/Element/Flags.php
@@ -16,6 +16,7 @@ class Flags
     const CLASS_HAS_DYNAMIC_PROPERTIES = (1 << 8);
     const IS_CLONE_OF_VARIADIC         = (1 << 9);
     const CLASS_FORBID_UNDECLARED_MAGIC_PROPERTIES = (1 << 10);
+    const CLASS_FORBID_UNDECLARED_MAGIC_METHODS    = (1 << 11);
 
     /**
      * Either enable or disable the given flag on

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -560,6 +560,20 @@ class UnionType implements \Serializable
         return $result;
     }
 
+    public function nullableClone() : UnionType
+    {
+        $result = new UnionType();
+        foreach ($this->getTypeSet() as $type) {
+            if ($type->getIsNullable()) {
+                $result->addType($type);
+                continue;
+            }
+
+            $result->addType($type->withIsNullable(true));
+        }
+        return $result;
+    }
+
     /**
      * @param UnionType $union_type
      * A union type to compare against

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -144,15 +144,27 @@ class ParseVisitor extends ScopeVisitor
 
         // Depends on code_base for checking existence of __get and __set.
         // TODO: Add a check in analyzeClasses phase that magic @property declarations
-        // are limited to classes with either __get or __set declared.
+        // are limited to classes with either __get or __set declared (or interface/abstract
         $class->setMagicPropertyMap(
             $comment->getMagicPropertyMap(),
             $this->code_base,
             $this->context
         );
 
+        // Depends on code_base for checking existence of __call or __callStatic.
+        // TODO: Add a check in analyzeClasses phase that magic @method declarations
+        // are limited to classes with either __get or __set declared (or interface/abstract)
+        $class->setMagicMethodMap(
+            $comment->getMagicMethodMap(),
+            $this->code_base,
+            $this->context
+        );
+
         // usually used together with magic @property annotations
         $class->setForbidUndeclaredMagicProperties($comment->getForbidUndeclaredMagicProperties());
+
+        // usually used together with magic @method annotations
+        $class->setForbidUndeclaredMagicMethods($comment->getForbidUndeclaredMagicMethods());
 
         // Look to see if we have a parent class
         if (!empty($node->children['extends'])) {

--- a/tests/files/expected/0281_magic_method_support.php.expected
+++ b/tests/files/expected/0281_magic_method_support.php.expected
@@ -4,15 +4,17 @@
 %s:39 PhanTypeMismatchArgument Argument 1 (x) is int but \expects_a281() takes \A281 defined at %s:28
 %s:43 PhanTypeMismatchArgument Argument 2 (b) is null but \A281::fooWithOptionalSecondParam() takes int defined at %s:17
 %s:44 PhanParamTooFew Call with 0 arg(s) to \A281::fooWithOptionalSecondParam() which requires 1 arg(s) defined at %s:17
-%s:49 PhanTypeMismatchArgument Argument 1 (x) is int but \A281::fooWithOptionalNullableParam() takes ?string defined at %s:17
-%s:51 PhanTypeMismatchArgument Argument 1 (x) is int but \expects_a281() takes \A281 defined at %s:28
-%s:54 PhanTypeMismatchArgument Argument 1 (x) is \A281 but \expects_int281() takes int defined at %s:31
-%s:57 PhanParamTooFew Call with 0 arg(s) to \A281::myMethodWithParams() which requires 1 arg(s) defined at %s:17
-%s:58 PhanTypeMismatchArgument Argument 1 (x) is string but \A281::myMethodWithParams() takes int defined at %s:17
-%s:61 PhanParamTooFew Call with 0 arg(s) to \A281::myMethodWithUntypedParams() which requires 1 arg(s) defined at %s:17
-%s:64 PhanTypeMismatchArgument Argument 1 (x) is string but \A281::myMethodWithPHPDocParams() takes float defined at %s:17
-%s:64 PhanTypeMismatchArgument Argument 2 (y) is null but \A281::myMethodWithPHPDocParams() takes object defined at %s:17
-%s:66 PhanTypeMismatchArgument Argument 4 (x) is float but \A281::myMethodWithVariadicParams() takes int|string defined at %s:17
-%s:68 PhanTypeMismatchArgument Argument 1 (x) is int|string but \expects_a281() takes \A281 defined at %s:28
-%s:73 PhanUndeclaredMethod Call to undeclared method \C281::undeclaredMagicMethod
-%s:74 PhanTypeVoidAssignment Cannot assign void return value
+%s:45 PhanStaticCallToNonStatic Static call to non-static method \A281::fooWithOptionalSecondParam() defined at %s:17
+%s:50 PhanTypeMismatchArgument Argument 1 (x) is int but \A281::fooWithOptionalNullableParam() takes ?string defined at %s:17
+%s:52 PhanTypeMismatchArgument Argument 1 (x) is int but \expects_a281() takes \A281 defined at %s:28
+%s:55 PhanTypeMismatchArgument Argument 1 (x) is \A281 but \expects_int281() takes int defined at %s:31
+%s:56 PhanParamTooMany Call with 1 arg(s) to \A281::static_foo_with_return_type_of_static() which only takes 0 arg(s) defined at %s:17
+%s:59 PhanParamTooFew Call with 0 arg(s) to \A281::myMethodWithParams() which requires 1 arg(s) defined at %s:17
+%s:60 PhanTypeMismatchArgument Argument 1 (x) is string but \A281::myMethodWithParams() takes int defined at %s:17
+%s:63 PhanParamTooFew Call with 0 arg(s) to \A281::myMethodWithUntypedParams() which requires 1 arg(s) defined at %s:17
+%s:66 PhanTypeMismatchArgument Argument 1 (x) is string but \A281::myMethodWithPHPDocParams() takes float defined at %s:17
+%s:66 PhanTypeMismatchArgument Argument 2 (y) is null but \A281::myMethodWithPHPDocParams() takes object defined at %s:17
+%s:68 PhanTypeMismatchArgument Argument 4 (x) is float but \A281::myMethodWithVariadicParams() takes int|string defined at %s:17
+%s:70 PhanTypeMismatchArgument Argument 1 (x) is int|string but \expects_a281() takes \A281 defined at %s:28
+%s:75 PhanUndeclaredMethod Call to undeclared method \C281::undeclaredMagicMethod
+%s:76 PhanTypeVoidAssignment Cannot assign void return value

--- a/tests/files/expected/0281_magic_method_support.php.expected
+++ b/tests/files/expected/0281_magic_method_support.php.expected
@@ -1,0 +1,18 @@
+%s:35 PhanUndeclaredMethod Call to undeclared method \A281::undeclaredMagicMethod
+%s:36 PhanTypeVoidAssignment Cannot assign void return value
+%s:38 PhanParamTooMany Call with 1 arg(s) to \A281::fooWithReturnType() which only takes 0 arg(s) defined at %s:17
+%s:39 PhanTypeMismatchArgument Argument 1 (x) is int but \expects_a281() takes \A281 defined at %s:28
+%s:43 PhanTypeMismatchArgument Argument 2 (b) is null but \A281::fooWithOptionalSecondParam() takes int defined at %s:17
+%s:44 PhanParamTooFew Call with 0 arg(s) to \A281::fooWithOptionalSecondParam() which requires 1 arg(s) defined at %s:17
+%s:49 PhanTypeMismatchArgument Argument 1 (x) is int but \A281::fooWithOptionalNullableParam() takes ?string defined at %s:17
+%s:51 PhanTypeMismatchArgument Argument 1 (x) is int but \expects_a281() takes \A281 defined at %s:28
+%s:54 PhanTypeMismatchArgument Argument 1 (x) is \A281 but \expects_int281() takes int defined at %s:31
+%s:57 PhanParamTooFew Call with 0 arg(s) to \A281::myMethodWithParams() which requires 1 arg(s) defined at %s:17
+%s:58 PhanTypeMismatchArgument Argument 1 (x) is string but \A281::myMethodWithParams() takes int defined at %s:17
+%s:61 PhanParamTooFew Call with 0 arg(s) to \A281::myMethodWithUntypedParams() which requires 1 arg(s) defined at %s:17
+%s:64 PhanTypeMismatchArgument Argument 1 (x) is string but \A281::myMethodWithPHPDocParams() takes float defined at %s:17
+%s:64 PhanTypeMismatchArgument Argument 2 (y) is null but \A281::myMethodWithPHPDocParams() takes object defined at %s:17
+%s:66 PhanTypeMismatchArgument Argument 4 (x) is float but \A281::myMethodWithVariadicParams() takes int|string defined at %s:17
+%s:68 PhanTypeMismatchArgument Argument 1 (x) is int|string but \expects_a281() takes \A281 defined at %s:28
+%s:73 PhanUndeclaredMethod Call to undeclared method \C281::undeclaredMagicMethod
+%s:74 PhanTypeVoidAssignment Cannot assign void return value

--- a/tests/files/expected/0282_forbid_undeclared_magic_methods.php.expected
+++ b/tests/files/expected/0282_forbid_undeclared_magic_methods.php.expected
@@ -1,0 +1,7 @@
+%s:27 PhanTypeMismatchArgument Argument 1 (arg) is string but \Magic282::instanceMethod() takes ?int defined at %s:8
+%s:28 PhanUndeclaredMethod Call to undeclared method \Magic282::missingMethod
+%s:29 PhanParamTooFew Call with 0 arg(s) to \Magic282::instanceMethod() which requires 1 arg(s) defined at %s:8
+%s:30 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is array but \intdiv() takes int
+%s:32 PhanTypeMismatchArgument Argument 1 (arg) is int but \Magic282::static_method() takes string defined at %s:8
+%s:34 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
+%s:36 PhanUndeclaredStaticMethod Static call to undeclared method \Magic282::undeclared_magic_static_method

--- a/tests/files/src/0281_magic_method_support.php
+++ b/tests/files/src/0281_magic_method_support.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * @method foo() implicitly a void
+ * @method int fooWithReturnType()
+ * @method fooWithOptionalSecondParam(int, int $b=2) - Phan doesn't check if the default is valid, just for the presence
+ * @method fooWithOptionalNullableParam(string $x=  null  )This is a nullable string, the only time we check the default
+ * @method static static_foo()
+ * @method static int static_foo_with_return_type()
+ * @method static static static_foo_with_return_type_of_static()
+ * @method int myMethodWithParams(int $x)
+ * @method int myMethodWithUntypedParams($x)
+ * @method int myMethodWithPHPDocParams(double $x, object $y)
+ * @method int|string myMethodWithVariadicParams(int $a, int|string   ... $x )
+ * @method int|string myMethodWithVariadicParams(int $a, int|string   ... $x )
+ */
+interface A281 {
+
+}
+
+/**
+ * @method foo() implicitly a void
+ */
+abstract class C281 {
+
+}
+
+function expects_a281(A281 $x) {
+}
+
+function expects_int281(int $x) {
+}
+
+function testA281(A281 $a) {
+    $a->undeclaredMagicMethod();  // should warn, this is undeclared
+    $b = $a->foo();  // should warn about using return value of void
+    expects_int281($a->fooWithReturnType());  // valid, no params
+    expects_int281($a->fooWithReturnType('extra param'));  // Too many params, should warn
+    expects_a281($a->fooWithReturnType());  // mismatch
+
+    $a->fooWithOptionalSecondParam(42); // valid
+    $a->fooWithOptionalSecondParam(42, 1); // valid
+    $a->fooWithOptionalSecondParam(42, null); // invalid
+    $a->fooWithOptionalSecondParam(); // invalid, expects 1 to 2 params.
+
+    $a->fooWithOptionalNullableParam('string'); // expects optional string
+    $a->fooWithOptionalNullableParam(null); // expects optional, nullable string
+    $a->fooWithOptionalNullableParam(); // expects optional, nullable string
+    $a->fooWithOptionalNullableParam(42); // invalid, doesn't expect int.
+
+    expects_a281(A281::static_foo_with_return_type());  // invalid, return type is int
+
+    expects_a281(A281::static_foo_with_return_type_of_static());  // valid, return types match
+    expects_int281(A281::static_foo_with_return_type_of_static());  // invalid, expects int but got object
+
+    expects_int281($a->myMethodWithParams(22));
+    $a->myMethodWithParams();  // invalid, not enough params
+    expects_int281($a->myMethodWithParams('string'));  // invalid, passed string instead of int.
+
+    $a->myMethodWithUntypedParams(new stdClass());
+    $a->myMethodWithUntypedParams();  // not enough
+
+    expects_int281($a->myMethodWithPHPDocParams(23.0, $a));  // right
+    expects_int281($a->myMethodWithPHPDocParams('str', null));  // wrong
+
+    $v = $a->myMethodWithVariadicParams(2, 'str', 2, 4.2);  // 4.2 is not valid, but int|string is.
+    expects_int281($v);
+    expects_a281($v);  // invalid, $v is int|string
+}
+
+// a quick check that support also works for abstract classes, not just interfaces
+function testC281(C281 $c) {
+    $c->undeclaredMagicMethod();  // should warn, this is undeclared
+    $d = $c->foo();  // should warn about using return value of void
+}

--- a/tests/files/src/0281_magic_method_support.php
+++ b/tests/files/src/0281_magic_method_support.php
@@ -42,6 +42,7 @@ function testA281(A281 $a) {
     $a->fooWithOptionalSecondParam(42, 1); // valid
     $a->fooWithOptionalSecondParam(42, null); // invalid
     $a->fooWithOptionalSecondParam(); // invalid, expects 1 to 2 params.
+    $a::fooWithOptionalSecondParam(42); // invalid, calling an instance method statically.
 
     $a->fooWithOptionalNullableParam('string'); // expects optional string
     $a->fooWithOptionalNullableParam(null); // expects optional, nullable string
@@ -52,6 +53,7 @@ function testA281(A281 $a) {
 
     expects_a281(A281::static_foo_with_return_type_of_static());  // valid, return types match
     expects_int281(A281::static_foo_with_return_type_of_static());  // invalid, expects int but got object
+    $a->static_foo_with_return_type_of_static(42); // warn, calling a magic static method on an instance.
 
     expects_int281($a->myMethodWithParams(22));
     $a->myMethodWithParams();  // invalid, not enough params

--- a/tests/files/src/0282_forbid_undeclared_magic_methods.php
+++ b/tests/files/src/0282_forbid_undeclared_magic_methods.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @method array instanceMethod(?int $arg)
+ * @method static string static_method(string $arg)
+ * @phan-forbid-undeclared-magic-methods
+ */
+class Magic282 {
+    public function __call(string $name, array $args) {
+        if ($name == 'instanceMethod') {
+            return $args;
+        }
+        throw new RuntimeException("Bad instance method name");
+    }
+
+    public static function __callStatic(string $name, array $args) {
+        if ($name == 'static_method') {
+            return 'prefix' . $args[0];
+        }
+        throw new RuntimeException("Bad static method name");
+    }
+}
+
+function test282() {
+    $m = new Magic282();
+    $m->instanceMethod(null);  // valid
+    $m->instanceMethod("str");  // valid
+    $m->missingMethod();  // should warn, because of @phan-forbid-undeclared-magic-methods
+    $v = $m->instanceMethod();  // should warn
+    echo intdiv($v, 2);  // warn about passing array, expect int.
+
+    Magic282::static_method(22);  // should warn about wrong type
+    $s = Magic282::static_method('str');
+    echo intdiv($s, 2);  // warn about passing string, expect int
+    // Should warn about undeclared static methods because of @phan-forbid-undeclared-magic-methods
+    Magic282::undeclared_magic_static_method();
+}


### PR DESCRIPTION
Fixes issue #467

- Currently, Phan treats these magic methods identically to real methods
  (Except there's no body to analyze)
- magic method names are case insensitive right now.

Additionally, add "@phan-forbid-undeclared-magic-methods",
to warn in case a method is mistyped. (Not aware of an official equivalent)

- The new annotation affects the class/interfaces and things subclassing classes.
  In future PRs, this may also check Clazz->interface_fqsen_list.


This was parsed, but code changes (In places which allowed undeclared
methods if __call/__callStatic existed) weren't yet made.

Also, add a test for warning about static call to non static methods.

This PR doesn't bother checking if __call and __callStatic are declared
with any of these annotations.
The implementation assumes that they those methods have been declared
in the class (Or in subclasses of the class with the required magic methods),
and that the annotations are kept up to date.

- This is meant to make it as easy as possible to start using phan with
  frameworks such as phpunit mock objects, or laravel, etc,
  where interfaces or abstract classes declare magic methods.

This is implemented based off of https://github.com/etsy/phan/pull/593

This PR supports the following parts of
https://phpdoc.org/docs/latest/references/phpdoc/tags/method.html ,
as well as some undocumented parts that have been added to the
phpdocumentor2 codebase

- @method static [type], to declare a magic method as
- defaults: [paramType] [$paramName] = default
- noting nullability with defaults, via : T [$paramName] = null
  (Phan treats the type as ?T)
  (Not specific to phpdoc, but convenient)
- If Phan is unable to parse the magic method or the params,
  it will reject it silently.
  Future PRs may add a warning message for invalid comments.

TODO: in another PR, warn about calling static magic methods as instance
methods. They may only exist in __callStatic()