### PR TITLE
Add an option to exclude files by a regular expression

### DIFF
--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -503,6 +503,7 @@ EOB;
                 );
             }
 
+            $exclude_file_regex = Config::get()->exclude_file_regex;
             $iterator = new \CallbackFilterIterator(
                 new \RecursiveIteratorIterator(
                     new \RecursiveDirectoryIterator(
@@ -510,7 +511,7 @@ EOB;
                         \RecursiveDirectoryIterator::FOLLOW_SYMLINKS
                     )
                 ),
-                function(\SplFileInfo $file_info) use ($file_extensions) {
+                function(\SplFileInfo $file_info) use ($file_extensions, $exclude_file_regex) {
                     if (!in_array($file_info->getExtension(), $file_extensions, true)) {
                         return false;
                     }
@@ -518,6 +519,10 @@ EOB;
                     if (!$file_info->isFile() || !$file_info->isReadable()) {
                         $file_path = $file_info->getRealPath();
                         error_log("Unable to read file {$file_path}");
+                        return false;
+                    }
+
+                    if ($exclude_file_regex && preg_match($exclude_file_regex,$file_info->getBasename())) {
                         return false;
                     }
 

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -511,18 +511,20 @@ EOB;
                     )
                 ),
                 function(\SplFileInfo $file_info) use ($file_extensions) {
-                    return in_array($file_info->getExtension(), $file_extensions, true);
+                    if (!in_array($file_info->getExtension(), $file_extensions, true)) {
+                        return false;
+                    }
+
+                    if (!$file_info->isFile() || !$file_info->isReadable()) {
+                        error_log("Unable to read file {$file_info->getRealPath()}");
+                        return false;
+                    }
+
+                    return true;
                 }
             );
 
-            foreach (array_keys(iterator_to_array($iterator)) as $file_name) {
-                $file_path = Config::projectPath($file_name);
-                if (is_file($file_path) && is_readable($file_path)) {
-                    $file_list[] = $file_name;
-                } else {
-                    error_log("Unable to read file $file_path");
-                }
-            }
+            $file_list = array_keys(iterator_to_array($iterator));
         } catch (\Exception $exception) {
             error_log($exception->getMessage());
         }

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -497,25 +497,22 @@ EOB;
         try {
             $file_extensions = Config::get()->analyzed_file_extensions;
 
-            if (!is_array($file_extensions) || count($file_extensions) == 0) {
+            if (!is_array($file_extensions) || count($file_extensions) === 0) {
                 throw new \InvalidArgumentException(
                     'Empty list in config analyzed_file_extensions. Nothing to analyze.'
                 );
             }
 
-            $extension_regex = implode('|', array_map(function ($extension) {
-                return preg_quote($extension, '/');
-            }, $file_extensions));
-
-            $iterator = new \RegexIterator(
+            $iterator = new \CallbackFilterIterator(
                 new \RecursiveIteratorIterator(
                     new \RecursiveDirectoryIterator(
                         $directory_name,
                         \RecursiveDirectoryIterator::FOLLOW_SYMLINKS
                     )
                 ),
-                '/^.+\.(' . $extension_regex . ')$/i',
-                \RecursiveRegexIterator::GET_MATCH
+                function(\SplFileInfo $file_info) use ($file_extensions) {
+                    return in_array($file_info->getExtension(), $file_extensions, true);
+                }
             );
 
             foreach (array_keys(iterator_to_array($iterator)) as $file_name) {

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -516,7 +516,8 @@ EOB;
                     }
 
                     if (!$file_info->isFile() || !$file_info->isReadable()) {
-                        error_log("Unable to read file {$file_info->getRealPath()}");
+                        $file_path = $file_info->getRealPath();
+                        error_log("Unable to read file {$file_path}");
                         return false;
                     }
 

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -39,6 +39,10 @@ class Config
         // (e.g. php, html, htm)
         'analyzed_file_extensions' => ['php'],
 
+        // A regular expression to filter out files with matching filenames.
+        // (e.g. '/Test\.php$/')
+        'exclude_file_regex' => '',
+
         // A file list that defines files that will be excluded
         // from parsing and analysis and will not be read at all.
         //


### PR DESCRIPTION
First I implemented exclusion by suffix (to address #635). But then I decided to make file filtering a lot more flexible, and added an option to filter by a regular expression.

Tests are still passing. Didn't notice any changes to performance in my local ad-hoc testing.

P.S. My previous commits are showing up in this PR, even though they have been already merged. Not sure what causes that or how to avoid them showing up here. If this is a problem, I'll create a new fork and submit a new pull request.