### PR TITLE
Fix bug in dead code detection on methods(compared object to string)

### DIFF
--- a/src/Phan/Analysis/ReferenceCountsAnalyzer.php
+++ b/src/Phan/Analysis/ReferenceCountsAnalyzer.php
@@ -5,6 +5,7 @@ use Phan\CLI;
 use Phan\CodeBase;
 use Phan\CodeBase\ClassMap;
 use Phan\Config;
+use Phan\Exception\CodeBaseException;
 use Phan\Issue;
 use Phan\Language\Element\AddressableElement;
 use Phan\Language\Element\ClassConstant;
@@ -163,7 +164,6 @@ class ReferenceCountsAnalyzer
                     return;
                 }
             }
-
             if ($element->getIsOverride()) {
                 return;
             }
@@ -172,8 +172,12 @@ class ReferenceCountsAnalyzer
 
             // Don't analyze elements defined in a parent
             // class
-            if ($class_fqsen != $element->getDefiningClassFQSEN()) {
-                return;
+            try {
+                if ($class_fqsen != $element->getDefiningClassFQSEN()) {
+                    return;
+                }
+            } catch (CodeBaseException $e) {
+                // No defining class for property/constant/etc.
             }
 
             $defining_class =

--- a/src/Phan/Analysis/ReferenceCountsAnalyzer.php
+++ b/src/Phan/Analysis/ReferenceCountsAnalyzer.php
@@ -7,6 +7,7 @@ use Phan\CodeBase\ClassMap;
 use Phan\Config;
 use Phan\Issue;
 use Phan\Language\Element\AddressableElement;
+use Phan\Language\Element\ClassConstant;
 use Phan\Language\Element\ClassElement;
 use Phan\Language\Element\Method;
 use Phan\Language\Element\Property;
@@ -156,6 +157,13 @@ class ReferenceCountsAnalyzer
 
         // Skip methods that are overrides of other methods
         if ($element instanceof ClassElement) {
+            if ($element instanceof ClassConstant) {
+                // should not warn about self::class
+                if (strcasecmp($element->getName(), 'class') === 0) {
+                    return;
+                }
+            }
+
             if ($element->getIsOverride()) {
                 return;
             }
@@ -164,7 +172,7 @@ class ReferenceCountsAnalyzer
 
             // Don't analyze elements defined in a parent
             // class
-            if ((string)$class_fqsen !== $element->getFQSEN()) {
+            if ($class_fqsen != $element->getDefiningClassFQSEN()) {
                 return;
             }
 


### PR DESCRIPTION
Cast both to string so that the comparison will work properly