### PR TITLE
Change -h option so it doesn't require value

### DIFF
--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -61,7 +61,7 @@ class CLI
         // Parse command line args
         // still available: g,n,t,u,w
         $opts = getopt(
-            "f:m:o:c:k:aeqbr:pid:3:y:l:xj:zh:v",
+            "f:m:o:c:k:aeqbr:pid:3:y:l:xj:zhv",
             [
                 'backward-compatibility-checks',
                 'color',


### PR DESCRIPTION
`phan -h` was previously returning an error at the top of its output, even though functionally it would still give the usage output.