### PR TITLE
Fix for #690

### DIFF
--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -183,7 +183,7 @@ class Type
                 $namespace,
                 substr($type_name, 0, $pos),
                 $template_parameter_type_list,
-                $is_nullable,
+                false,
                 $is_phpdoc_type
             ), $is_nullable);
         }
@@ -523,7 +523,7 @@ class Type
                     $fqsen->getNamespace(),
                     $fqsen->getName(),
                     $template_parameter_type_list,
-                    $is_nullable,
+                    false,
                     $is_phpdoc_type
                 ), $is_nullable);
             }

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -185,7 +185,7 @@ class Type
                 $template_parameter_type_list,
                 $is_nullable,
                 $is_phpdoc_type
-            ));
+            ), $is_nullable);
         }
 
         assert(
@@ -295,13 +295,18 @@ class Type
 
         // If this is a generic type (like int[]), return
         // a generic of internal types.
+        //
+        // When there's a nullability operator such as in
+        // `?int[]`, it applies to the array rather than
+        // the int
         if (false !== ($pos = strrpos($type_name, '[]'))) {
             return GenericArrayType::fromElementType(
                 self::fromInternalTypeName(
                     substr($type_name, 0, $pos),
-                    $is_nullable,
+                    false,
                     $is_phpdoc_type
-                )
+                ),
+                $is_nullable
             );
         }
 
@@ -520,7 +525,7 @@ class Type
                     $template_parameter_type_list,
                     $is_nullable,
                     $is_phpdoc_type
-                ));
+                ), $is_nullable);
             }
 
             return Type::make(
@@ -569,7 +574,7 @@ class Type
             return GenericArrayType::fromElementType(
                 static::fromFullyQualifiedString(
                     (string)$context->getClassFQSEN()
-                )
+                ), $is_nullable
             );
         }
 
@@ -887,7 +892,7 @@ class Type
             return ArrayType::instance(false);
         }
 
-        return GenericArrayType::fromElementType($this);
+        return GenericArrayType::fromElementType($this, false);
     }
 
     /**

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -16,12 +16,39 @@ class GenericArrayType extends ArrayType
     /**
      * @param Type $type
      * The type of every element in this array
+     *
+     * @param bool $is_nullable
+     * Set to true if the type should be nullable, else pass
+     * false
      */
-    protected function __construct(Type $type)
+    protected function __construct(Type $type, bool $is_nullable)
     {
         parent::__construct('\\', self::NAME, [], false);
         $this->element_type = $type;
+        $this->is_nullable = $is_nullable;
     }
+
+    /**
+     * @param bool $is_nullable
+     * Set to true if the type should be nullable, else pass
+     * false
+     *
+     * @return Type
+     * A new type that is a copy of this type but with the
+     * given nullability value.
+     */
+    public function withIsNullable(bool $is_nullable) : Type
+    {
+        if ($is_nullable === $this->is_nullable) {
+            return $this;
+        }
+
+        return GenericArrayType::fromElementType(
+            $this->element_type,
+            $is_nullable
+        );
+    }
+
 
     /**
      * @return bool
@@ -54,28 +81,43 @@ class GenericArrayType extends ArrayType
      * @param Type $type
      * The element type for an array.
      *
+     * @param bool $is_nullable
+     * Set to true if the type should be nullable, else pass
+     * false
+     *
      * @return GenericArrayType
      * Get a type representing an array of the given type
      */
