### PR TITLE
Turning off the type expansion cache

### DIFF
--- a/tests/files/expected/0178_static_from_global_scope.php.expected
+++ b/tests/files/expected/0178_static_from_global_scope.php.expected
@@ -1,2 +1,2 @@
-%s:21 PhanTypeMismatchArgument Argument 1 (p) is \D but \g() takes \E defined at %s:19
+%s:21 PhanTypeMismatchArgument Argument 1 (p) is \C|\D but \g() takes \E defined at %s:19
 %s:22 PhanTypeMismatchArgument Argument 1 (p) is \C but \g() takes \E defined at %s:19

--- a/tests/files/expected/0188_prop_array_access.php.expected
+++ b/tests/files/expected/0188_prop_array_access.php.expected
@@ -1,1 +1,0 @@
-%s:9 PhanTypeMismatchProperty Assigning int[] to property but \E::p is \C


### PR DESCRIPTION
Formerly, Phan would cache the results of `Type::asExpandedTypes`. This was generally fine, but when we'd expand types during parsing of constants, we'd end up caching only partially expanded types depending on the order in which files were parsed, leading to some nasty bugs.

This patch disables that cache. Performance is not negatively impacted in any easily perceivable way.