### PR TITLE
Inhibiting the casting of `x|null` to `?x`  with `null_casts_as_any_type`

### DIFF
--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -421,6 +421,15 @@ class Config
         return $instance;
     }
 
+    /**
+     * @return array
+     * A map of configuration keys and their values
+     */
+    public function toArray() : array
+    {
+        return $this->configuration;
+    }
+
     /** @return mixed */
     public function __get(string $name)
     {

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -142,10 +142,6 @@ class Parameter extends Variable
      */
     public function handleDefaultValueOfNull()
     {
-        if (Config::get()->null_casts_as_any_type) {
-            return;
-        }
-
         if ($this->default_value_type->isType(NullType::instance(false))) {
             // If it isn't already nullable, convert the parameter type to nullable.
             $this->convertToNullable();

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -2,6 +2,7 @@
 namespace Phan\Language\Element;
 
 use Phan\CodeBase;
+use Phan\Config;
 use Phan\Exception\IssueException;
 use Phan\Issue;
 use Phan\Language\Context;
@@ -141,6 +142,10 @@ class Parameter extends Variable
      */
     public function handleDefaultValueOfNull()
     {
+        if (Config::get()->null_casts_as_any_type) {
+            return;
+        }
+
         if ($this->default_value_type->isType(NullType::instance(false))) {
             // If it isn't already nullable, convert the parameter type to nullable.
             $this->convertToNullable();

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1064,12 +1064,21 @@ class Type
         if ($this === $type) {
             return true;
         }
+
         if ($type instanceof MixedType) {
             return true;
         }
 
         // A nullable type cannot cast to a non-nullable type
         if ($this->getIsNullable() && !$type->getIsNullable()) {
+
+            // If this is nullable, but that isn't, and we've
+            // configured nulls to cast as anything, ignore
+            // the nullable part.
+            if (Config::get()->null_casts_as_any_type) {
+                return $this->withIsNullable(false)->canCastToType($type);
+            }
+
             return false;
         }
 

--- a/tests/Phan/AbstractPhanFileTest.php
+++ b/tests/Phan/AbstractPhanFileTest.php
@@ -26,9 +26,13 @@ abstract class AbstractPhanFileTest
      */
     abstract public function getTestFiles();
 
+    /**
+     * Setup our state before running reach test
+     *
+     * @return void
+     */
     public function setUp() {
         parent::setUp();
-
 
         // Backup the config file
         foreach (Config::get()->toArray() as $key => $value) {
@@ -36,7 +40,12 @@ abstract class AbstractPhanFileTest
         }
     }
 
+    /**
+     * Reset any changes we made to our global state
+     */
     public function tearDown() {
+        parent::tearDown();
+
         // Reinstate the original config
         foreach ($this->original_config as $key => $value) {
             Config::get()->__set($key, $value);

--- a/tests/Phan/IntlTest.php
+++ b/tests/Phan/IntlTest.php
@@ -18,8 +18,8 @@ class IntlTest extends AbstractPhanFileTest {
      *
      * @dataProvider getTestFiles
      */
-    public function testFiles($test_file_list, $expected_file_path) {
-        parent::testFiles($test_file_list, $expected_file_path);
+    public function testFiles($test_file_list, $expected_file_path, $config_file_path = null) {
+        parent::testFiles($test_file_list, $expected_file_path, $config_file_path);
     }
 
     /**

--- a/tests/Phan/MultiFileTest.php
+++ b/tests/Phan/MultiFileTest.php
@@ -56,6 +56,15 @@ class MultiFileTest extends AbstractPhanFileTest {
                 MULTI_EXPECTED_DIR . DIRECTORY_SEPARATOR . '551.php' . AbstractPhanFileTest::EXPECTED_SUFFIX
             ],
 
+            // #699
+            [
+                [
+                    MULTI_FILE_DIR . DIRECTORY_SEPARATOR . '699.php',
+                ],
+                MULTI_EXPECTED_DIR . DIRECTORY_SEPARATOR . '699.php' . AbstractPhanFileTest::EXPECTED_SUFFIX,
+                MULTI_FILE_DIR . DIRECTORY_SEPARATOR . '699_config.php',
+            ],
+
             // Manually add additional file sets and expected
             // output here.
 

--- a/tests/Phan/SoapTest.php
+++ b/tests/Phan/SoapTest.php
@@ -18,8 +18,8 @@ class SoapTest extends AbstractPhanFileTest {
      *
      * @dataProvider getTestFiles
      */
-    public function testFiles($test_file_list, $expected_file_path) {
-        parent::testFiles($test_file_list, $expected_file_path);
+    public function testFiles($test_file_list, $expected_file_path, $config_file_path = null) {
+        parent::testFiles($test_file_list, $expected_file_path, $config_file_path);
     }
 
     /**

--- a/tests/multi_files/src/699.php
+++ b/tests/multi_files/src/699.php
@@ -1,0 +1,5 @@
+<?php
+function f(int $p) {}
+function g(int $p = null) {
+    f($p);
+}

--- a/tests/multi_files/src/699_config.php
+++ b/tests/multi_files/src/699_config.php
@@ -1,0 +1,4 @@
+<?php
+return [
+    'null_casts_as_any_type' => true,
+];


### PR DESCRIPTION
When `Config::get()->null_casts_as_any_type` is enabled, we shouldn't convert parameters with a default value of null to their nullable types.

```php
function f(int $p) {}
function g(int $p = null) {
    f($p);
}
```

In this example, Phan would emit an issue disallowing the casting of `?int` to `int` in the call to `f`, however, if `null_casts_as_any_type`, we'd expect it to work.
