### PR TITLE
Check for redundant analysis steps in non-quick recursion.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,10 @@ New Features (Analysis)
   Also add `PhanAccessPropertyStaticAsNonStatic`
 + Supports magic instance/static `@method` annotations. (Issue #467)
   This is enabled by default.
++ Change the behavior of non-quick recursion (Affects emitted issues in large projects).
+  Improve perfomance of non-quick analysis by checking for redundant analysis steps
+  (E.g. calls from two different places passing the same union types for each parameter),
+  continuing to recurse when passing by reference.
 + Support for checking for misuses of "@internal" annotations. Phan assumes this means it is internal to a namespace. (Issue #353)
   This checks properties, methods, class constants, and classes.
   (Adds `PhanAccessConstantInternal`, `PhanAccessClassInternal`, `PhanAccessClassConstantInternal`, `PhanAccessPropertyInternal`, `PhanAccessMethodInternal`)

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1778,6 +1778,10 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             return clone($parameter);
         }, $method->getParameterList());
 
+        if (count($original_parameter_list) === 0) {
+            return;  // No point in recursing if there's no changed parameters.
+        }
+
         // always resolve all arguments outside of quick mode to detect undefined variables, other problems in call arguments.
         // Fixes https://github.com/etsy/phan/issues/583
         $argument_types = [];
@@ -1837,7 +1841,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         // Now that we know something about the parameters used
         // to call the method, we can reanalyze the method with
         // the types of the parameter
-        $method->analyze($method->getContext(), $code_base);
+        $method->analyzeWithNewParams($method->getContext(), $code_base);
 
         // Reset to the original parameter list and scope after
         // having tested the parameters with the types passed in

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -176,4 +176,12 @@ interface FunctionInterface extends AddressableElementInterface {
      * in the given context
      */
     public function analyze(Context $context, CodeBase $code_base) : Context;
+
+    /**
+     * @return Context
+     * Analyze the node associated with this object
+     * in the given context.
+     * This function's parameter list may or may not have been modified.
+     */
+    public function analyzeWithNewParams(Context $context, CodeBase $code_base) : Context;
 }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -547,7 +547,17 @@ class UnionType implements \Serializable
      */
     public function isEqualTo(UnionType $union_type) : bool
     {
-        return ((string)$this === (string)$union_type);
+        $type_set = $this->getTypeSet();
+        $other_type_set = $union_type->getTypeSet();
+        if (count($type_set) !== count($other_type_set)) {
+            return false;
+        }
+        foreach ($type_set as $type) {
+            if (!$other_type_set->contains($type)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**


### PR DESCRIPTION
For issue #592

A single-process test run on drupal had the duration of analysis reduced
from 75 seconds to 60 seconds
(Most of that improvement may be due to skipping
over function calls where there are 0 parameters)

- Note that if parameters are optional, and something is invoked with 0
  params, the parameter_list will still have parameters
  (based on defaults and original type)
- This changes the behavior of non-quick mode. A different set of issues
  will be emitted as a result (of similar quality)
  (Previously, the recursion depth check was implemented incorrectly - it was incremented but never decremented)
  Also, some similar issues with different union types (for different
  calling locations) may be emitted for the same lines of code.
- This also accounts for the recursion depth in checking for redundant
  calls - If a new call would recurse deeper than the old one, then the
  new call isn't redundant.
- Continue to always recurse for calls to functions with reference parameters.
  Those should be infrequent enough that they don't hurt performance.
  tests/rasmus_files/src/0039_static_property_ref.php somewhat covers
  the expected behavior already.
- I checked, and visitMethod on a Method has self::$recursion_depth == 0 to start (so it works as expected)

Update NEWS

E.g. https://gist.github.com/TysonAndre/e86f9579bbab9d35f3c936d88ac7a7b1 compares drupal errors before/after this change (about 100 out of a 5000 line file)