### PR TITLE
Fix new false positives that showed up when `?mixed` was inferred for null param default

### DIFF
--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -389,8 +389,10 @@ trait FunctionTrait {
                 // and only allowable type.
                 $wasEmpty = $parameter->getUnionType()->isEmpty();
                 if ($wasEmpty) {
+                    // TODO: Errors on usage of ?mixed are poorly defined and greatly differ from phan's old behavior.
+                    // Consider passing $defaultIsNull once this is fixed.
                     $parameter->addUnionType(
-                        MixedType::instance($defaultIsNull)->asUnionType()
+                        MixedType::instance(false)->asUnionType()
                     );
                 }
 

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1065,6 +1065,9 @@ class Type
         if ($this === $type) {
             return true;
         }
+        if ($type instanceof MixedType) {
+            return true;
+        }
 
         // A nullable type cannot cast to a non-nullable type
         if ($this->getIsNullable() && !$type->getIsNullable()) {
@@ -1105,6 +1108,9 @@ class Type
             return true;
         }
 
+        if ($type instanceof MixedType) {
+            return true;
+        }
         // A matrix of allowable type conversions
         static $matrix = [
             '\Traversable' => [

--- a/src/Phan/Language/Type/MixedType.php
+++ b/src/Phan/Language/Type/MixedType.php
@@ -1,7 +1,21 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
+use Phan\Language\Type;
+
 class MixedType extends NativeType
 {
     const NAME = 'mixed';
+
+    // mixed or ?mixed can cast to/from anything.
+    // For purposes of analysis, there's no difference between mixed and nullable mixed.
+    public function canCastToType(Type $type) : bool {
+        return true;
+    }
+
+    // mixed or ?mixed can cast to/from anything.
+    // For purposes of analysis, there's no difference between mixed and nullable mixed.
+    protected function canCastToNonNullableType(Type $type) : bool {
+        return true;
+    }
 }

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -60,6 +60,13 @@ abstract class NativeType extends Type
      */
     protected function canCastToNonNullableType(Type $type) : bool
     {
+        // Anything can cast to mixed or ?mixed
+        // Not much of a distinction in nullable mixed, except to emphasize in comments that it definitely can be null.
+        // MixedType overrides the canCastTo*Type methods to always return true.
+        if ($type instanceof MixedType) {
+            return true;
+        }
+
         if (!($type instanceof NativeType)
             || $this instanceof GenericArrayType
             || $type instanceof GenericArrayType

--- a/tests/files/expected/0124_override_signature.php.expected
+++ b/tests/files/expected/0124_override_signature.php.expected
@@ -18,5 +18,5 @@
 %s:67 PhanParamSignatureRealMismatch Declaration of function k(&$a) should be compatible with function k($a) defined in %s:62
 %s:68 PhanParamSignatureMismatch Declaration of function l($b) should be compatible with function l(&$b) defined in %s:63
 %s:68 PhanParamSignatureRealMismatch Declaration of function l($b) should be compatible with function l(&$b) defined in %s:63
-%s:76 PhanParamSignatureMismatch Declaration of function m($a) should be compatible with function m(?mixed $a = null) defined in %s:72
+%s:76 PhanParamSignatureMismatch Declaration of function m($a) should be compatible with function m(mixed $a = null) defined in %s:72
 %s:76 PhanParamSignatureRealMismatch Declaration of function m($a) should be compatible with function m($a = null) defined in %s:72


### PR DESCRIPTION
Keep using `mixed`.  Start working on casting rules for `?mixed` - It's the same as mixed.

Update unit test expectation (?mixed -> mixed in error message)

Fixes #667