### PR TITLE
Fixes #697 - don't emit issues for type mismatches when assigning to dynamic props

### DIFF
--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -304,7 +304,6 @@ class AssignmentVisitor extends AnalysisVisitor
      */
     public function visitProp(Node $node) : Context
     {
-
         $property_name = $node->children['prop'];
 
         // Things like $foo->$bar
@@ -339,7 +338,6 @@ class AssignmentVisitor extends AnalysisVisitor
                 if (!$clazz->hasMethodWithName($this->code_base, '__set')) {
                     continue;
                 }
-
             }
 
             try {
@@ -359,9 +357,11 @@ class AssignmentVisitor extends AnalysisVisitor
             }
 
             if (!$this->right_type->canCastToExpandedUnionType(
-                $property->getUnionType(),
-                $this->code_base
-            )) {
+                    $property->getUnionType(),
+                    $this->code_base
+                )
+                && !$clazz->getHasDynamicProperties($this->code_base)
+            ) {
                 // TODO: optionally, change the message from "::" to "->"?
                 $this->emitIssue(
                     Issue::TypeMismatchProperty,

--- a/tests/files/src/0286_dynamic_property_assignment.php
+++ b/tests/files/src/0286_dynamic_property_assignment.php
@@ -3,9 +3,9 @@ class C286 {
     function f() {}
 }
 
-$v0 = new \stdClass;
-$v0->p = 42;
+$v286a = new \stdClass;
+$v286a->p286 = 42;
 
-$v1 = new \stdClass;
-$v1->p = new C286();
-$v1->p->f();
+$v286b= new \stdClass;
+$v286b->p286 = new C286();
+$v286b->p286->f();

--- a/tests/files/src/0286_dynamic_property_assignment.php
+++ b/tests/files/src/0286_dynamic_property_assignment.php
@@ -1,0 +1,11 @@
+<?php
+class C286 {
+    function f() {}
+}
+
+$v0 = new \stdClass;
+$v0->p = 42;
+
+$v1 = new \stdClass;
+$v1->p = new C286();
+$v1->p->f();


### PR DESCRIPTION
This will result in some false negatives, such as for the following. I'm leaning toward merging this in, however, given our general preference for reducing false positives.

```php
$v = new \stdClass;
$v->p = 42;
$v->p = 'string';
```