### PR TITLE
Fix for uncaught exception converting generic array type to/from nullable

### DIFF
--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -17,9 +17,9 @@ class GenericArrayType extends ArrayType
      * @param Type $type
      * The type of every element in this array
      */
-    protected function __construct(Type $type)
+    protected function __construct(Type $type, bool $is_nullable)
     {
-        parent::__construct('\\', self::NAME, [], false);
+        parent::__construct('\\', self::NAME, [], $is_nullable);
         $this->element_type = $type;
     }
 
@@ -71,7 +71,7 @@ class GenericArrayType extends ArrayType
         if (!$canonical_object_map->contains($type)) {
             $canonical_object_map->attach(
                 $type,
-                new GenericArrayType($type)
+                new GenericArrayType($type, false)
             );
         }
 
@@ -102,5 +102,24 @@ class GenericArrayType extends ArrayType
         }
 
         return $string;
+    }
+
+    /**
+     * @param bool $is_nullable
+     * Set to true if the type should be nullable, else pass
+     * false
+     *
+     * @return Type
+     * A new type that is a copy of this type but with the
+     * given nullability value.
+     */
+    public function withIsNullable(bool $is_nullable) : Type
+    {
+        if ($this->is_nullable === $is_nullable) {
+            return $this;
+        }
+        // FIXME: fully implement follow up for https://github.com/etsy/phan/issues/665
+        // Resolve the ambiguity of (?string)[] vs ?(string[]) in __toString()
+        return new static($this->element_type, $is_nullable);
     }
 }

--- a/tests/files/expected/0284_crash.php.expected
+++ b/tests/files/expected/0284_crash.php.expected
@@ -1,0 +1,2 @@
+%s:7 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is int[] but \intdiv() takes int
+%s:9 PhanTypeMismatchArgument Argument 1 (test) is null but \test() takes int[] defined at %s:6

--- a/tests/files/src/0284_crash.php
+++ b/tests/files/src/0284_crash.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @param int[] $test
+ */
+function test284($test=[1]) {
+    echo intdiv($test, 2);  // Should emit an error
+}
+test284(null);  // unrelated
+
+/**
+ * @param int[] $test
+ */
+function test284B($test = null) {
+    echo intdiv($test, 2);
+}


### PR DESCRIPTION
The generic array was converted to nullable when checking the types of parameter defaults for the nullable version of a generic array.
Currently, phan parses `?string[]` as `(?string)[]`, which seems fine.

For https://github.com/etsy/phan/issues/665

The issue is that `new static(namespace, name, ...)` in Type::make (Called because of withIsNullable()) would end up invoking GenericArrayType::__construct(Type $inner), throwing a PHP Error

- There are some issues to solve, e.g. whether or not the uncommon `?string[]` is a meaningful annotation. This is the easiest/fastest way to stop throwing an Error.

- Also, that seems to be ambiguous, since it could be interpreted as `(?string)[]` or `?(string[])`, and converting the type to/from string would suffer from that ambiguity.