-    public static function fromElementType(Type $type) : GenericArrayType
+    public static function fromElementType(
+        Type $type,
+        bool $is_nullable
+    ) : GenericArrayType
     {
-
         // Make sure we only ever create exactly one
         // object for any unique type
-        static $canonical_object_map = null;
+        static $canonical_object_map_non_nullable = null;
+        static $canonical_object_map_nullable = null;
 
-        if (!$canonical_object_map) {
-            $canonical_object_map = new \SplObjectStorage();
+        if (!$canonical_object_map_non_nullable) {
+            $canonical_object_map_non_nullable = new \SplObjectStorage();
         }
 
-        if (!$canonical_object_map->contains($type)) {
-            $canonical_object_map->attach(
+        if (!$canonical_object_map_nullable) {
+            $canonical_object_map_nullable = new \SplObjectStorage();
+        }
+
+        $map = $is_nullable
+            ? $canonical_object_map_nullable
+            : $canonical_object_map_non_nullable;
+
+        if (!$map->contains($type)) {
+            $map->attach(
                 $type,
-                new GenericArrayType($type)
+                new GenericArrayType($type, $is_nullable)
             );
         }
 
-        return $canonical_object_map->offsetGet($type);
+        return $map->offsetGet($type);
     }
 
     public function isGenericArray() : bool

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -88,8 +88,8 @@ class UnionTypeTest extends \PHPUnit_Framework_TestCase {
     public function testGenericArrayType() {
         $type = GenericArrayType::fromElementType(
             GenericArrayType::fromElementType(
-                IntType::instance(false)
-            )
+                IntType::instance(false), false
+            ), false
         );
 
         $this->assertEquals(

--- a/tests/files/expected/0241_nullable_71.php.expected
+++ b/tests/files/expected/0241_nullable_71.php.expected
@@ -2,5 +2,4 @@
 %s:4 PhanTypeMismatchReturn Returning type int but f241_1() is declared to return ?string
 %s:13 PhanTypeMismatchArgument Argument 1 (name) is int but \f241_3() takes ?string defined at %s:11
 %s:26 PhanTypeMismatchReturn Returning type int but f241_5() is declared to return ?string
-%s:38 PhanTypeMismatchReturn Returning type null but f241_9() is declared to return ?string[]
 %s:41 PhanTypeMismatchReturn Returning type null but f241_10() is declared to return \Tuple<int,string>

--- a/tests/files/expected/0285_nullable_generic_array.php.expected
+++ b/tests/files/expected/0285_nullable_generic_array.php.expected
@@ -1,0 +1,1 @@
+%s:25 PhanTypeMismatchReturn Returning type string[] but f285_6() is declared to return ?int[]

--- a/tests/files/src/0284_non_empty_array_default.php
+++ b/tests/files/src/0284_non_empty_array_default.php
@@ -1,0 +1,3 @@
+<?php
+/** @param int[] */
+function f($p=[1]) {}

--- a/tests/files/src/0285_nullable_generic_array.php
+++ b/tests/files/src/0285_nullable_generic_array.php
@@ -1,0 +1,36 @@
+<?php
+
+/** @return ?int[] */
+function f285_0() {
+    return null;
+}
+
+/** @return ?int[] */
+function f285_1() : ?array {
+    return null;
+}
+
+/** @return ?int[] */
+function f285_3() : ?array {
+    return [];
+}
+
+/** @return ?int[] */
+function f285_4() : ?array {
+    return [42];
+}
+
+/** @return ?int[] */
+function f285_6() {
+    return ['string'];
+}
+
+/** @return ??int[] */
+function f285_7() {
+    return null;
+}
+
+/** @return ??int[] */
+function f285_8() {
+    return [null];
+}


### PR DESCRIPTION
Oddly, the issue with #690 was that nullability wasn't implemented for generic arrays.

This patch makes the choice that `?int[]` implies that the object is a nullable array (`?array`) with the elements being non-nullable ints (`int`).

My defense for this choice is that since PHP-proper doesn't actually support `int[]`, we want to have as much compatibility with the PHP-supported type of `array` as possible. As such, if the PHP-dictated type is `?array`, we'd want to give folks the ability to write a phpdoc annotation of `?int[]` to get the same behavior, but narrowed.

In general, binding the nullability bit to the outer-most element will generally line up with what engineers will typically want, which is to say that they might return a null, or are willing to accept a null as a parameter.

