### PR TITLE
Possible fix for #686

### DIFF
--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -457,6 +457,7 @@ class ArgumentType
      * @param CodeBase $code_base
      *
      * @return bool
+     * Return true if an issue was found, else false.
      *
      * @see \Phan\Deprecated\Pass2::arg_check
      * Formerly `function arg_check`
@@ -477,7 +478,7 @@ class ArgumentType
                 // (array pieces, string glue) or
                 // (array pieces)
                 if ($argcount == 1) {
-                    self::analyzeNodeUnionTypeCast(
+                    return !self::analyzeNodeUnionTypeCast(
                         $arglist->children[0],
                         $context,
                         $code_base,
@@ -485,18 +486,17 @@ class ArgumentType
                         function (UnionType $node_type) use ($context, $method) {
                         // "arg#1(pieces) is %s but {$method->getFQSEN()}() takes array when passed only 1 arg"
                             return Issue::fromType(Issue::ParamSpecial2)(
-                            $context->getFile(),
-                            $context->getLineNumberStart(), [
-                                1,
-                                'pieces',
-                                (string)$method->getFQSEN(),
-                                'string',
-                                'array'
-                            ]
+                                $context->getFile(),
+                                $context->getLineNumberStart(), [
+                                    1,
+                                    'pieces',
+                                    (string)$method->getFQSEN(),
+                                    'string',
+                                    'array'
+                                ]
                             );
                         }
                     );
-                    return;
                 } elseif ($argcount == 2) {
                     $arg1_type = UnionType::fromNode(
                         $context,

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -587,6 +587,10 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             $node->children['expr']
         );
 
+        if ($expression_type->isEmpty()) {
+            $expression_type = VoidType::instance(false)->asUnionType();
+        }
+
         if ($expression_type->hasStaticType()) {
             $expression_type =
                 $expression_type->withStaticResolvedInContext(

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -587,7 +587,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             $node->children['expr']
         );
 
-        if ($expression_type->isEmpty()) {
+        if (null === $node->children['expr']) {
             $expression_type = VoidType::instance(false)->asUnionType();
         }
 
@@ -644,10 +644,8 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             $method->getUnionType()->addUnionType($expression_type);
         }
 
-        // Mark the method as returning something
-        $method->setHasReturn(
-            isset($node->children['expr'])
-        );
+        // Mark the method as returning something (even if void)
+        $method->setHasReturn(true);
 
         return $this->context;
     }

--- a/tests/files/expected/0279_void_return.php.expected
+++ b/tests/files/expected/0279_void_return.php.expected
@@ -1,0 +1,2 @@
+%s:9 PhanTypeMismatchReturn Returning type void but f() is declared to return \DateTime
+%s:15 PhanTypeMismatchReturn Returning type void but g() is declared to return int

--- a/tests/files/src/0279_void_return.php
+++ b/tests/files/src/0279_void_return.php
@@ -1,0 +1,16 @@
+<?php
+
+function unknownType() {
+    $v = ['a', 42, new DateTime];
+    return $v[1];
+}
+
+function f() : DateTime {
+    if (true) { return; }
+    if (true) { return unknownType(); }
+    return new DateTime;
+}
+
+function g() : int {
+    return;
+}


### PR DESCRIPTION
By calling an empty return type a `void`, we avoid missing that an empty return type isn't OK in the context of returns.