### PR TITLE
Remove tests of phpdoc on class const, those don't exist in php 7.0

### DIFF
--- a/tests/files/src/0278_internal_elements.php
+++ b/tests/files/src/0278_internal_elements.php
@@ -4,7 +4,7 @@ namespace NS278\A {
 
     const CONST_PUBLIC = 41;
 
-    /** @internal */
+    // NOTE: Not able to parse doc comments on constants in php-ast in php 7.0, so that part of the test was left out.
     const CONST_INTERNAL = 42;
 
     /** @internal */
@@ -17,7 +17,7 @@ namespace NS278\A {
     class C2 {
         const CONST_PUBLIC = 41;
 
-        /** @internal */
+        // NOTE: Not able to parse doc comments on constants in php-ast in php 7.0, so that part of the test was left out.
         const CONST_INTERNAL = 42;
 
         /** @internal */


### PR DESCRIPTION
Jenkins runs this test suite with both 7.0 and 7.1
So the outputs would be different for @internal on a class const in 7.0
The functionality still works if php 7.1 were to be used.