### PR TITLE
Improve PhanParam*RealMismatch error messages, fix bugs.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,7 +4,8 @@ Phan NEWS
 -----------------------
 
 New Features (Analysis)
-+ Add `PhanParamSignatureRealMismatch`, which ignores phpdoc types and imitates PHP's inheritance warning/error checks as closely as possible. (Issue #374)
++ Add `PhanParamSignatureRealMismatch*` (e.g. `ParamSignatureRealMismatchTooManyRequiredParameters`),
+  which ignores phpdoc types and imitates PHP's inheritance warning/error checks as closely as possible. (Issue #374)
   This has a much lower rate of false positives than `PhanParamSignatureMismatch`, which is based on Liskov Substitution Principle and also accounts for phpdoc types.
   (`PhanParamSignatureMismatch` continues to exist)
 + Create `PhanUndeclaredStaticProperty` (Issue #610)

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -357,89 +357,130 @@ class ParameterTypesAnalyzer
         // type parameters we may have
         $o_return_union_type = $o_method->getRealReturnType();
 
-        // Determine if the signatures match up
-        $signatures_match = true;
-        $signature_error_cause = '';
-
         // Make sure the count of parameters matches
         if ($method->getNumberOfRequiredRealParameters()
             > $o_method->getNumberOfRequiredRealParameters()
         ) {
-            $signatures_match = false;
-            $signature_error_cause = 'method override has more required parameters';
+            self::emitSignatureRealMismatchIssue(
+                $code_base,
+                $method,
+                $o_method,
+                Issue::ParamSignatureRealMismatchTooManyRequiredParameters,
+                Issue::ParamSignatureRealMismatchTooManyRequiredParametersInternal,
+                $method->getNumberOfRequiredRealParameters(),
+                $o_method->getNumberOfRequiredRealParameters()
+            );
+            return;
         } else if ($method->getNumberOfRealParameters()
             < $o_method->getNumberOfRealParameters()
         ) {
-            $signatures_match = false;
-            $signature_error_cause = 'method override has fewer parameters';
-        // If parameter counts match, check their types
-        } else {
-            foreach ($method->getRealParameterList() as $i => $parameter) {
-                $offset = $i + 1;
-                // TODO: check if variadic
-                if (!isset($o_parameter_list[$i])) {
-                    continue;
+            self::emitSignatureRealMismatchIssue(
+                $code_base,
+                $method,
+                $o_method,
+                Issue::ParamSignatureRealMismatchTooFewParameters,
+                Issue::ParamSignatureRealMismatchTooFewParametersInternal,
+                $method->getNumberOfRealParameters(),
+                $o_method->getNumberOfRealParameters()
+            );
+            return;
+            // If parameter counts match, check their types
+        }
+        foreach ($method->getRealParameterList() as $i => $parameter) {
+            $offset = $i + 1;
+            // TODO: check if variadic
+            if (!isset($o_parameter_list[$i])) {
+                continue;
+            }
+
+            // TODO: check that the variadic types match up?
+            $o_parameter = $o_parameter_list[$i];
+
+            // Changing pass by reference is not ok
+            // @see https://3v4l.org/Utuo8
+            if ($parameter->isPassByReference() != $o_parameter->isPassByReference()) {
+                $is_reference = $parameter->isPassByReference();
+                self::emitSignatureRealMismatchIssue(
+                    $code_base,
+                    $method,
+                    $o_method,
+                    ($is_reference ? Issue::ParamSignatureRealMismatchParamIsReference         : Issue::ParamSignatureRealMismatchParamIsNotReference),
+                    ($is_reference ? Issue::ParamSignatureRealMismatchParamIsReferenceInternal : Issue::ParamSignatureRealMismatchParamIsNotReferenceInternal),
+                    $offset
+                );
+                return;
+            }
+
+            // Changing variadic to/from non-variadic is not ok?
+            // (Not absolutely sure about that)
+            if ($parameter->isVariadic() != $o_parameter->isVariadic()) {
+                $is_variadic = $parameter->isVariadic();
+                self::emitSignatureRealMismatchIssue(
+                    $code_base,
+                    $method,
+                    $o_method,
+                    ($is_variadic ? Issue::ParamSignatureRealMismatchParamVariadic         : Issue::ParamSignatureRealMismatchParamNotVariadic),
+                    ($is_variadic ? Issue::ParamSignatureRealMismatchParamVariadicInternal : Issue::ParamSignatureRealMismatchParamNotVariadicInternal),
+                    $offset
+                );
+                return;
+            }
+
+            // Either 0 or both of the params must have types for the signatures to be compatible.
+            $o_parameter_union_type = $o_parameter->getUnionType();
+            $parameter_union_type = $parameter->getUnionType();
+            if ($parameter_union_type->isEmpty() != $o_parameter_union_type->isEmpty()) {
+                if ($parameter_union_type->isEmpty()) {
+                    self::emitSignatureRealMismatchIssue(
+                        $code_base,
+                        $method,
+                        $o_method,
+                        Issue::ParamSignatureRealMismatchHasNoParamType,
+                        Issue::ParamSignatureRealMismatchHasNoParamTypeInternal,
+                        $offset,
+                        (string)$o_parameter_union_type
+                    );
+                    return;
+                } else {
+                    self::emitSignatureRealMismatchIssue(
+                        $code_base,
+                        $method,
+                        $o_method,
+                        Issue::ParamSignatureRealMismatchHasParamType,
+                        Issue::ParamSignatureRealMismatchHasParamTypeInternal,
+                        $offset,
+                        (string)$parameter_union_type
+                    );
+                    return;
                 }
+            }
 
-                // TODO: check that the variadic types match up?
-                $o_parameter = $o_parameter_list[$i];
+            // If both have types, make sure they are identical.
+            // Non-nullable param types can be substituted with the nullable equivalents.
+            // E.g. A::foo(?int $x) can override BaseClass::foo(int $x)
+            if (!$parameter_union_type->isEmpty()) {
+                if (!$o_parameter_union_type->isEqualTo($parameter_union_type) &&
+                    !($parameter_union_type->containsNullable() && $o_parameter_union_type->isEqualTo($parameter_union_type->nonNullableClone()))
+                ) {
+                    // There is one exception to this in php 7.1 - the pseudo-type "iterable" can replace ArrayAccess/array in a subclass
+                    // TODO: Traversable and array work, but Iterator doesn't. Check for those specific cases?
+                    $is_exception_to_rule = $parameter_union_type->hasIterable() &&
+                        $o_parameter_union_type->hasIterable() &&
+                        ($parameter_union_type->hasType(IterableType::instance(true)) ||
+                         $parameter_union_type->hasType(IterableType::instance(false)) && !$o_parameter_union_type->containsNullable());
 
-                // Changing pass by reference is not ok
-                // @see https://3v4l.org/Utuo8
-                if ($parameter->isPassByReference() != $o_parameter->isPassByReference()) {
-                    if ($parameter->isPassByReference()) {
-                        $signature_error_cause = "non-reference parameter #$offset was overridden with a reference argument";
-                    } else {
-                        $signature_error_cause = "reference parameter #$offset was overridden with a non-reference argument";
-                    }
-                    $signatures_match = false;
-                    break;
-                }
-
-                // Changing variadic to/from non-variadic is not ok?
-                // (Not absolutely sure about that)
-                if ($parameter->isVariadic() != $o_parameter->isVariadic()) {
-                    if ($parameter->isVariadic()) {
-                        $signature_error_cause = "non-variadic parameter #$offset was replaced with a variadic parameter";
-                    } else {
-                        $signature_error_cause = "variadic parameter #$offset was replaced with a non-variadic parameter";
-                    }
-                    $signatures_match = false;
-                    break;
-                }
-
-                // Either 0 or both of the params must have types for the signatures to be compatible.
-                $o_parameter_union_type = $o_parameter->getUnionType();
-                $parameter_union_type = $parameter->getUnionType();
-                if ($parameter_union_type->isEmpty() != $o_parameter_union_type->isEmpty()) {
-                    if ($parameter_union_type->isEmpty()) {
-                        $signature_error_cause = "parameter #$offset has no type, but original has type($o_parameter_union_type)";
-                    } else {
-                        $signature_error_cause = "parameter #$offset has type($parameter_union_type), but original does not";
-                    }
-                    $signatures_match = false;
-                    break;
-                }
-
-                // If both have types, make sure they are identical.
-                // Non-nullable param types can be substituted with the nullable equivalents.
-                // E.g. A::foo(?int $x) can override BaseClass::foo(int $x)
-                if (!$parameter_union_type->isEmpty()) {
-                    if (!$o_parameter_union_type->isEqualTo($parameter_union_type) &&
-                        !($parameter_union_type->containsNullable() && $o_parameter_union_type->isEqualTo($parameter_union_type->nonNullableClone()))
-                    ) {
-                        // There is one exception to this in php 7.1 - the pseudo-type "iterable" can replace ArrayAccess/array in a subclass
-                        // TODO: Traversable and array work, but Iterator doesn't. Check for those specific cases?
-                        $is_exception_to_rule = $parameter_union_type->hasIterable() &&
-                            $o_parameter_union_type->hasIterable() &&
-                            ($parameter_union_type->hasType(IterableType::instance(true)) ||
-                             $parameter_union_type->hasType(IterableType::instance(false)) && !$o_parameter_union_type->containsNullable());
-
-                        if (!$is_exception_to_rule) {
-                            $signature_error_cause = "parameter #$offset of type $parameter_union_type cannot replace original parameter of type $o_parameter_union_type";
-                            $signatures_match = false;
-                            break;
-                        }
+                    if (!$is_exception_to_rule) {
+                        self::emitSignatureRealMismatchIssue(
+                            $code_base,
+                            $method,
+                            $o_method,
+                            Issue::ParamSignatureRealMismatchParamType,
+                            Issue::ParamSignatureRealMismatchParamTypeInternal,
+                            $offset,
+                            (string)$parameter_union_type,
+                            (string)$o_parameter_union_type
+                        );
+                        return;
                     }
                 }
             }
@@ -452,35 +493,55 @@ class ParameterTypesAnalyzer
             if (!($o_return_union_type->isEqualTo($return_union_type) || (
                 $o_return_union_type->containsNullable() && !($o_return_union_type->nonNullableClone()->isEqualTo($return_union_type)))
                 )) {
-                    $signature_error_cause = "method returning '$return_union_type' cannot override method returning '$o_return_union_type'";
-                    $signatures_match = false;
+
+                self::emitSignatureRealMismatchIssue(
+                    $code_base,
+                    $method,
+                    $o_method,
+                    Issue::ParamSignatureRealMismatchReturnType,
+                    Issue::ParamSignatureRealMismatchReturnTypeInternal,
+                    (string)$return_union_type,
+                    (string)$o_return_union_type
+                );
+                return;
             }
         }
+    }
 
-        if (!$signatures_match) {
-            if ($o_method->isPHPInternal()) {
-                Issue::maybeEmit(
-                    $code_base,
-                    $method->getContext(),
-                    Issue::ParamSignatureRealMismatchInternal,
-                    $method->getFileRef()->getLineNumberStart(),
-                    $method->toRealSignatureString(),
-                    $o_method->toRealSignatureString(),
-                    $signature_error_cause
-                );
-            } else {
-                Issue::maybeEmit(
-                    $code_base,
-                    $method->getContext(),
-                    Issue::ParamSignatureRealMismatch,
-                    $method->getFileRef()->getLineNumberStart(),
-                    $method->toRealSignatureString(),
-                    $o_method->toRealSignatureString(),
-                    $signature_error_cause,
+    /**
+     * Emit an
+     *
+     * @param CodeBase $code_base
+     * @param Method $method
+     * @param Method $o_method the overridden method
+     * @param string $issue_type the ParamSignatureRealMismatch* (issue type if overriding user-defined method)
+     * @param string $internal_issue_type the ParamSignatureRealMismatch* (issue type if overriding internal method)
+     * @param int|string ...$args
+     */
+    private static function emitSignatureRealMismatchIssue(CodeBase $code_base, Method $method, Method $o_method, string $issue_type, string $internal_issue_type, ...$args) {
+        if ($o_method->isPHPInternal()) {
+            Issue::maybeEmit(
+                $code_base,
+                $method->getContext(),
+                $internal_issue_type,
+                $method->getFileRef()->getLineNumberStart(),
+                $method->toRealSignatureString(),
+                $o_method->toRealSignatureString(),
+                ...$args
+            );
+        } else {
+            Issue::maybeEmit(
+                $code_base,
+                $method->getContext(),
+                $issue_type,
+                $method->getFileRef()->getLineNumberStart(),
+                $method->toRealSignatureString(),
+                $o_method->toRealSignatureString(),
+                ...array_merge($args, [
                     $o_method->getFileRef()->getFile(),
-                    $o_method->getFileRef()->getLineNumberStart()
-                );
-            }
+                    $o_method->getFileRef()->getLineNumberStart(),
+                ])
+            );
         }
     }
 }

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -892,7 +892,7 @@ class Issue
                 self::SEVERITY_CRITICAL,
                 "Declaration of {METHOD} should be compatible with {METHOD} (method returning '{TYPE}' cannot override method returning '{TYPE}') defined in {FILE}:{LINE}",
                 self::REMEDIATION_B,
-                7015
+                7013
             ),
             new Issue(
                 self::ParamSignatureRealMismatchReturnTypeInternal,
@@ -900,7 +900,7 @@ class Issue
                 self::SEVERITY_CRITICAL,
                 "Declaration of {METHOD} should be compatible with internal {METHOD} (method returning '{TYPE}' cannot override method returning '{TYPE}') defined in {FILE}:{LINE}",
                 self::REMEDIATION_B,
-                7016
+                7014
             ),
             new Issue(
                 self::ParamSignatureRealMismatchParamType,
@@ -908,7 +908,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Declaration of {METHOD} should be compatible with {METHOD} (parameter #{INDEX} of type '{TYPE}' cannot replace original parameter of type '{TYPE}') defined in {FILE}:{LINE}",
                 self::REMEDIATION_B,
-                7017
+                7015
             ),
             new Issue(
                 self::ParamSignatureRealMismatchParamTypeInternal,
@@ -916,7 +916,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Declaration of {METHOD} should be compatible with internal {METHOD} (parameter #{INDEX} of type '{TYPE}' cannot replace original parameter of type '{TYPE}') defined in {FILE}:{LINE}",
                 self::REMEDIATION_B,
-                7018
+                7016
             ),
             new Issue(
                 self::ParamSignatureRealMismatchHasParamType,
@@ -924,7 +924,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Declaration of {METHOD} should be compatible with {METHOD} (parameter #{INDEX} of has type '{TYPE}' cannot replace original parameter with no type) defined in {FILE}:{LINE}",
                 self::REMEDIATION_B,
-                7019
+                7017
             ),
             new Issue(
                 self::ParamSignatureRealMismatchHasParamTypeInternal,
@@ -932,7 +932,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Declaration of {METHOD} should be compatible with internal {METHOD} (parameter #{INDEX} of has type '{TYPE}' cannot replace original parameter with no type) defined in {FILE}:{LINE}",
                 self::REMEDIATION_B,
-                7020
+                7018
             ),
             new Issue(
                 self::ParamSignatureRealMismatchHasNoParamType,
@@ -940,7 +940,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Declaration of {METHOD} should be compatible with {METHOD} (parameter #{INDEX} with no type cannot replace original parameter with type '{TYPE}') defined in {FILE}:{LINE}",
                 self::REMEDIATION_B,
-                7021
+                7019
             ),
             new Issue(
                 self::ParamSignatureRealMismatchHasNoParamTypeInternal,
@@ -948,7 +948,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Declaration of {METHOD} should be compatible with internal {METHOD} (parameter #{INDEX} with no type cannot replace original parameter with type '{TYPE}') defined in {FILE}:{LINE}",
                 self::REMEDIATION_B,
-                7022
+                7020
             ),
             new Issue(
                 self::ParamSignatureRealMismatchParamVariadic,
@@ -956,7 +956,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Declaration of {METHOD} should be compatible with {METHOD} (parameter #{INDEX} is a variadic parameter replacing a non-variadic parameter) defined in {FILE}:{LINE}",
                 self::REMEDIATION_B,
-                7023
+                7021
             ),
             new Issue(
                 self::ParamSignatureRealMismatchParamVariadicInternal,
@@ -964,7 +964,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Declaration of {METHOD} should be compatible with internal {METHOD} (parameter #{INDEX} is a variadic parameter replacing a non-variadic parameter) defined in {FILE}:{LINE}",
                 self::REMEDIATION_B,
-                7024
+                7022
             ),
             new Issue(
                 self::ParamSignatureRealMismatchParamNotVariadic,
@@ -972,7 +972,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Declaration of {METHOD} should be compatible with {METHOD} (parameter #{INDEX} is a non-variadic parameter replacing a variadic parameter) defined in {FILE}:{LINE}",
                 self::REMEDIATION_B,
-                7025
+                7023
             ),
             new Issue(
                 self::ParamSignatureRealMismatchParamNotVariadicInternal,
@@ -980,7 +980,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Declaration of {METHOD} should be compatible with internal {METHOD} (parameter #{INDEX} is a non-variadic parameter replacing a variadic parameter) defined in {FILE}:{LINE}",
                 self::REMEDIATION_B,
-                7026
+                7024
             ),
             new Issue(
                 self::ParamSignatureRealMismatchParamIsReference,
@@ -988,7 +988,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Declaration of {METHOD} should be compatible with {METHOD} (parameter #{INDEX} is a reference parameter overriding a non-reference parameter) defined in {FILE}:{LINE}",
                 self::REMEDIATION_B,
-                7027
+                7025
             ),
             new Issue(
                 self::ParamSignatureRealMismatchParamIsReferenceInternal,
@@ -996,7 +996,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Declaration of {METHOD} should be compatible with internal {METHOD} (parameter #{INDEX} is a reference parameter overriding a non-reference parameter) defined in {FILE}:{LINE}",
                 self::REMEDIATION_B,
-                7028
+                7026
             ),
             new Issue(
                 self::ParamSignatureRealMismatchParamIsNotReference,
@@ -1004,7 +1004,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Declaration of {METHOD} should be compatible with {METHOD} (parameter #{INDEX} is a non-reference parameter overriding a reference parameter) defined in {FILE}:{LINE}",
                 self::REMEDIATION_B,
-                7029
+                7027
             ),
             new Issue(
                 self::ParamSignatureRealMismatchParamIsNotReferenceInternal,
@@ -1012,7 +1012,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Declaration of {METHOD} should be compatible with internal {METHOD} (parameter #{INDEX} is a non-reference parameter overriding a reference parameter) defined in {FILE}:{LINE}",
                 self::REMEDIATION_B,
-                7030
+                7028
             ),
             new Issue(
                 self::ParamSignatureRealMismatchTooFewParameters,
@@ -1020,7 +1020,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Declaration of {METHOD} should be compatible with {METHOD} (the method override accepts {COUNT} parameters, but the overridden method can accept {COUNT}) defined in {FILE}:{LINE}",
                 self::REMEDIATION_B,
-                7031
+                7029
             ),
             new Issue(
                 self::ParamSignatureRealMismatchTooFewParametersInternal,
@@ -1028,7 +1028,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Declaration of {METHOD} should be compatible with internal {METHOD} (the method override accepts {COUNT} parameters, but the overridden method can accept {COUNT}) defined in {FILE}:{LINE}",
                 self::REMEDIATION_B,
-                7032
+                7030
             ),
             new Issue(
                 self::ParamSignatureRealMismatchTooManyRequiredParameters,
@@ -1036,7 +1036,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Declaration of {METHOD} should be compatible with {METHOD} (the method override requires {COUNT} parameters, but the overridden method requires only {COUNT}) defined in {FILE}:{LINE}",
                 self::REMEDIATION_B,
-                7033
+                7031
             ),
             new Issue(
                 self::ParamSignatureRealMismatchTooManyRequiredParametersInternal,

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -92,9 +92,28 @@ class Issue
     const ParamTypeMismatch         = 'PhanParamTypeMismatch';
     const ParamSignatureMismatch    = 'PhanParamSignatureMismatch';
     const ParamSignatureMismatchInternal = 'PhanParamSignatureMismatchInternal';
-    const ParamSignatureRealMismatch    = 'PhanParamSignatureRealMismatch';
-    const ParamSignatureRealMismatchInternal = 'PhanParamSignatureRealMismatchInternal';
     const ParamRedefined            = 'PhanParamRedefined';
+
+    const ParamSignatureRealMismatchReturnType                        = 'PhanParamSignatureRealMismatch';
+    const ParamSignatureRealMismatchReturnTypeInternal                = 'PhanParamSignatureRealMismatchInternal';
+    const ParamSignatureRealMismatchTooManyRequiredParameters         = 'PhanParamSignatureRealMismatchTooManyRequiredParameters';
+    const ParamSignatureRealMismatchTooManyRequiredParametersInternal = 'PhanParamSignatureRealMismatchTooManyRequiredParametersInternal';
+    const ParamSignatureRealMismatchTooFewParameters                  = 'PhanParamSignatureRealMismatchTooFewParameters';
+    const ParamSignatureRealMismatchTooFewParametersInternal          = 'PhanParamSignatureRealMismatchTooFewParametersInternal';
+    const ParamSignatureRealMismatchHasParamType                      = 'PhanParamSignatureRealMismatchHasParamType';
+    const ParamSignatureRealMismatchHasParamTypeInternal              = 'PhanParamSignatureRealMismatchHasParamTypeInternal';
+    const ParamSignatureRealMismatchHasNoParamType                    = 'PhanParamSignatureRealMismatchHasNoParamType';
+    const ParamSignatureRealMismatchHasNoParamTypeInternal            = 'PhanParamSignatureRealMismatchHasNoParamTypeInternal';
+    const ParamSignatureRealMismatchParamIsReference                  = 'PhanParamSignatureRealMismatchParamIsReference';
+    const ParamSignatureRealMismatchParamIsReferenceInternal          = 'PhanParamSignatureRealMismatchParamIsReferenceInternal';
+    const ParamSignatureRealMismatchParamIsNotReference               = 'PhanParamSignatureRealMismatchParamIsNotReference';
+    const ParamSignatureRealMismatchParamIsNotReferenceInternal       = 'PhanParamSignatureRealMismatchParamIsNotReferenceInternal';
+    const ParamSignatureRealMismatchParamVariadic                     = 'PhanParamSignatureRealMismatchParamVariadic';
+    const ParamSignatureRealMismatchParamVariadicInternal             = 'PhanParamSignatureRealMismatchParamVariadicInternal';
+    const ParamSignatureRealMismatchParamNotVariadic                  = 'PhanParamSignatureRealMismatchParamNotVariadic';
+    const ParamSignatureRealMismatchParamNotVariadicInternal          = 'PhanParamSignatureRealMismatchParamNotVariadicInternal';
+    const ParamSignatureRealMismatchParamType                         = 'PhanParamSignatureRealMismatchParamType';
+    const ParamSignatureRealMismatchParamTypeInternal                 = 'PhanParamSignatureRealMismatchParamTypeInternal';
 
     // Issue::CATEGORY_NOOP
     const NoopArray                 = 'PhanNoopArray';
@@ -865,22 +884,167 @@ class Issue
                 7012
             ),
             // TODO: Optionally, change the other message to say that it's based off of phpdoc and LSP in a future PR.
+            // NOTE: Incompatibilities in the param list are SEVERITY_NORMAL, because the php interpreter emits a notice.
+            // Incompatibilities in the return types are SEVERITY_CRITICAL, because the php interpreter will throw an Error.
             new Issue(
-                self::ParamSignatureRealMismatch,
+                self::ParamSignatureRealMismatchReturnType,
                 self::CATEGORY_PARAMETER,
                 self::SEVERITY_CRITICAL,
-                "Declaration of %s should be compatible with %s (reason: %s) defined in %s:%d",
+                "Declaration of {METHOD} should be compatible with {METHOD} (method returning '{TYPE}' cannot override method returning '{TYPE}') defined in {FILE}:{LINE}",
                 self::REMEDIATION_B,
-                7013
+                7015
             ),
-            // NOTE: some extensions don't define arg info
             new Issue(
-                self::ParamSignatureRealMismatchInternal,
+                self::ParamSignatureRealMismatchReturnTypeInternal,
                 self::CATEGORY_PARAMETER,
                 self::SEVERITY_CRITICAL,
-                "Declaration of %s should be compatible with internal %s (reason: %s)",
+                "Declaration of {METHOD} should be compatible with internal {METHOD} (method returning '{TYPE}' cannot override method returning '{TYPE}') defined in {FILE}:{LINE}",
                 self::REMEDIATION_B,
-                7014
+                7016
+            ),
+            new Issue(
+                self::ParamSignatureRealMismatchParamType,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_NORMAL,
+                "Declaration of {METHOD} should be compatible with {METHOD} (parameter #{INDEX} of type '{TYPE}' cannot replace original parameter of type '{TYPE}') defined in {FILE}:{LINE}",
+                self::REMEDIATION_B,
+                7017
+            ),
+            new Issue(
+                self::ParamSignatureRealMismatchParamTypeInternal,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_NORMAL,
+                "Declaration of {METHOD} should be compatible with internal {METHOD} (parameter #{INDEX} of type '{TYPE}' cannot replace original parameter of type '{TYPE}') defined in {FILE}:{LINE}",
+                self::REMEDIATION_B,
+                7018
+            ),
+            new Issue(
+                self::ParamSignatureRealMismatchHasParamType,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_NORMAL,
+                "Declaration of {METHOD} should be compatible with {METHOD} (parameter #{INDEX} of has type '{TYPE}' cannot replace original parameter with no type) defined in {FILE}:{LINE}",
+                self::REMEDIATION_B,
+                7019
+            ),
+            new Issue(
+                self::ParamSignatureRealMismatchHasParamTypeInternal,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_NORMAL,
+                "Declaration of {METHOD} should be compatible with internal {METHOD} (parameter #{INDEX} of has type '{TYPE}' cannot replace original parameter with no type) defined in {FILE}:{LINE}",
+                self::REMEDIATION_B,
+                7020
+            ),
+            new Issue(
+                self::ParamSignatureRealMismatchHasNoParamType,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_NORMAL,
+                "Declaration of {METHOD} should be compatible with {METHOD} (parameter #{INDEX} with no type cannot replace original parameter with type '{TYPE}') defined in {FILE}:{LINE}",
+                self::REMEDIATION_B,
+                7021
+            ),
+            new Issue(
+                self::ParamSignatureRealMismatchHasNoParamTypeInternal,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_NORMAL,
+                "Declaration of {METHOD} should be compatible with internal {METHOD} (parameter #{INDEX} with no type cannot replace original parameter with type '{TYPE}') defined in {FILE}:{LINE}",
+                self::REMEDIATION_B,
+                7022
+            ),
+            new Issue(
+                self::ParamSignatureRealMismatchParamVariadic,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_NORMAL,
+                "Declaration of {METHOD} should be compatible with {METHOD} (parameter #{INDEX} is a variadic parameter replacing a non-variadic parameter) defined in {FILE}:{LINE}",
+                self::REMEDIATION_B,
+                7023
+            ),
+            new Issue(
+                self::ParamSignatureRealMismatchParamVariadicInternal,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_NORMAL,
+                "Declaration of {METHOD} should be compatible with internal {METHOD} (parameter #{INDEX} is a variadic parameter replacing a non-variadic parameter) defined in {FILE}:{LINE}",
+                self::REMEDIATION_B,
+                7024
+            ),
+            new Issue(
+                self::ParamSignatureRealMismatchParamNotVariadic,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_NORMAL,
+                "Declaration of {METHOD} should be compatible with {METHOD} (parameter #{INDEX} is a non-variadic parameter replacing a variadic parameter) defined in {FILE}:{LINE}",
+                self::REMEDIATION_B,
+                7025
+            ),
+            new Issue(
+                self::ParamSignatureRealMismatchParamNotVariadicInternal,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_NORMAL,
+                "Declaration of {METHOD} should be compatible with internal {METHOD} (parameter #{INDEX} is a non-variadic parameter replacing a variadic parameter) defined in {FILE}:{LINE}",
+                self::REMEDIATION_B,
+                7026
+            ),
+            new Issue(
+                self::ParamSignatureRealMismatchParamIsReference,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_NORMAL,
+                "Declaration of {METHOD} should be compatible with {METHOD} (parameter #{INDEX} is a reference parameter overriding a non-reference parameter) defined in {FILE}:{LINE}",
+                self::REMEDIATION_B,
+                7027
+            ),
+            new Issue(
+                self::ParamSignatureRealMismatchParamIsReferenceInternal,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_NORMAL,
+                "Declaration of {METHOD} should be compatible with internal {METHOD} (parameter #{INDEX} is a reference parameter overriding a non-reference parameter) defined in {FILE}:{LINE}",
+                self::REMEDIATION_B,
+                7028
+            ),
+            new Issue(
+                self::ParamSignatureRealMismatchParamIsNotReference,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_NORMAL,
+                "Declaration of {METHOD} should be compatible with {METHOD} (parameter #{INDEX} is a non-reference parameter overriding a reference parameter) defined in {FILE}:{LINE}",
+                self::REMEDIATION_B,
+                7029
+            ),
+            new Issue(
+                self::ParamSignatureRealMismatchParamIsNotReferenceInternal,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_NORMAL,
+                "Declaration of {METHOD} should be compatible with internal {METHOD} (parameter #{INDEX} is a non-reference parameter overriding a reference parameter) defined in {FILE}:{LINE}",
+                self::REMEDIATION_B,
+                7030
+            ),
+            new Issue(
+                self::ParamSignatureRealMismatchTooFewParameters,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_NORMAL,
+                "Declaration of {METHOD} should be compatible with {METHOD} (the method override accepts {COUNT} parameters, but the overridden method can accept {COUNT}) defined in {FILE}:{LINE}",
+                self::REMEDIATION_B,
+                7031
+            ),
+            new Issue(
+                self::ParamSignatureRealMismatchTooFewParametersInternal,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_NORMAL,
+                "Declaration of {METHOD} should be compatible with internal {METHOD} (the method override accepts {COUNT} parameters, but the overridden method can accept {COUNT}) defined in {FILE}:{LINE}",
+                self::REMEDIATION_B,
+                7032
+            ),
+            new Issue(
+                self::ParamSignatureRealMismatchTooManyRequiredParameters,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_NORMAL,
+                "Declaration of {METHOD} should be compatible with {METHOD} (the method override requires {COUNT} parameters, but the overridden method requires only {COUNT}) defined in {FILE}:{LINE}",
+                self::REMEDIATION_B,
+                7033
+            ),
+            new Issue(
+                self::ParamSignatureRealMismatchTooManyRequiredParametersInternal,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_NORMAL,
+                "Declaration of {METHOD} should be compatible with internal {METHOD} (the method override requires {COUNT} parameters, but the overridden method requires only {COUNT}) defined in {FILE}:{LINE}",
+                self::REMEDIATION_B,
+                7032
             ),
 
             // Issue::CATEGORY_NOOP
@@ -1199,13 +1363,13 @@ class Issue
                 self::REMEDIATION_B,
                 15004
             ),
-
-
         ];
 
         $error_map = [];
         foreach ($error_list as $i => $error) {
-            $error_map[$error->getType()] = $error;
+            $error_type = $error->getType();
+            assert(!array_key_exists($error_type, $error_map), "Issue of type $error_type has multiple definitions");
+            $error_map[$error_type] = $error;
         }
 
         return $error_map;

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -869,7 +869,7 @@ class Issue
                 self::ParamSignatureRealMismatch,
                 self::CATEGORY_PARAMETER,
                 self::SEVERITY_CRITICAL,
-                "Declaration of %s should be compatible with %s defined in %s:%d",
+                "Declaration of %s should be compatible with %s (reason: %s) defined in %s:%d",
                 self::REMEDIATION_B,
                 7013
             ),
@@ -878,7 +878,7 @@ class Issue
                 self::ParamSignatureRealMismatchInternal,
                 self::CATEGORY_PARAMETER,
                 self::SEVERITY_CRITICAL,
-                "Declaration of %s should be compatible with internal %s",
+                "Declaration of %s should be compatible with internal %s (reason: %s)",
                 self::REMEDIATION_B,
                 7014
             ),

--- a/tests/files/expected/0124_override_signature.php.expected
+++ b/tests/files/expected/0124_override_signature.php.expected
@@ -1,21 +1,21 @@
 %s:6 PhanParamSignatureMismatch Declaration of function f() should be compatible with function f(int $a) defined in %s:3
-%s:6 PhanParamSignatureRealMismatch Declaration of function f() should be compatible with function f(int $a) (reason: method override has fewer parameters) defined in %s:3
+%s:6 PhanParamSignatureRealMismatchTooFewParameters Declaration of function f() should be compatible with function f(int $a) (the method override accepts 0 parameters, but the overridden method can accept 1) defined in %s:3
 %s:12 PhanParamSignatureMismatch Declaration of function f(int $a, int $b) should be compatible with function f(int $a) defined in %s:3
-%s:12 PhanParamSignatureRealMismatch Declaration of function f(int $a, int $b) should be compatible with function f(int $a) (reason: method override has more required parameters) defined in %s:3
+%s:12 PhanParamSignatureRealMismatchTooManyRequiredParameters Declaration of function f(int $a, int $b) should be compatible with function f(int $a) (the method override requires 2 parameters, but the overridden method requires only 1) defined in ./tests/files/src/0124_override_signature.php:3
 %s:15 PhanParamSignatureMismatch Declaration of function f(string $a) should be compatible with function f(int $a) defined in %s:3
-%s:15 PhanParamSignatureRealMismatch Declaration of function f(string $a) should be compatible with function f(int $a) (reason: parameter #1 of type string cannot replace original parameter of type int) defined in %s:3
+%s:15 PhanParamSignatureRealMismatchParamType Declaration of function f(string $a) should be compatible with function f(int $a) (parameter #1 of type 'string' cannot replace original parameter of type 'int') defined in %s:3
 %s:18 PhanParamSignatureMismatch Declaration of function f($a) should be compatible with function f(int $a) defined in %s:3
-%s:18 PhanParamSignatureRealMismatch Declaration of function f($a) should be compatible with function f(int $a) (reason: parameter #1 has no type, but original has type(int)) defined in %s:3
+%s:18 PhanParamSignatureRealMismatchHasNoParamType Declaration of function f($a) should be compatible with function f(int $a) (parameter #1 with no type cannot replace original parameter with type 'int') defined in %s:3
 %s:25 PhanParamSignatureMismatch Declaration of function g() : int should be compatible with function g() : string defined in %s:22
-%s:25 PhanParamSignatureRealMismatch Declaration of function g() : int should be compatible with function g() : string (reason: method returning 'int' cannot override method returning 'string') defined in %s:22
-%s:28 PhanParamSignatureRealMismatch Declaration of function g() should be compatible with function g() : string (reason: method returning '' cannot override method returning 'string') defined in %s:22
-%s:35 PhanParamSignatureRealMismatch Declaration of function h(int $a) should be compatible with function h($a) (reason: parameter #1 has type(int), but original does not) defined in %s:32
+%s:25 PhanParamSignatureRealMismatch Declaration of function g() : int should be compatible with function g() : string (method returning 'int' cannot override method returning 'string') defined in %s:22
+%s:28 PhanParamSignatureRealMismatch Declaration of function g() should be compatible with function g() : string (method returning '' cannot override method returning 'string') defined in %s:22
+%s:35 PhanParamSignatureRealMismatchHasParamType Declaration of function h(int $a) should be compatible with function h($a) (parameter #1 of has type 'int' cannot replace original parameter with no type) defined in %s:32
 %s:50 PhanParamSignatureMismatch Declaration of function i($a) should be compatible with function i($a, mixed|string $b = default) defined in %s:46
-%s:50 PhanParamSignatureRealMismatch Declaration of function i($a) should be compatible with function i($a, $b = default) (reason: method override has fewer parameters) defined in %s:46
+%s:50 PhanParamSignatureRealMismatchTooFewParameters Declaration of function i($a) should be compatible with function i($a, $b = default) (the method override accepts 1 parameters, but the overridden method can accept 2) defined in ./tests/files/src/0124_override_signature.php:46
 %s:58 PhanParamSignatureMismatch Declaration of function j() should be compatible with function &j() defined in %s:54
 %s:67 PhanParamSignatureMismatch Declaration of function k(&$a) should be compatible with function k($a) defined in %s:62
-%s:67 PhanParamSignatureRealMismatch Declaration of function k(&$a) should be compatible with function k($a) (reason: non-reference parameter #1 was overridden with a reference argument) defined in %s:62
+%s:67 PhanParamSignatureRealMismatchParamIsReference Declaration of function k(&$a) should be compatible with function k($a) (parameter #1 is a reference parameter overriding a non-reference parameter) defined in %s:62
 %s:68 PhanParamSignatureMismatch Declaration of function l($b) should be compatible with function l(&$b) defined in %s:63
-%s:68 PhanParamSignatureRealMismatch Declaration of function l($b) should be compatible with function l(&$b) (reason: reference parameter #1 was overridden with a non-reference argument) defined in %s:63
+%s:68 PhanParamSignatureRealMismatchParamIsNotReference Declaration of function l($b) should be compatible with function l(&$b) (parameter #1 is a non-reference parameter overriding a reference parameter) defined in %s:63
 %s:76 PhanParamSignatureMismatch Declaration of function m($a) should be compatible with function m(mixed $a = null) defined in %s:72
-%s:76 PhanParamSignatureRealMismatch Declaration of function m($a) should be compatible with function m($a = null) (reason: method override has more required parameters) defined in %s:72
+%s:76 PhanParamSignatureRealMismatchTooManyRequiredParameters Declaration of function m($a) should be compatible with function m($a = null) (the method override requires 1 parameters, but the overridden method requires only 0) defined in %s:72

--- a/tests/files/expected/0124_override_signature.php.expected
+++ b/tests/files/expected/0124_override_signature.php.expected
@@ -1,22 +1,21 @@
 %s:6 PhanParamSignatureMismatch Declaration of function f() should be compatible with function f(int $a) defined in %s:3
-%s:6 PhanParamSignatureRealMismatch Declaration of function f() should be compatible with function f(int $a) defined in %s:3
+%s:6 PhanParamSignatureRealMismatch Declaration of function f() should be compatible with function f(int $a) (reason: method override has fewer parameters) defined in %s:3
 %s:12 PhanParamSignatureMismatch Declaration of function f(int $a, int $b) should be compatible with function f(int $a) defined in %s:3
-%s:12 PhanParamSignatureRealMismatch Declaration of function f(int $a, int $b) should be compatible with function f(int $a) defined in %s:3
+%s:12 PhanParamSignatureRealMismatch Declaration of function f(int $a, int $b) should be compatible with function f(int $a) (reason: method override has more required parameters) defined in %s:3
 %s:15 PhanParamSignatureMismatch Declaration of function f(string $a) should be compatible with function f(int $a) defined in %s:3
-%s:15 PhanParamSignatureRealMismatch Declaration of function f(string $a) should be compatible with function f(int $a) defined in %s:3
+%s:15 PhanParamSignatureRealMismatch Declaration of function f(string $a) should be compatible with function f(int $a) (reason: parameter #1 of type string cannot replace original parameter of type int) defined in %s:3
 %s:18 PhanParamSignatureMismatch Declaration of function f($a) should be compatible with function f(int $a) defined in %s:3
-%s:18 PhanParamSignatureRealMismatch Declaration of function f($a) should be compatible with function f(int $a) defined in %s:3
+%s:18 PhanParamSignatureRealMismatch Declaration of function f($a) should be compatible with function f(int $a) (reason: parameter #1 has no type, but original has type(int)) defined in %s:3
 %s:25 PhanParamSignatureMismatch Declaration of function g() : int should be compatible with function g() : string defined in %s:22
-%s:25 PhanParamSignatureRealMismatch Declaration of function g() : int should be compatible with function g() : string defined in %s:22
-%s:28 PhanParamSignatureRealMismatch Declaration of function g() should be compatible with function g() : string defined in %s:22
-%s:35 PhanParamSignatureRealMismatch Declaration of function h(int $a) should be compatible with function h($a) defined in %s:32
+%s:25 PhanParamSignatureRealMismatch Declaration of function g() : int should be compatible with function g() : string (reason: method returning 'int' cannot override method returning 'string') defined in %s:22
+%s:28 PhanParamSignatureRealMismatch Declaration of function g() should be compatible with function g() : string (reason: method returning '' cannot override method returning 'string') defined in %s:22
+%s:35 PhanParamSignatureRealMismatch Declaration of function h(int $a) should be compatible with function h($a) (reason: parameter #1 has type(int), but original does not) defined in %s:32
 %s:50 PhanParamSignatureMismatch Declaration of function i($a) should be compatible with function i($a, mixed|string $b = default) defined in %s:46
-%s:50 PhanParamSignatureRealMismatch Declaration of function i($a) should be compatible with function i($a, $b = default) defined in %s:46
+%s:50 PhanParamSignatureRealMismatch Declaration of function i($a) should be compatible with function i($a, $b = default) (reason: method override has fewer parameters) defined in %s:46
 %s:58 PhanParamSignatureMismatch Declaration of function j() should be compatible with function &j() defined in %s:54
-%s:58 PhanParamSignatureRealMismatch Declaration of function j() should be compatible with function &j() defined in %s:54
 %s:67 PhanParamSignatureMismatch Declaration of function k(&$a) should be compatible with function k($a) defined in %s:62
-%s:67 PhanParamSignatureRealMismatch Declaration of function k(&$a) should be compatible with function k($a) defined in %s:62
+%s:67 PhanParamSignatureRealMismatch Declaration of function k(&$a) should be compatible with function k($a) (reason: non-reference parameter #1 was overridden with a reference argument) defined in %s:62
 %s:68 PhanParamSignatureMismatch Declaration of function l($b) should be compatible with function l(&$b) defined in %s:63
-%s:68 PhanParamSignatureRealMismatch Declaration of function l($b) should be compatible with function l(&$b) defined in %s:63
+%s:68 PhanParamSignatureRealMismatch Declaration of function l($b) should be compatible with function l(&$b) (reason: reference parameter #1 was overridden with a non-reference argument) defined in %s:63
 %s:76 PhanParamSignatureMismatch Declaration of function m($a) should be compatible with function m(mixed $a = null) defined in %s:72
-%s:76 PhanParamSignatureRealMismatch Declaration of function m($a) should be compatible with function m($a = null) defined in %s:72
+%s:76 PhanParamSignatureRealMismatch Declaration of function m($a) should be compatible with function m($a = null) (reason: method override has more required parameters) defined in %s:72

--- a/tests/files/expected/0126_override_signature.php.expected
+++ b/tests/files/expected/0126_override_signature.php.expected
@@ -1,6 +1,6 @@
 %s:12 PhanParamSignatureMismatch Declaration of function f($p) should be compatible with function f(\CB $p) defined in %s:8
-%s:12 PhanParamSignatureRealMismatch Declaration of function f($p) should be compatible with function f(\CB $p) (reason: parameter #1 has no type, but original has type(\CB)) defined in %s:8
+%s:12 PhanParamSignatureRealMismatchHasNoParamType Declaration of function f($p) should be compatible with function f(\CB $p) (parameter #1 with no type cannot replace original parameter with type '\CB') defined in %s:8
 %s:16 PhanParamSignatureMismatch Declaration of function f(\CC $p) should be compatible with function f(\CB $p) defined in %s:8
-%s:16 PhanParamSignatureRealMismatch Declaration of function f(\CC $p) should be compatible with function f(\CB $p) (reason: parameter #1 of type \CC cannot replace original parameter of type \CB) defined in %s:8
+%s:16 PhanParamSignatureRealMismatchParamType Declaration of function f(\CC $p) should be compatible with function f(\CB $p) (parameter #1 of type '\CC' cannot replace original parameter of type '\CB') defined in %s:8
 %s:20 PhanParamSignatureMismatch Declaration of function f(\CA $p) should be compatible with function f(\CB $p) defined in %s:8
-%s:20 PhanParamSignatureRealMismatch Declaration of function f(\CA $p) should be compatible with function f(\CB $p) (reason: parameter #1 of type \CA cannot replace original parameter of type \CB) defined in %s:8
+%s:20 PhanParamSignatureRealMismatchParamType Declaration of function f(\CA $p) should be compatible with function f(\CB $p) (parameter #1 of type '\CA' cannot replace original parameter of type '\CB') defined in %s:8

--- a/tests/files/expected/0126_override_signature.php.expected
+++ b/tests/files/expected/0126_override_signature.php.expected
@@ -1,6 +1,6 @@
 %s:12 PhanParamSignatureMismatch Declaration of function f($p) should be compatible with function f(\CB $p) defined in %s:8
-%s:12 PhanParamSignatureRealMismatch Declaration of function f($p) should be compatible with function f(\CB $p) defined in %s:8
+%s:12 PhanParamSignatureRealMismatch Declaration of function f($p) should be compatible with function f(\CB $p) (reason: parameter #1 has no type, but original has type(\CB)) defined in %s:8
 %s:16 PhanParamSignatureMismatch Declaration of function f(\CC $p) should be compatible with function f(\CB $p) defined in %s:8
-%s:16 PhanParamSignatureRealMismatch Declaration of function f(\CC $p) should be compatible with function f(\CB $p) defined in %s:8
+%s:16 PhanParamSignatureRealMismatch Declaration of function f(\CC $p) should be compatible with function f(\CB $p) (reason: parameter #1 of type \CC cannot replace original parameter of type \CB) defined in %s:8
 %s:20 PhanParamSignatureMismatch Declaration of function f(\CA $p) should be compatible with function f(\CB $p) defined in %s:8
-%s:20 PhanParamSignatureRealMismatch Declaration of function f(\CA $p) should be compatible with function f(\CB $p) defined in %s:8
+%s:20 PhanParamSignatureRealMismatch Declaration of function f(\CA $p) should be compatible with function f(\CB $p) (reason: parameter #1 of type \CA cannot replace original parameter of type \CB) defined in %s:8

--- a/tests/files/expected/0227_trait_class_interface.php.expected
+++ b/tests/files/expected/0227_trait_class_interface.php.expected
@@ -1,2 +1,2 @@
 %s:13 PhanParamSignatureMismatch Declaration of function f(array $a) should be compatible with function f(array $a, array $b) defined in %s:4
-%s:13 PhanParamSignatureRealMismatch Declaration of function f(array $a) should be compatible with function f(array $a, array $b) (reason: method override has fewer parameters) defined in %s:4
+%s:13 PhanParamSignatureRealMismatchTooFewParameters Declaration of function f(array $a) should be compatible with function f(array $a, array $b) (the method override accepts 1 parameters, but the overridden method can accept 2) defined in %s:4

--- a/tests/files/expected/0227_trait_class_interface.php.expected
+++ b/tests/files/expected/0227_trait_class_interface.php.expected
@@ -1,2 +1,2 @@
 %s:13 PhanParamSignatureMismatch Declaration of function f(array $a) should be compatible with function f(array $a, array $b) defined in %s:4
-%s:13 PhanParamSignatureRealMismatch Declaration of function f(array $a) should be compatible with function f(array $a, array $b) defined in %s:4
+%s:13 PhanParamSignatureRealMismatch Declaration of function f(array $a) should be compatible with function f(array $a, array $b) (reason: method override has fewer parameters) defined in %s:4

--- a/tests/files/expected/0278_should_differentiate_phpdoc_return_type.php.expected
+++ b/tests/files/expected/0278_should_differentiate_phpdoc_return_type.php.expected
@@ -1,1 +1,1 @@
-%s:10 PhanParamSignatureRealMismatch Declaration of function foo() should be compatible with function foo() : void (reason: method returning '' cannot override method returning 'void') defined in %s:5
+%s:10 PhanParamSignatureRealMismatch Declaration of function foo() should be compatible with function foo() : void (method returning '' cannot override method returning 'void') defined in %s:5

--- a/tests/files/expected/0278_should_differentiate_phpdoc_return_type.php.expected
+++ b/tests/files/expected/0278_should_differentiate_phpdoc_return_type.php.expected
@@ -1,1 +1,1 @@
-%s:10 PhanParamSignatureRealMismatch Declaration of function foo() should be compatible with function foo() : void defined in %s:5
+%s:10 PhanParamSignatureRealMismatch Declaration of function foo() should be compatible with function foo() : void (reason: method returning '' cannot override method returning 'void') defined in %s:5

--- a/tests/files/expected/0279_should_check_variadic_mismatch.php.expected
+++ b/tests/files/expected/0279_should_check_variadic_mismatch.php.expected
@@ -1,10 +1,10 @@
 %s:21 PhanParamSignatureMismatch Declaration of function foo(int ...$args) should be compatible with function foo(int $args) defined in %s:4
-%s:21 PhanParamSignatureRealMismatch Declaration of function foo(int ...$args) should be compatible with function foo(int $args) (reason: non-variadic parameter #1 was replaced with a variadic parameter) defined in %s:4
+%s:21 PhanParamSignatureRealMismatchParamVariadic Declaration of function foo(int ...$args) should be compatible with function foo(int $args) (parameter #1 is a variadic parameter replacing a non-variadic parameter) defined in %s:4
 %s:23 PhanParamSignatureMismatch Declaration of function bar(int $args) should be compatible with function bar(int ...$args) defined in %s:6
-%s:23 PhanParamSignatureRealMismatch Declaration of function bar(int $args) should be compatible with function bar(int ...$args) (reason: method override has more required parameters) defined in %s:6
+%s:23 PhanParamSignatureRealMismatchTooManyRequiredParameters Declaration of function bar(int $args) should be compatible with function bar(int ...$args) (the method override requires 1 parameters, but the overridden method requires only 0) defined in %s:6
 %s:27 PhanParamSignatureMismatch Declaration of function bag() should be compatible with function bag(int ...$args) defined in %s:10
-%s:27 PhanParamSignatureRealMismatch Declaration of function bag() should be compatible with function bag(int ...$args) (reason: method override has fewer parameters) defined in %s:10
+%s:27 PhanParamSignatureRealMismatchTooFewParameters Declaration of function bag() should be compatible with function bag(int ...$args) (the method override accepts 0 parameters, but the overridden method can accept 1) defined in %s:10
 %s:32 PhanParamSignatureMismatch Declaration of function man(...$args) should be compatible with function man(array $args) defined in %s:15
-%s:32 PhanParamSignatureRealMismatch Declaration of function man(...$args) should be compatible with function man(array $args) (reason: non-variadic parameter #1 was replaced with a variadic parameter) defined in %s:15
+%s:32 PhanParamSignatureRealMismatchParamVariadic Declaration of function man(...$args) should be compatible with function man(array $args) (parameter #1 is a variadic parameter replacing a non-variadic parameter) defined in %s:15
 %s:34 PhanParamSignatureMismatch Declaration of function dog(array $args) should be compatible with function dog(...$args) defined in %s:17
-%s:34 PhanParamSignatureRealMismatch Declaration of function dog(array $args) should be compatible with function dog(...$args) (reason: method override has more required parameters) defined in %s:17
+%s:34 PhanParamSignatureRealMismatchTooManyRequiredParameters Declaration of function dog(array $args) should be compatible with function dog(...$args) (the method override requires 1 parameters, but the overridden method requires only 0) defined in %s:17

--- a/tests/files/expected/0279_should_check_variadic_mismatch.php.expected
+++ b/tests/files/expected/0279_should_check_variadic_mismatch.php.expected
@@ -1,10 +1,10 @@
 %s:21 PhanParamSignatureMismatch Declaration of function foo(int ...$args) should be compatible with function foo(int $args) defined in %s:4
-%s:21 PhanParamSignatureRealMismatch Declaration of function foo(int ...$args) should be compatible with function foo(int $args) defined in %s:4
+%s:21 PhanParamSignatureRealMismatch Declaration of function foo(int ...$args) should be compatible with function foo(int $args) (reason: non-variadic parameter #1 was replaced with a variadic parameter) defined in %s:4
 %s:23 PhanParamSignatureMismatch Declaration of function bar(int $args) should be compatible with function bar(int ...$args) defined in %s:6
-%s:23 PhanParamSignatureRealMismatch Declaration of function bar(int $args) should be compatible with function bar(int ...$args) defined in %s:6
+%s:23 PhanParamSignatureRealMismatch Declaration of function bar(int $args) should be compatible with function bar(int ...$args) (reason: method override has more required parameters) defined in %s:6
 %s:27 PhanParamSignatureMismatch Declaration of function bag() should be compatible with function bag(int ...$args) defined in %s:10
-%s:27 PhanParamSignatureRealMismatch Declaration of function bag() should be compatible with function bag(int ...$args) defined in %s:10
+%s:27 PhanParamSignatureRealMismatch Declaration of function bag() should be compatible with function bag(int ...$args) (reason: method override has fewer parameters) defined in %s:10
 %s:32 PhanParamSignatureMismatch Declaration of function man(...$args) should be compatible with function man(array $args) defined in %s:15
-%s:32 PhanParamSignatureRealMismatch Declaration of function man(...$args) should be compatible with function man(array $args) defined in %s:15
+%s:32 PhanParamSignatureRealMismatch Declaration of function man(...$args) should be compatible with function man(array $args) (reason: non-variadic parameter #1 was replaced with a variadic parameter) defined in %s:15
 %s:34 PhanParamSignatureMismatch Declaration of function dog(array $args) should be compatible with function dog(...$args) defined in %s:17
-%s:34 PhanParamSignatureRealMismatch Declaration of function dog(array $args) should be compatible with function dog(...$args) defined in %s:17
+%s:34 PhanParamSignatureRealMismatch Declaration of function dog(array $args) should be compatible with function dog(...$args) (reason: method override has more required parameters) defined in %s:17

--- a/tests/files/expected/0280_should_infer_nullable_from_default.php.expected
+++ b/tests/files/expected/0280_should_infer_nullable_from_default.php.expected
@@ -1,4 +1,4 @@
 %s:23 PhanParamSignatureMismatch Declaration of function foo(int $arg = 20) should be compatible with function foo(?int $arg = null) defined in %s:10
-%s:23 PhanParamSignatureRealMismatch Declaration of function foo(int $arg = 20) should be compatible with function foo(?int $arg = null) (reason: parameter #1 of type int cannot replace original parameter of type ?int) defined in %s:10
+%s:23 PhanParamSignatureRealMismatchParamType Declaration of function foo(int $arg = 20) should be compatible with function foo(?int $arg = null) (parameter #1 of type 'int' cannot replace original parameter of type '?int') defined in %s:10
 %s:27 PhanTypeMismatchDefault Default value for ?int $x can't be float
 %s:34 PhanTypeMismatchArgument Argument 1 (arg) is null but \C280::foo() takes int defined at %s:23

--- a/tests/files/expected/0280_should_infer_nullable_from_default.php.expected
+++ b/tests/files/expected/0280_should_infer_nullable_from_default.php.expected
@@ -1,4 +1,4 @@
 %s:23 PhanParamSignatureMismatch Declaration of function foo(int $arg = 20) should be compatible with function foo(?int $arg = null) defined in %s:10
-%s:23 PhanParamSignatureRealMismatch Declaration of function foo(int $arg = 20) should be compatible with function foo(?int $arg = null) defined in %s:10
+%s:23 PhanParamSignatureRealMismatch Declaration of function foo(int $arg = 20) should be compatible with function foo(?int $arg = null) (reason: parameter #1 of type int cannot replace original parameter of type ?int) defined in %s:10
 %s:27 PhanTypeMismatchDefault Default value for ?int $x can't be float
 %s:34 PhanTypeMismatchArgument Argument 1 (arg) is null but \C280::foo() takes int defined at %s:23


### PR DESCRIPTION
Include a cause for the incompatibility, to make fixing the
incompatibility easier.

Methods returning reference and not returning references can be
mixed in overrides, without issue.

getNumberOfOptionalParameters() can be influenced by the presence of
func_get_args() and variadic params in the overriding method (and
overridden). Move away from that.

getNumberOfRequiredParameters() can be influenced by out of date method
signatures in phan's function type info.
Also, if a module is missing reflection info and has classes that can be
extended, it is permitted to have 0 required parameters in a method override.