### PR TITLE
Moving TypedElement::isInternal to TypedElement::isPHPInternal

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1273,7 +1273,7 @@ class UnionTypeVisitor extends AnalysisVisitor
         // TODO: I don't believe we need this any more
         // If this is an internal function, see if we can get
         // its types from the static dataset.
-        if ($function->isInternal()
+        if ($function->isPHPInternal()
             && $function->getUnionType()->isEmpty()
         ) {
             $map = UnionType::internalFunctionSignatureMapForFQSEN(

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -191,7 +191,7 @@ class Analysis
         {
             if ($show_progress) { CLI::progress('method', (++$i)/$function_count); }
 
-            if ($function_or_method->isInternal()) {
+            if ($function_or_method->isPHPInternal()) {
                 continue;
             }
 

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -46,7 +46,7 @@ class ArgumentType
     ) {
         // Special common cases where we want slightly
         // better multi-signature error messages
-        if ($method->isInternal()) {
+        if ($method->isPHPInternal()) {
             if(self::analyzeInternalArgumentType(
                 $method,
                 $node,
@@ -116,7 +116,7 @@ class ArgumentType
             }
 
             if (!$alternate_found) {
-                if ($method->isInternal()) {
+                if ($method->isPHPInternal()) {
                     Issue::maybeEmit(
                         $code_base,
                         $context,
@@ -156,7 +156,7 @@ class ArgumentType
 
             if (!$alternate_found) {
                 $max = $method->getNumberOfParameters();
-                if ($method->isInternal()) {
+                if ($method->isPHPInternal()) {
                     Issue::maybeEmit(
                         $code_base,
                         $context,
@@ -325,7 +325,7 @@ class ArgumentType
 
                 if (is_object($parameter_type) && $parameter_type->hasTemplateType()) {
                     // Don't worry about template types
-                } elseif ($method->isInternal()) {
+                } elseif ($method->isPHPInternal()) {
                     // If we are not in strict mode and we accept a string parameter
                     // and the argument we are passing has a __toString method then it is ok
                     if(!$context->getIsStrictTypes() && is_object($parameter_type) && $parameter_type->hasType(StringType::instance(false))) {

--- a/src/Phan/Analysis/DuplicateClassAnalyzer.php
+++ b/src/Phan/Analysis/DuplicateClassAnalyzer.php
@@ -37,7 +37,7 @@ class DuplicateClassAnalyzer
 
         // Check to see if the original definition was from
         // an internal class
-        if ($original_class->isInternal()) {
+        if ($original_class->isPHPInternal()) {
             Issue::maybeEmit(
                 $code_base,
                 $clazz->getContext(),

--- a/src/Phan/Analysis/DuplicateFunctionAnalyzer.php
+++ b/src/Phan/Analysis/DuplicateFunctionAnalyzer.php
@@ -47,7 +47,7 @@ class DuplicateFunctionAnalyzer
         $method_name = $method->getName();
 
         if (!$method->hasSuppressIssue(Issue::RedefineFunction)) {
-            if ($original_method->isInternal()) {
+            if ($original_method->isPHPInternal()) {
                 Issue::maybeEmit(
                     $code_base,
                     $method->getContext(),

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -261,7 +261,7 @@ class ParameterTypesAnalyzer
         }
 
         if (!$signatures_match) {
-            if ($o_method->isInternal()) {
+            if ($o_method->isPHPInternal()) {
                 Issue::maybeEmit(
                     $code_base,
                     $method->getContext(),
@@ -288,7 +288,7 @@ class ParameterTypesAnalyzer
         if ($o_method->isProtected() && $method->isPrivate()
             || $o_method->isPublic() && !$method->isPublic()
         ) {
-            if ($o_method->isInternal()) {
+            if ($o_method->isPHPInternal()) {
                 Issue::maybeEmit(
                     $code_base,
                     $method->getContext(),

--- a/src/Phan/Analysis/ParentClassExistsAnalyzer.php
+++ b/src/Phan/Analysis/ParentClassExistsAnalyzer.php
@@ -21,7 +21,7 @@ class ParentClassExistsAnalyzer
     ) {
 
         // Don't worry about internal classes
-        if ($clazz->isInternal()) {
+        if ($clazz->isPHPInternal()) {
             return;
         }
 

--- a/src/Phan/Analysis/ParentConstructorCalledAnalyzer.php
+++ b/src/Phan/Analysis/ParentConstructorCalledAnalyzer.php
@@ -29,7 +29,7 @@ class ParentConstructorCalledAnalyzer
         }
 
         // Don't worry about internal classes
-        if ($clazz->isInternal()) {
+        if ($clazz->isPHPInternal()) {
             return;
         }
 

--- a/src/Phan/Analysis/ReferenceCountsAnalyzer.php
+++ b/src/Phan/Analysis/ReferenceCountsAnalyzer.php
@@ -150,7 +150,7 @@ class ReferenceCountsAnalyzer
     ) {
 
         // Don't worry about internal elements
-        if ($element->isInternal()) {
+        if ($element->isPHPInternal()) {
             return;
         }
 

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -368,7 +368,7 @@ class CodeBase
     public function exportFunctionAndMethodSet() : array {
         $result = [];
         foreach ($this->func_and_method_set as $function_or_method) {
-            if ($function_or_method->isInternal()) {
+            if ($function_or_method->isPHPInternal()) {
                 continue;
             }
             $fqsen = $function_or_method->getFQSEN();

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -1817,7 +1817,7 @@ class Clazz extends AddressableElement
      */
     public final function analyze(CodeBase $code_base)
     {
-        if ($this->isInternal()) {
+        if ($this->isPHPInternal()) {
             return;
         }
 

--- a/src/Phan/Language/Element/Flags.php
+++ b/src/Phan/Language/Element/Flags.php
@@ -4,7 +4,7 @@ namespace Phan\Language\Element;
 class Flags
 {
     const IS_DEPRECATED                = (1 << 1);
-    const IS_INTERNAL                  = (1 << 2);
+    const IS_PHP_INTERNAL              = (1 << 2);
 
     const IS_PARENT_CONSTRUCTOR_CALLED = (1 << 3);
 

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -258,7 +258,7 @@ trait FunctionTrait {
         FunctionInterface $function,
         Comment $comment
     ) {
-        if ($function->isInternal()) {
+        if ($function->isPHPInternal()) {
             return;
         }
         $parameter_offset = 0;

--- a/src/Phan/Language/Element/PassByReferenceVariable.php
+++ b/src/Phan/Language/Element/PassByReferenceVariable.php
@@ -93,8 +93,8 @@ class PassByReferenceVariable extends Variable
         $this->element->setIsDeprecated($is_deprecated);
     }
 
-    public function isInternal() : bool
+    public function isPHPInternal() : bool
     {
-        return $this->element->isInternal();
+        return $this->element->isPHPInternal();
     }
 }

--- a/src/Phan/Language/Element/TypedElement.php
+++ b/src/Phan/Language/Element/TypedElement.php
@@ -81,7 +81,7 @@ abstract class TypedElement implements TypedElementInterface
         $this->name = $name;
         $this->type = $type;
         $this->flags = $flags;
-        $this->setIsInternal($context->isInternal());
+        $this->setIsInternal($context->isPHPInternal());
     }
 
     /**
@@ -267,7 +267,7 @@ abstract class TypedElement implements TypedElementInterface
      * @return bool
      * True if this was an internal PHP object
      */
-    public function isInternal() : bool
+    public function isPHPInternal() : bool
     {
         return Flags::bitVectorHasState(
             $this->getPhanFlags(),

--- a/src/Phan/Language/Element/TypedElement.php
+++ b/src/Phan/Language/Element/TypedElement.php
@@ -81,7 +81,7 @@ abstract class TypedElement implements TypedElementInterface
         $this->name = $name;
         $this->type = $type;
         $this->flags = $flags;
-        $this->setIsInternal($context->isPHPInternal());
+        $this->setIsPHPInternal($context->isPHPInternal());
     }
 
     /**
@@ -271,19 +271,19 @@ abstract class TypedElement implements TypedElementInterface
     {
         return Flags::bitVectorHasState(
             $this->getPhanFlags(),
-            Flags::IS_INTERNAL
+            Flags::IS_PHP_INTERNAL
         );
     }
 
     /**
      * @return void
      */
-    private function setIsInternal(bool $is_internal)
+    private function setIsPHPInternal(bool $is_internal)
     {
         $this->setPhanFlags(
             Flags::bitVectorWithState(
                 $this->getPhanFlags(),
-                Flags::IS_INTERNAL,
+                Flags::IS_PHP_INTERNAL,
                 $is_internal
             )
         );

--- a/src/Phan/Language/Element/TypedElementInterface.php
+++ b/src/Phan/Language/Element/TypedElementInterface.php
@@ -78,7 +78,7 @@ interface TypedElementInterface
      * @return bool
      * True if this was an internal PHP object
      */
-    public function isInternal() : bool;
+    public function isPHPInternal() : bool;
 
     /**
      * This method must be called before analysis

--- a/src/Phan/Language/FileRef.php
+++ b/src/Phan/Language/FileRef.php
@@ -80,7 +80,7 @@ class FileRef implements \Serializable
      * @return bool
      * True if this object is internal to PHP
      */
-    public function isInternal() : bool
+    public function isPHPInternal() : bool
     {
         return ('internal' === $this->getFile());
     }

--- a/src/Phan/Ordering.php
+++ b/src/Phan/Ordering.php
@@ -76,7 +76,7 @@ class Ordering
         foreach ($this->code_base->getClassMap() as $fqsen => $class) {
 
             // We won't be analyzing internal stuff
-            if ($class->isInternal()) {
+            if ($class->isPHPInternal()) {
                 continue;
             }
 


### PR DESCRIPTION
This patch just moves `TypedElement::isInternal` to `TypedElement::isPHPInternal` in preparation for possibly introducing the idea of internal elements (https://github.com/etsy/phan/issues/353).