### PR TITLE
Throw exceptions on failed asserts to link them to the code being analyzed

### DIFF
--- a/src/Phan/Bootstrap.php
+++ b/src/Phan/Bootstrap.php
@@ -27,7 +27,13 @@ define('EXIT_ISSUES_FOUND', EXIT_FAILURE);
 
 // Throw exceptions so asserts can be linked to the code being analyzed
 ini_set('assert.exception', '1');
+
+// Explicitly set each option in case INI is set otherwise
+assert_options(ASSERT_ACTIVE, true);
 assert_options(ASSERT_WARNING, false);
+assert_options(ASSERT_BAIL, false);
+assert_options(ASSERT_QUIET_EVAL, false);
+assert_options(ASSERT_CALLBACK, null);
 
 // Print more of the backtrace than is done by default
 set_exception_handler(function (Throwable $throwable) {

--- a/src/Phan/Bootstrap.php
+++ b/src/Phan/Bootstrap.php
@@ -37,7 +37,7 @@ assert_options(ASSERT_CALLBACK, null);
 
 // Print more of the backtrace than is done by default
 set_exception_handler(function (Throwable $throwable) {
-    print "$throwable\n";
+    error_log("$throwable\n");
     exit(EXIT_FAILURE);
 });
 
@@ -46,8 +46,12 @@ set_exception_handler(function (Throwable $throwable) {
  */
 function phan_error_handler($errno, $errstr, $errfile, $errline)
 {
-    print "$errfile:$errline [$errno] $errstr\n";
+    error_log("$errfile:$errline [$errno] $errstr\n");
+
+    ob_start();
     debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+    error_log(ob_get_clean());
+
     exit(EXIT_FAILURE);
 }
 set_error_handler('phan_error_handler');

--- a/src/Phan/Bootstrap.php
+++ b/src/Phan/Bootstrap.php
@@ -25,18 +25,9 @@ define('EXIT_SUCCESS', 0);
 define('EXIT_FAILURE', 1);
 define('EXIT_ISSUES_FOUND', EXIT_FAILURE);
 
-// Customize assertions
-assert_options(ASSERT_ACTIVE, true);
-assert_options(ASSERT_BAIL, true);
+// Throw exceptions so asserts can be linked to the code being analyzed
+ini_set('assert.exception', '1');
 assert_options(ASSERT_WARNING, false);
-assert_options(
-    ASSERT_CALLBACK,
-    function (string $script, int $line, $expression, $message) {
-        print "$script:$line ($expression) $message\n";
-        debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-        exit(EXIT_FAILURE);
-    }
-);
 
 // Print more of the backtrace than is done by default
 set_exception_handler(function (Throwable $throwable) {

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -121,6 +121,10 @@ class Phan implements IgnoredFilesFilterInterface {
                 $analyze_file_path_list[] = $file_path;
 
 
+            } catch (\AssertionError $assertion_error) {
+                print "While parsing $file_path...\n";
+                print "$assertion_error\n";
+                exit(EXIT_FAILURE);
             } catch (\Throwable $throwable) {
                 error_log($file_path . ' ' . $throwable->getMessage() . "\n");
                 $code_base->recordUnparseableFile($file_path);

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -122,8 +122,8 @@ class Phan implements IgnoredFilesFilterInterface {
 
 
             } catch (\AssertionError $assertion_error) {
-                print "While parsing $file_path...\n";
-                print "$assertion_error\n";
+                error_log("While parsing $file_path...\n");
+                error_log("$assertion_error\n");
                 exit(EXIT_FAILURE);
             } catch (\Throwable $throwable) {
                 error_log($file_path . ' ' . $throwable->getMessage() . "\n");


### PR DESCRIPTION
I've hit asserts while analyzing some shaggy code. The existing callback makes it hard to see what triggered them. This change enables the PHP7 style of asserts (turning them into exceptions). Those not caught in `Phan::analyzeFileList()` will be handled by the exception handler defined in Bootstrap.php, which produces similar output to the existing assert handler.