### PR TITLE
Rudimentary coloring support for the default (plain text) printer.

### DIFF
--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -64,6 +64,7 @@ class CLI
             "f:m:o:c:k:aeqbr:pid:3:y:l:xj:zh:v",
             [
                 'backward-compatibility-checks',
+                'color',
                 'dead-code-detection',
                 'directory:',
                 'dump-ast',
@@ -253,6 +254,9 @@ class CLI
                 case 'markdown-issue-messages':
                     Config::get()->markdown_issue_messages = true;
                     break;
+                case 'color':
+                    Config::get()->color_issue_messages = true;
+                    break;
                 default:
                     $this->usage("Unknown option '-$key'", EXIT_FAILURE);
                     break;
@@ -412,6 +416,9 @@ Usage: {$argv[0]} [options] [files...]
 
  -o, --output <filename>
   Output filename
+
+ --color
+  Add colors to the outputted issues. Tested for Unix, recommended for only the default --output-mode ('text')
 
  -p, --progress-bar
   Show progress bar

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -332,6 +332,18 @@ class Config
         // Emit issue messages with markdown formatting
         'markdown_issue_messages' => false,
 
+        // Emit colorized issue messages.
+        // NOTE: it is strongly recommended to enable this via the --color CLI flag instead,
+        // since this is incompatible with most output formatters.
+        'color_issue_messages' => false,
+
+        // Allow overriding color scheme in .phan/config.php for printing issues, for individual types.
+        // See the keys of Phan\Output\Colorizing::styles for valid color names,
+        // and the keys of Phan\Output\Colorizing::default_color_for_template for valid color names.
+        // E.g. to change the color for the file(of an issue instance) to red, set this to ['FILE' => 'red']
+        // E.g. to use the terminal's default color for the line(of an issue instance), set this to ['LINE' => 'none']
+        'color_scheme' => [],
+
         // Enable or disable support for generic templated
         // class types.
         'generic_types_enabled' => true,

--- a/src/Phan/Output/Colorizing.php
+++ b/src/Phan/Output/Colorizing.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Phan\Output;
+
+use Phan\Issue;
+use Phan\Config;
+
+// Colorizing codes are based on https://github.com/kevinlebrun/colors.php/
+class Colorizing {
+    const styles = [
+        'none'             => '0',  // Alias of 'reset'
+        'reset'            => '0',  // Use 'reset' for the absense of color.
+        'bold'             => '1',
+        'dark'             => '2',
+        'italic'           => '3',
+        'underline'        => '4',
+        'blink'            => '5',
+        'reverse'          => '7',
+        'concealed'        => '8',
+        'default'          => '39',
+        'black'            => '30',
+        'red'              => '31',
+        'green'            => '32',
+        'yellow'           => '33',
+        'blue'             => '34',
+        'magenta'          => '35',
+        'cyan'             => '36',
+        'light_gray'       => '37',
+        'dark_gray'        => '90',
+        'light_red'        => '91',
+        'light_green'      => '92',
+        'light_yellow'     => '93',
+        'light_blue'       => '94',
+        'light_magenta'    => '95',
+        'light_cyan'       => '96',
+        'white'            => '97',
+        'bg_default'       => '49',
+        'bg_black'         => '40',
+        'bg_red'           => '41',
+        'bg_green'         => '42',
+        'bg_yellow'        => '43',
+        'bg_blue'          => '44',
+        'bg_magenta'       => '45',
+        'bg_cyan'          => '46',
+        'bg_light_gray'    => '47',
+        'bg_dark_gray'     => '100',
+        'bg_light_red'     => '101',
+        'bg_light_green'   => '102',
+        'bg_light_yellow'  => '103',
+        'bg_light_blue'    => '104',
+        'bg_light_magenta' => '105',
+        'bg_light_cyan'    => '106',
+        'bg_white'         => '107',
+    ];
+
+    const esc_pattern = "\033[%sm";
+    const esc_reset = "\033[0m";
+
+    // NOTE: Keep sorted and in sync with Issue::uncolored_format_string_for_template
+    // In future PRs, it will be possible for users to add their own color schemes in .phan/config.php
+    const default_color_for_template = [
+        'CLASS'         => 'green',
+        'CONST'         => 'light_red',
+        'COUNT'         => 'light_magenta',
+        'FILE'          => 'light_cyan',
+        'FUNCTIONLIKE'  => 'light_yellow',
+        'FUNCTION'      => 'light_yellow',
+        'INDEX'         => 'light_magenta',
+        'INTERFACE'     => 'green',
+        'ISSUETYPE'     => 'light_yellow',  // used by Phan\Output\Printer, for minor issues
+        'ISSUETYPE_CRITICAL' => 'red',  // for critical issues, e.g. "PhanUndeclaredMethod"
+        'ISSUETYPE_NORMAL' => 'light_red',  // for normal issues
+        'LINE'          => 'light_gray',
+        'METHOD'        => 'light_yellow',
+        'PARAMETER'     => 'cyan',
+        'PROPERTY'      => 'cyan',
+        'TYPE'          => 'light_gray',
+        'TRAIT'         => 'green',
+        'VARIABLE'      => 'light_cyan',
+    ];
+
+    /**
+     * @var array|null - Lazily initialized from Config
+     */
+    private static $color_scheme = null;
+
+    /**
+     * @param string $template
+     * @param int[]|string[] $template_parameters
+     * @param int $severity (Issue::SEVERITY_*)
+     */
+    public static function colorizeTemplate(
+        string $template,
+        array $template_parameters
+    ) : string {
+        $i = 0;
+        /** @param string[] $matches */
+        return preg_replace_callback('/{([A-Z_]+)}|%[sdf]/', function(array $matches) use ($template, $template_parameters, &$i) : string {
+            $j = $i++;
+            if ($j >= count($template_parameters)) {
+                error_log("Missing argument for colorized output ($template), offset $j");
+                return '(MISSING)';
+            }
+            $arg = $template_parameters[$j];
+            $format_str = $matches[0];
+            if ($format_str[0] === '%') {
+                return sprintf($format_str, $arg);
+            }
+            $template = $matches[1];
+            return self::colorizeField($template, $arg);
+        }, $template);
+    }
+
+    /**
+     * @param string $template_type (A key of _uncolored_format_string_for_template, e.g. "FILE")
+     * @param int|string $arg (Argument for format string, e.g. a type name, method fqsen, line number, etc.)
+     * @return string - Colorized for unix terminals.
+     */
+    public static function colorizeField(string $template_type, $arg) : string {
+        $fmt_directive = Issue::uncolored_format_string_for_template[$template_type] ?? null;
+        if ($fmt_directive === null) {
+            error_log("Unknown template type '$template_type'");
+        }
+        // TODO: Add more complicated color coding, e.g. MyClass::method should have the option for multiple colors.
+        // TODO: Allow choosing color schemes via .phan/config.php
+        $arg_str = sprintf($fmt_directive, (string)$arg);
+        $color = self::colorForTemplate($template_type);
+        if ($color === null) {
+            error_log("No color information for template type $template_type");
+            return $arg_str;
+        }
+        // TODO: Could extend this to support background colors.
+        $color_code = self::styles[$color] ?? null;
+        if ($color_code === null) {
+            error_log("Invalid color name ($color) for template type $template_type");
+            return $arg_str;
+        }
+        if ($color_code == '0') {
+            return $arg_str;
+        }
+        return sprintf(self::esc_pattern, $color_code) . ((string) $arg) . self::esc_reset;
+    }
+
+    /**
+     * @return ?string - null if there is no valid color
+     */
+    private static function colorForTemplate(string $template_type) {
+        if (self::$color_scheme === null) {
+            self::initColorScheme();
+        }
+        return self::$color_scheme[$template_type] ?? null;
+    }
+
+    /**
+     * Initialize the color scheme, merging it with Config::color_scheme
+     */
+    private static function initColorScheme() {
+        self::$color_scheme = self::default_color_for_template;
+        foreach (Config::get()->color_scheme ?? [] as $template_type => $color_name) {
+            if (!is_scalar($color_name) || !array_key_exists($color_name, self::styles)) {
+                error_log("Invalid color name ($color_name)");
+                continue;
+            }
+            if (!array_key_exists($template_type, Colorizing::default_color_for_template)) {
+                error_log("Unknown template_type ($template_type)");
+                continue;
+            }
+            self::$color_scheme[$template_type] = $color_name;
+        }
+    }
+}

--- a/src/Phan/Output/Printer/PlainTextPrinter.php
+++ b/src/Phan/Output/Printer/PlainTextPrinter.php
@@ -1,8 +1,11 @@
 <?php declare(strict_types = 1);
 namespace Phan\Output\Printer;
 
+use Phan\Config;
+use Phan\Issue;
 use Phan\IssueInstance;
 use Phan\Output\IssuePrinterInterface;
+use Phan\Output\Colorizing;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class PlainTextPrinter implements IssuePrinterInterface
@@ -11,22 +14,51 @@ final class PlainTextPrinter implements IssuePrinterInterface
     /** @var OutputInterface */
     private $output;
 
-    /** @param IssueInstance $instance */
+    /**
+     * @param IssueInstance $instance
+     * @return void
+     */
     public function print(IssueInstance $instance)
     {
-        $issue = sprintf(
-            '%s:%d %s %s',
-            $instance->getFile(),
-            $instance->getLine(),
-            $instance->getIssue()->getType(),
-            $instance->getMessage()
-        );
+        $file    = $instance->getFile();
+        $line    = $instance->getLine();
+        $issue   = $instance->getIssue();
+        $type    = $issue->getType();
+        $message = $instance->getMessage();
+        if (Config::get()->color_issue_messages) {
+            switch($issue->getSeverity()) {
+            case Issue::SEVERITY_CRITICAL:
+                $issue_type_template = '{ISSUETYPE_CRITICAL}';
+                break;
+            case Issue::SEVERITY_NORMAL:
+                $issue_type_template = '{ISSUETYPE_NORMAL}';
+                break;
+            default:
+                $issue_type_template = '{ISSUETYPE}';
+                break;
+            }
+            $issue = Colorizing::colorizeTemplate("{FILE}:{LINE} $issue_type_template %s", [
+                $instance->getFile(),
+                $instance->getLine(),
+                $instance->getIssue()->getType(),
+                $instance->getMessage(),
+            ]);
+        } else {
+            $issue = sprintf(
+                '%s:%d %s %s',
+                $instance->getFile(),
+                $instance->getLine(),
+                $instance->getIssue()->getType(),
+                $instance->getMessage()
+            );
+        }
 
         $this->output->writeln($issue);
     }
 
     /**
      * @param OutputInterface $output
+     * @return void
      */
     public function configureOutput(OutputInterface $output)
     {


### PR DESCRIPTION
To use it, invoke phan with `--color`.
These colors are arbitrary, I couldn't think of a well known color scheme to
imitate for this.

For Issue #160.
The message would be colorized for other printers, which is usually
undesirable, but not bothering to check that (e.g. in xml).

Choose color based on issue severity (Red for severe, pink/orange for normal,
yellow for minor)

- Bold/italic with the same color might make more sense

Further work

- color based on regex for constant names, etc.
  (E.g. multiple colors for the class and constant of `\A::constname`)
- 32-bit color, if supported by the terminal
- Allow multiple directives, e.g. to set the background color.
- (This assumes a dark terminal background.
  Adding --dark-colorscheme in the future will be useful)
- Migrate the plugins in `.phan/plugins` to include coloring info.
  They will continue to work, these directives (`{FILE}`) can be mixed with `%s` and `%d` without losing positions.
- less common format string directives (e.g. `'%2$s'` for second argument as a string) don't currently work, but could be fixed if needed.
The below image is example output in a terminal with a dark background)
(Note: copied files from tests folder, and some of those had duplicate class names across files, which a regular phan run wouldn't handle)
![phan_colorized_output](https://cloud.githubusercontent.com/assets/1904430/24835543/e2cc79d6-1cb9-11e7-89b1-4f2e8adffd86.png)
