### PR TITLE
Fix checking constants/functions relative to namespaces

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -41,14 +41,14 @@ Bug Fixes
 - Fix uncaught exception when conditional node is a scalar (Issue #613)
 - Existence of __get() no longer affects analyzing static properties. (Issue #610)
 - Phan can now detect the declaration of constants relative to a `use`d namespace (Issue #509)
-- Phan can now detect the declaration of functions relative to a `use`d namespace (Issue #509)
+- Phan can now detect the declaration of functions relative to a `use`d namespace (Issue #510)
 
 Backwards Incompatible Changes
-- Declarations of user-defined constants are now consistently 
+- Declarations of user-defined constants are now consistently
   analyzed in a case sensitive way.
   This may affect projects using `define(name, value, case_insensitive = true)`.
   Change the code being analyzed to exactly match the constant name in define())
-  
+ 
 0.9.1 Mar 15, 2017
 ------------------
 

--- a/NEWS
+++ b/NEWS
@@ -40,7 +40,15 @@ Bug Fixes
 - Fix PhanTypeMismatchArgument, etc. for uses of `new static()`, static::CONST, etc in a method. (Issue #632)
 - Fix uncaught exception when conditional node is a scalar (Issue #613)
 - Existence of __get() no longer affects analyzing static properties. (Issue #610)
+- Phan can now detect the declaration of constants relative to a `use`d namespace (Issue #509)
+- Phan can now detect the declaration of functions relative to a `use`d namespace (Issue #509)
 
+Backwards Incompatible Changes
+- Declarations of user-defined constants are now consistently 
+  analyzed in a case sensitive way.
+  This may affect projects using `define(name, value, case_insensitive = true)`.
+  Change the code being analyzed to exactly match the constant name in define())
+  
 0.9.1 Mar 15, 2017
 ------------------
 

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -793,33 +793,34 @@ class ContextNode
      */
     public function getConst() : GlobalConstant
     {
+        $node = $this->node;
         assert(
-            $this->node instanceof \ast\Node,
-            '$this->node must be a node'
+            $node instanceof \ast\Node,
+            '$node must be a node'
         );
 
         assert(
-            $this->node->kind === \ast\AST_CONST,
+            $node->kind === \ast\AST_CONST,
             "Node must be of type \ast\AST_CONST"
         );
 
-        if ($this->node->children['name']->kind !== \ast\AST_NAME) {
+        if ($node->children['name']->kind !== \ast\AST_NAME) {
             throw new NodeException(
-                $this->node,
+                $node,
                 "Can't determine constant name"
             );
         }
 
         $constant_name =
-            $this->node->children['name']->children['name'];
+            $node->children['name']->children['name'];
 
+        // TODO: could speed up looking up reserved words such as null, true, false
         $fqsen = FullyQualifiedGlobalConstantName::fromStringInContext(
             $constant_name,
             $this->context
         );
 
         if (!$this->code_base->hasGlobalConstantWithFQSEN($fqsen)) {
-
             $fqsen = FullyQualifiedGlobalConstantName::fromFullyQualifiedString(
                 $constant_name
             );
@@ -828,7 +829,7 @@ class ContextNode
                 throw new IssueException(
                     Issue::fromType(Issue::UndeclaredConstant)(
                         $this->context->getFile(),
-                        $this->node->lineno ?? 0,
+                        $node->lineno ?? 0,
                         [ $fqsen ]
                     )
                 );
@@ -846,7 +847,7 @@ class ContextNode
             throw new IssueException(
                 Issue::fromType(Issue::AccessConstantInternal)(
                     $this->context->getFile(),
-                    $this->node->lineno ?? 0,
+                    $node->lineno ?? 0,
                     [
                         (string)$constant->getFQSEN(),
                         $constant->getFileRef()->getFile(),

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -150,6 +150,14 @@ class Analysis
         ))($node);
 
         assert(!empty($context), 'Context cannot be null');
+        $kind = $node->kind;
+
+        // \ast\AST_GROUP_USE has \ast\AST_USE as a child.
+        // We don't want to use block twice in the parse phase.
+        // (E.g. `use MyNS\{const A, const B}` would lack the MyNs part if this were to recurse.
+        if ($kind === \ast\AST_GROUP_USE) {
+            return $context;
+        }
 
         // Recurse into each child node
         $child_context = $context;
@@ -177,12 +185,12 @@ class Analysis
         // For closed context elements (that have an inner scope)
         // return the outer context instead of their inner context
         // after we finish parsing their children.
-        if (in_array($node->kind, [
+        if (in_array($kind, [
             \ast\AST_CLASS,
             \ast\AST_METHOD,
             \ast\AST_FUNC_DECL,
             \ast\AST_CLOSURE,
-        ])) {
+        ], true)) {
             return $outer_context;
         }
 

--- a/src/Phan/Analysis/ScopeVisitor.php
+++ b/src/Phan/Analysis/ScopeVisitor.php
@@ -132,7 +132,7 @@ abstract class ScopeVisitor extends AnalysisVisitor {
         ) {
             list($flags, $target) = $map;
             $context = $context->withNamespaceMap(
-                $node->flags ?? 0, $alias, $target
+                $node->flags ?: $flags, $alias, $target
             );
         }
 

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -596,4 +596,41 @@ class BlockAnalysisVisitor extends AnalysisVisitor {
         );
         return $context;
     }
+
+    /**
+     * Analyzes a node of type \ast\AST_GROUP_USE
+     * This is the same as visit(), but does not recurse into the child nodes.
+     *
+     * If this function override didn't exist,
+     * then visit() would recurse into \ast\AST_USE,
+     * which would lack part of the namespace.
+     * (E.g. for use \NS\{const X, const Y}, we don't want to analyze const X or const Y
+     * without the preceding \NS\)
+     */
+    public function visitGroupUse(Node $node) : Context
+    {
+        $context = $this->context->withLineNumberStart(
+            $node->lineno ?? 0
+        );
+
+        // Visit the given node populating the code base
+        // with anything we learn and get a new context
+        // indicating the state of the world within the
+        // given node
+        $context = (new PreOrderAnalysisVisitor(
+            $this->code_base, $context
+        ))($node);
+
+        // Let any configured plugins do a pre-order
+        // analysis of the node.
+        ConfigPluginSet::instance()->preAnalyzeNode(
+            $this->code_base, $context, $node
+        );
+
+        assert(!empty($context), 'Context cannot be null');
+
+        $context = $this->postOrderAnalyze($context, $node);
+
+        return $context;
+    }
 }

--- a/src/Phan/Bootstrap.php
+++ b/src/Phan/Bootstrap.php
@@ -33,7 +33,7 @@ assert_options(ASSERT_ACTIVE, true);
 assert_options(ASSERT_WARNING, false);
 assert_options(ASSERT_BAIL, false);
 assert_options(ASSERT_QUIET_EVAL, false);
-assert_options(ASSERT_CALLBACK, null);
+assert_options(ASSERT_CALLBACK, '');  // Can't explicitly set ASSERT_CALLBACK to null?
 
 // Print more of the backtrace than is done by default
 set_exception_handler(function (Throwable $throwable) {

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -402,6 +402,9 @@ class CLI
         return $this->file_list;
     }
 
+    // FIXME: If I stop using defined() in UnionTypeVisitor,
+    // this will warn about the undefined constant EXIT_SUCCESS when a
+    // user-defined constant is used in parse phase in a function declaration
     private function usage(string $msg = '', int $exit_code = EXIT_SUCCESS, bool $print_extended_help = false)
     {
         global $argv;

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -119,6 +119,7 @@ class CodeBase
         array $internal_class_name_list,
         array $internal_interface_name_list,
         array $internal_trait_name_list,
+        array $internal_constant_name_list,
         array $internal_function_name_list
     ) {
         $this->fqsen_class_map = new Map;
@@ -128,10 +129,11 @@ class CodeBase
         $this->func_and_method_set = new Set;
 
         // Add any pre-defined internal classes, interfaces,
-        // traits and functions
+        // constants, traits and functions
         $this->addClassesByNames($internal_class_name_list);
         $this->addClassesByNames($internal_interface_name_list);
         $this->addClassesByNames($internal_trait_name_list);
+        $this->addGlobalConstantsByNames($internal_constant_name_list);
         $this->addFunctionsByNames($internal_function_name_list);
     }
 
@@ -224,8 +226,21 @@ class CodeBase
      */
     private function addClassesByNames(array $class_name_list)
     {
-        foreach ($class_name_list as $i => $class_name) {
+        foreach ($class_name_list as $class_name) {
             $this->addClass(Clazz::fromClassName($this, $class_name));
+        }
+    }
+
+    /**
+     * @param string[] $const_name_list
+     * A list of global constant names to load type information for
+     *
+     * @return void
+     */
+    private function addGlobalConstantsByNames(array $const_name_list)
+    {
+        foreach ($const_name_list as $const_name) {
+            $this->addGlobalConstant(GlobalConstant::fromGlobalConstantName($this, $const_name));
         }
     }
 
@@ -306,7 +321,7 @@ class CodeBase
      */
     public function shallowClone() : CodeBase
     {
-        $code_base = new CodeBase([], [], [], []);
+        $code_base = new CodeBase([], [], [], [], []);
         $code_base->fqsen_class_map =
             clone($this->fqsen_class_map);
         $code_base->fqsen_global_constant_map =

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -185,10 +185,10 @@ class Context extends FileRef
         if ($flags !== \ast\flags\USE_CONST) {
             $alias = strtolower($alias);
         } else {
-            $lastPartIndex = strrpos('\\', $alias);
-            if ($lastPartIndex !== false) {
+            $last_part_index = strrpos('\\', $alias);
+            if ($last_part_index !== false) {
                 // Convert the namespace to lowercase, but not the constant name.
-                $alias = strtolower(substr($alias, 0, $lastPartIndex + 1)) . substr($alias, $lastPartIndex + 1);
+                $alias = strtolower(substr($alias, 0, $last_part_index + 1)) . substr($alias, $last_part_index + 1);
             }
         }
         $this->namespace_map[$flags][$alias] = $target;

--- a/src/Phan/Language/Element/GlobalConstant.php
+++ b/src/Phan/Language/Element/GlobalConstant.php
@@ -1,8 +1,11 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Element;
 
+use Phan\CodeBase;
+use Phan\Language\Context;
 use Phan\Language\FQSEN;
 use Phan\Language\FQSEN\FullyQualifiedGlobalConstantName;
+use Phan\Language\Type;
 use Phan\Language\UnionType;
 
 class GlobalConstant extends AddressableElement implements ConstantInterface
@@ -33,5 +36,34 @@ class GlobalConstant extends AddressableElement implements ConstantInterface
     {
         assert(!empty($this->fqsen), "FQSEN must be defined");
         return $this->fqsen;
+    }
+
+    /**
+     * @param string $class_name
+     * The name of a builtin constant to build a new GlobalConstant structural
+     * element from.
+     *
+     * @return GlobalConstant
+     * A GlobalConstant structural element representing the given named
+     * builtin constant.
+     */
+    public static function fromGlobalConstantName(
+        CodeBase $code_base,
+        string $name
+    ) : GlobalConstant {
+        if (!defined($name)) {
+            throw new \InvalidArgumentException("This should not happen, const '$name' does not exist");
+        }
+        $value = constant($name);
+        $constant_fqsen = FullyQualifiedGlobalConstantName::fromFullyQualifiedString(
+            '\\' . $name
+        );
+        return new self(
+            new Context(),
+            $name,
+            Type::fromObject($value)->asUnionType(),
+            0,
+            $constant_fqsen
+        );
     }
 }

--- a/src/Phan/Language/FQSEN/AbstractFQSEN.php
+++ b/src/Phan/Language/FQSEN/AbstractFQSEN.php
@@ -73,6 +73,18 @@ abstract class AbstractFQSEN implements FQSEN
 
     /**
      * @return string
+     * The canonical representation of the name of the object,
+     * for use in array key lookups for singletons, namespace maps, etc.
+     * This should not be used directly or indirectly in issue output
+     * If an FQSEN is case sensitive, this should return $name
+     */
+    public static function canonicalLookupKey(string $name) : string
+    {
+        return strtolower($name);
+    }
+
+    /**
+     * @return string
      * A string representation of this fully-qualified
      * structural element name.
      */

--- a/src/Phan/Language/FQSEN/FullyQualifiedClassConstantName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedClassConstantName.php
@@ -15,4 +15,16 @@ class FullyQualifiedClassConstantName extends FullyQualifiedClassElement impleme
     {
         return \ast\flags\USE_CONST;
     }
+
+    /**
+     * @return string
+     * The canonical representation of the name of the object,
+     * for use in array key lookups for singletons, namespace maps, etc.
+     * This should not be used directly or indirectly in issue output
+     * If an FQSEN is case sensitive, this should return $name
+     */
+    public static function canonicalLookupKey(string $name) : string
+    {
+        return $name;
+    }
 }

--- a/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
@@ -25,6 +25,8 @@ class FullyQualifiedClassName extends FullyQualifiedGlobalStructuralElement
      * @return string
      * The canonical representation of the name of the object. Functions
      * and Methods, for instance, lowercase their names.
+     * TODO: Separate the function used to render names in phan errors
+     *       from the ones used for generating array keys.
      */
     public static function canonicalName(string $name) : string
     {

--- a/src/Phan/Language/FQSEN/FullyQualifiedFunctionName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedFunctionName.php
@@ -23,6 +23,8 @@ class FullyQualifiedFunctionName extends FullyQualifiedGlobalStructuralElement
      * @return string
      * The canonical representation of the name of the object. Functions
      * and Methods, for instance, lowercase their names.
+     * TODO: Separate the funciton used to render names in phan errors
+     *       from the ones used for generating array keys.
      */
     public static function canonicalName(string $name) : string
     {
@@ -51,11 +53,6 @@ class FullyQualifiedFunctionName extends FullyQualifiedGlobalStructuralElement
         $fqsen_string = $parts[0];
         $alternate_id = (int)($parts[1] ?? 0);
 
-        assert(
-            is_int($alternate_id),
-            "Alternate must be an integer"
-        );
-
         $parts = explode('\\', $fqsen_string);
         $name = array_pop($parts);
 
@@ -65,10 +62,10 @@ class FullyQualifiedFunctionName extends FullyQualifiedGlobalStructuralElement
         );
 
         // Check for a name map
-        if ($context->hasNamespaceMapFor(static::getNamespaceMapType(), $name)) {
+        if ($context->hasNamespaceMapFor(static::getNamespaceMapType(), $fqsen_string)) {
             return $context->getNamespaceMapFor(
                 static::getNamespaceMapType(),
-                $name
+                $fqsen_string
             );
         }
 

--- a/src/Phan/Language/FQSEN/FullyQualifiedGlobalConstantName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedGlobalConstantName.php
@@ -14,4 +14,16 @@ class FullyQualifiedGlobalConstantName extends FullyQualifiedGlobalStructuralEle
     {
         return \ast\flags\USE_CONST;
     }
+
+    /**
+     * @return string
+     * The canonical representation of the name of the object,
+     * for use in array key lookups for singletons, namespace maps, etc.
+     * This should not be used directly or indirectly in issue output
+     * If an FQSEN is case sensitive, this should return $name
+     */
+    public static function canonicalLookupKey(string $name) : string
+    {
+        return $name;
+    }
 }

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -12,6 +12,7 @@ use Phan\Language\Type\GenericArrayType;
 use Phan\Language\Type\IntType;
 use Phan\Language\Type\IterableType;
 use Phan\Language\Type\MixedType;
+use Phan\Language\Type\NativeType;
 use Phan\Language\Type\NullType;
 use Phan\Language\Type\ObjectType;
 use Phan\Language\Type\ResourceType;
@@ -19,6 +20,9 @@ use Phan\Language\Type\StaticType;
 use Phan\Language\Type\StringType;
 use Phan\Language\Type\TemplateType;
 use Phan\Language\Type\VoidType;
+use Phan\Library\None;
+use Phan\Library\Option;
+use Phan\Library\Some;
 use Phan\Library\Tuple4;
 
 class Type
@@ -305,6 +309,92 @@ class Type
             $type->getIsNullable(),
             false
         );
+    }
+
+    /**
+     * If the $name is a reserved constant, then returns the NativeType for that name
+     * Otherwise, this returns null.
+     * @return Option<NativeType>
+     */
+    public static function fromReservedConstantName(string $name) : Option {
+        static $lookup;
+        if ($lookup === null) {
+            $lookup = self::createReservedConstantNameLookup();
+        }
+        $result = $lookup[strtoupper(ltrim($name, '\\'))] ?? null;
+        if (isset($result)) {
+            return new Some($result);
+        }
+        return new None;
+    }
+
+    /**
+     * @return NativeType[] a map from the **uppercase** reserved constant name to the subclass of NativeType for that constant.
+     * Uses the constants and types from https://secure.php.net/manual/en/reserved.constants.php
+     */
+    private static function createReservedConstantNameLookup() : array {
+        $int = IntType::instance(false);
+        $bool = BoolType::instance(false);
+        $null = NullType::instance(false);
+        $string = StringType::instance(false);
+        $float  = FloatType::instance(false);
+        return [
+            'PHP_VERSION'           => $string,
+            'PHP_MAJOR_VERSION'     => $int,
+            'PHP_MINOR_VERSION'     => $int,
+            'PHP_RELEASE_VERSION'   => $int,
+            'PHP_VERSION_ID'        => $int,
+            'PHP_EXTRA_VERSION'     => $string,
+            'PHP_ZTS'               => $int,
+            'PHP_MAXPATHLEN'        => $int,
+            'PHP_OS'                => $string,
+            'PHP_OS_FAMILY'         => $string,
+            'PHP_SAPI'              => $string,
+            'PHP_EOL'               => $string,
+            'PHP_INT_MAX'           => $int,
+            'PHP_INT_MIN'           => $int,  // since 7.0.0
+            'PHP_INT_SIZE'          => $int,  // since 7.0.0
+            //'PHP_FLOAT_DIG'         => $int,  // since 7.2.0
+            //'PHP_FLOAT_EPSILON'     => $float,  // since 7.2.0
+            //'PHP_FLOAT_MIN'         => $int, // since 7.2.0
+            //'PHP_FLOAT_MAX'         => $int, // since 7.2.0
+            'DEFAULT_INCLUDE_PATH'  => $string,
+            'PEAR_INSTALL_DIR'      => $string,
+            'PEAR_EXTENSION_DIR'    => $string,
+            'PHP_EXTENSION_DIR'     => $string,
+            'PEAR_EXTENSION_DIR'    => $string,
+            'PHP_PREFIX'            => $string,
+            'PHP_BINDIR'            => $string,
+            'PHP_BINARY'            => $string,
+            'PHP_MANDIR'            => $string,
+            'PHP_LIBDIR'            => $string,
+            'PHP_DATADIR'           => $string,
+            'PHP_SYSCONFDIR'        => $string,
+            'PHP_LOCALSTATEDIR'     => $string,
+            'PHP_CONFIG_FILE_PATH'  => $string,
+            'PHP_CONFIG_FILE_SCAN_DIR' => $string,
+            'PHP_SHLIB_SUFFIX'      => $string,
+            //'PHP_FD_SETSIZE'            => $int,  // 7.2.0 TODO: web page documentation is wrong, says string.
+            'E_ERROR'               => $int,
+            'E_WARNING'             => $int,
+            'E_PARSE'               => $int,
+            'E_NOTICE'              => $int,
+            'E_CORE_ERROR'          => $int,
+            'E_CORE_WARNING'        => $int,
+            'E_COMPILE_ERROR'       => $int,
+            'E_COMPILE_WARNING'     => $int,
+            'E_USER_ERROR'          => $int,
+            'E_USER_WARNING'        => $int,
+            'E_USER_NOTICE'         => $int,
+            'E_DEPRECATED'          => $int,
+            'E_USER_DEPRECATED'     => $int,
+            'E_ALL'                 => $int,
+            'E_STRICT'              => $int,
+            '__COMPILER_HALT_OFFSET__' => $int,
+            'TRUE'                  => $bool,
+            'FALSE'                 => $bool,
+            'NULL'                  => $null,
+        ];
     }
 
     /**

--- a/src/codebase.php
+++ b/src/codebase.php
@@ -4,6 +4,10 @@
 $internal_class_name_list = get_declared_classes();
 $internal_interface_name_list = get_declared_interfaces();
 $internal_trait_name_list = get_declared_traits();
+// Get everything except user-defined constants
+$internal_const_name_list = array_keys(array_merge(...array_values(
+    array_diff_key(get_defined_constants(true), ['user' => []])
+)));
 $internal_function_name_list = get_defined_functions()['internal'];
 
 
@@ -22,5 +26,6 @@ return new CodeBase(
     $internal_class_name_list,
     $internal_interface_name_list,
     $internal_trait_name_list,
+    $internal_const_name_list,
     $internal_function_name_list
 );

--- a/tests/Phan/AnalyzerTest.php
+++ b/tests/Phan/AnalyzerTest.php
@@ -6,6 +6,9 @@ namespace Phan\Tests;
 $internal_class_name_list = get_declared_classes();
 $internal_interface_name_list = get_declared_interfaces();
 $internal_trait_name_list = get_declared_traits();
+$internal_const_name_list = array_keys(array_merge(...array_values(
+    array_diff_key(get_defined_constants(true), ['user' => []]))
+));
 $internal_function_name_list = get_defined_functions()['internal'];
 
 use Phan\Analysis;
@@ -19,6 +22,7 @@ class AnalyzerTest extends \PHPUnit_Framework_TestCase {
     private $class_name_list;
     private $interface_name_list;
     private $trait_name_list;
+    private $const_name_list;
     private $function_name_list;
 
     /**
@@ -30,10 +34,12 @@ class AnalyzerTest extends \PHPUnit_Framework_TestCase {
         global $internal_class_name_list;
         global $internal_interface_name_list;
         global $internal_trait_name_list;
+        global $internal_const_name_list;
         global $internal_function_name_list;
         $this->class_name_list = $internal_class_name_list;
         $this->interface_name_list = $internal_interface_name_list;
         $this->trait_name_list = $internal_trait_name_list;
+        $this->const_name_list = $internal_const_name_list;
         $this->function_name_list = $internal_function_name_list;
 
 
@@ -42,6 +48,7 @@ class AnalyzerTest extends \PHPUnit_Framework_TestCase {
                 [], // $this->class_name_list,
                 [], // $this->interface_name_list,
                 [], // $this->trait_name_list,
+                [], // $this->const_name_list,
                 []  // $this->function_name_list
             );
 

--- a/tests/Phan/Language/ContextTest.php
+++ b/tests/Phan/Language/ContextTest.php
@@ -17,7 +17,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase {
     protected $code_base = null;
 
     protected function setUp() {
-        $this->code_base = new CodeBase([], [], [], []);
+        $this->code_base = new CodeBase([], [], [], [], []);
     }
 
     protected function tearDown() {

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -10,6 +10,9 @@ use Phan\Language\Type\IntType;
 $internal_class_name_list = get_declared_classes();
 $internal_interface_name_list = get_declared_interfaces();
 $internal_trait_name_list = get_declared_traits();
+$internal_const_name_list = array_keys(array_merge(...array_values(
+    array_diff_key(get_defined_constants(true), ['user' => []])
+)));
 $internal_function_name_list = get_defined_functions()['internal'];
 
 use Phan\CodeBase;
@@ -29,12 +32,14 @@ class UnionTypeTest extends \PHPUnit_Framework_TestCase {
         global $internal_class_name_list;
         global $internal_interface_name_list;
         global $internal_trait_name_list;
+        global $internal_const_name_list;
         global $internal_function_name_list;
 
         $this->code_base = new CodeBase(
             $internal_class_name_list,
             $internal_interface_name_list,
             $internal_trait_name_list,
+            $internal_const_name_list,
             $internal_function_name_list
         );
 

--- a/tests/Phan/PhanTestListener.php
+++ b/tests/Phan/PhanTestListener.php
@@ -4,11 +4,16 @@ namespace Phan\Tests;
 global $internal_class_name_list;
 global $internal_interface_name_list;
 global $internal_trait_name_list;
+global $internal_const_name_list;
 global $internal_function_name_list;
 
 $internal_class_name_list = get_declared_classes();
 $internal_interface_name_list = get_declared_interfaces();
 $internal_trait_name_list = get_declared_traits();
+// Get everything except user-defined constants
+$internal_const_name_list = array_keys(array_merge(...array_values(
+    array_diff_key(get_defined_constants(true), ['user' => []])
+)));
 $internal_function_name_list = get_defined_functions()['internal'];
 
 use Phan\CodeBase;
@@ -34,12 +39,14 @@ class PhanTestListener
                 global $internal_class_name_list;
                 global $internal_interface_name_list;
                 global $internal_trait_name_list;
+                global $internal_const_name_list;
                 global $internal_function_name_list;
 
                 $code_base = new CodeBase(
                     $internal_class_name_list,
                     $internal_interface_name_list,
                     $internal_trait_name_list,
+                    $internal_const_name_list,
                     $internal_function_name_list
                 );
             }

--- a/tests/files/expected/0111_import_constant.php.expected
+++ b/tests/files/expected/0111_import_constant.php.expected
@@ -1,0 +1,4 @@
+%s:19 PhanUndeclaredConstant Reference to undeclared constant \c
+%s:21 PhanUndeclaredConstant Reference to undeclared constant \foo
+%s:22 PhanUndeclaredConstant Reference to undeclared constant \Bar
+%s:23 PhanUndeclaredConstant Reference to undeclared constant \UndeclaredConst

--- a/tests/files/expected/0288_use_relative_namespace_function.php.expected
+++ b/tests/files/expected/0288_use_relative_namespace_function.php.expected
@@ -1,0 +1,4 @@
+%s:19 PhanUndeclaredFunction Call to undeclared function \A510\inner\missingthisfn()
+%s:21 PhanUndeclaredFunction Call to undeclared function \A510\Inner\MissingGroupUseFn()
+%s:22 PhanUndeclaredFunction Call to undeclared function \mixedCaseFn()
+%s:25 PhanUndeclaredFunction Call to undeclared function \A510\Inner\missingfn()

--- a/tests/files/src/0111_import_constant.php
+++ b/tests/files/src/0111_import_constant.php
@@ -1,14 +1,24 @@
 <?php
-namespace A {
+namespace A111 {
     const C = 42;
     const D = 24;
+    const Foo = 24;
+    const bar = 24;
 }
 
 namespace {
-    use \A\{const C, const D};
+    use \A111\{const C, const D};
+    use const \A111\Foo;
+    use \A111\{const Bar};  // Import using the wrong case for the constant name
+    use \A111\{const UndeclaredConst};
     function f(int $v) : int {
         return $v;
     }
     $v = f(C);
     $v = f(D);
+    $v = f(c);  // undefined
+    $v = f(Foo);
+    $v = f(foo);  // also undefined
+    $v = f(Bar);
+    $v = f(UndeclaredConst);
 }

--- a/tests/files/src/0288_use_relative_namespace_function.php
+++ b/tests/files/src/0288_use_relative_namespace_function.php
@@ -1,0 +1,27 @@
+<?php
+// Tests for issue #510
+namespace A510\Inner {
+    function lowercasefn() {}
+    function mixedCaseFn() {}
+    function GroupUseFn() {}
+    const C = 42;
+    const D = 24;
+    const Foo = 24;
+    const bar = 24;
+}
+
+namespace B510 {
+    use A510 as B510_Alias;
+    use A510\Inner;  // TODO: Aliases?
+    use \A510\Inner\{function GroupUseFn, function MissingGroupUseFn};
+    function f510() {
+        B510_Alias\Inner\lowercaseFn();
+        B510_Alias\Inner\missingThisFn();
+        groupUseFn();  // fine
+        MissingGroupUseFn();  // should report an error
+        mixedCaseFn();  // should fail, this was not imported
+        A510\Inner\mixedCaseFn();
+        Inner\mixedCaseFn();
+        Inner\missingFn();  // should error
+    }
+}


### PR DESCRIPTION
Fixes #509 and adds tests
(Phan can't detect constants relative to `use` namespaces)
Fixes #510 and adds tests
(Phan can't detect functions relative to `use` namespaces)

Global constants need to be stored and fetched in a case insensitive
manner. They are case sensitive, unless define()
passes $case_insensitive = true.
- Suggest just fixing the codebase instead of supporting that use case

Hardcode types for reserved constants.
Prepare for moving away from defined() to access types of constants,
since phan defines its own constants and constants may be imported with
aliased names.
- Phan defines some user-defined constants such as EXIT_SUCCESS
- Not intending to finish moving away in this PR.
  If I did, phan would complain about constants used in default values
  of parse phase ($status = EXIT_SUCCESS)
- This allows more flexibility in the future to substitute the value of
  constants from stubs/different environments.

Add canonicalLookupKey - canonicalName is already used to generate
easily readable issue messages
(It's overridden, but it's always `return $name`. Could be cleaned up
in a separate PR.)