### PR TITLE
Reduce memory used by UnionType representation.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -42,6 +42,8 @@ New Features (CLI, Configs)
   The warning can be disabled by the Phan config setting `skip_slow_php_options_warning` to true.
 
 Maintenance
++ Reduce memory usage by around 15% by using a more efficient representation of union types (PR #729).
+  The optional extension https://github.com/runkit7/runkit_object_id can be installed to boost performance by around 10%.
 
 Bug Fixes
 + Work around known bugs in current releases of two PECL extensions (Issue #888, #889)

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -32,6 +32,7 @@ use Phan\Language\Type\StringType;
 use Phan\Language\Type\StaticType;
 use Phan\Language\Type\VoidType;
 use Phan\Language\UnionType;
+use Phan\Library\ArraySet;
 use ast\Node;
 use ast\Node\Decl;
 
@@ -800,6 +801,9 @@ class UnionTypeVisitor extends AnalysisVisitor
     {
         $union_type = $this->visitClassNode($node->children['class']);
 
+        // TODO: re-use the underlying type set in the common case
+        // Maybe UnionType::fromMap
+
         // For any types that are templates, map them to concrete
         // types based on the parameters passed in.
         return new UnionType(\array_map(function (Type $type) use ($node) {
@@ -858,7 +862,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             // Create a new type that assigns concrete
             // types to template type identifiers.
             return Type::fromType($type, $template_type_list);
-        }, $union_type->getTypeSet()->toArray()));
+        }, $union_type->getTypeSet()));
     }
 
     /**
@@ -1427,7 +1431,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                         $union_type = clone($union_type);
 
                         // Find the static type on the list
-                        $static_type = $union_type->getTypeSet()->find(function (Type $type) : bool {
+                        $static_type = ArraySet::find($union_type->getTypeSet(), function (Type $type) : bool {
                             return (
                                 $type->isGenericArray()
                                 && $type->genericArrayElementType()->isStaticType()

--- a/src/Phan/Analysis/ContextMergeVisitor.php
+++ b/src/Phan/Analysis/ContextMergeVisitor.php
@@ -247,11 +247,11 @@ class ContextMergeVisitor extends KindVisitorImplementation
                 }, $variable_list);
 
                 if (\count($type_set_list) < 2) {
-                    return new UnionType($type_set_list[0] ?? []);
+                    return new UnionType($type_set_list[0] ?? [], true);
                 }
 
                 return new UnionType(
-                    ArraySet::unionAll($type_set_list)
+                    ArraySet::unionAll($type_set_list), true
                 );
             };
 

--- a/src/Phan/Analysis/ContextMergeVisitor.php
+++ b/src/Phan/Analysis/ContextMergeVisitor.php
@@ -8,7 +8,7 @@ use Phan\Language\Element\Variable;
 use Phan\Language\Scope;
 use Phan\Language\Type\NullType;
 use Phan\Language\UnionType;
-use Phan\Library\Set;
+use Phan\Library\ArraySet;
 use ast\Node;
 
 class ContextMergeVisitor extends KindVisitorImplementation
@@ -242,7 +242,7 @@ class ContextMergeVisitor extends KindVisitorImplementation
                 ));
 
                 // Get the list of types for each version of the variable
-                $type_set_list = \array_map(function (Variable $variable) : Set {
+                $type_set_list = \array_map(function (Variable $variable) : array {
                     return $variable->getUnionType()->getTypeSet();
                 }, $variable_list);
 
@@ -251,7 +251,7 @@ class ContextMergeVisitor extends KindVisitorImplementation
                 }
 
                 return new UnionType(
-                    Set::unionAll($type_set_list)
+                    ArraySet::unionAll($type_set_list)
                 );
             };
 

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -360,7 +360,7 @@ class Clazz extends AddressableElement
                         return new UnionType(
                             \array_map(function (Type $type) use ($template_type_map) : Type {
                                 return $template_type_map[$type->getName()] ?? $type;
-                            }, $union_type->getTypeSet()->toArray())
+                            }, $union_type->getTypeSet())
                         );
                     }, $parent_type->getTemplateParameterTypeList())
                 );

--- a/src/Phan/Language/Type/CallableType.php
+++ b/src/Phan/Language/Type/CallableType.php
@@ -28,7 +28,13 @@ class CallableType extends NativeType
         // Avoids picking up changes to CallableType::instance(false) in the case that a result depends on asFQSEN()
         $instance = clone(self::callableInstance());
         $instance->fqsen = $fqsen;
+        $instance->memoizeFlushAll();
         return $instance;
+    }
+
+    public function __clone() {
+        assert($this->fqsen === null, 'should only clone null fqsen');
+        $result = new static($this->namespace, $this->name, $this->template_parameter_type_list, $this->is_nullable);
     }
 
     /**

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -8,6 +8,8 @@ abstract class NativeType extends Type
 {
     const NAME = '';
 
+    const KEY_PREFIX = '!';
+
     /**
      * @param bool $is_nullable
      * If true, returns a nullable instance of this native type

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -747,7 +747,7 @@ class UnionType implements \Serializable
      */
     public function typeCount() : int
     {
-        return count($this->type_set);
+        return \count($this->type_set);
     }
 
     /**
@@ -756,7 +756,7 @@ class UnionType implements \Serializable
      */
     public function isEmpty() : bool
     {
-        return ($this->typeCount() < 1);
+        return \count($this->type_set) === 0;
     }
 
     /**

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -8,6 +8,7 @@ use Phan\Exception\CodeBaseException;
 use Phan\Exception\IssueException;
 use Phan\Issue;
 use Phan\Language\Element\Clazz;
+use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\FQSEN\FullyQualifiedFunctionName;
 use Phan\Language\FQSEN\FullyQualifiedMethodName;
 use Phan\Language\Type\ArrayType;
@@ -18,13 +19,11 @@ use Phan\Language\Type\NullType;
 use Phan\Language\Type\ObjectType;
 use Phan\Language\Type\StaticType;
 use Phan\Language\Type\TemplateType;
-use Phan\Library\Set;
+use Phan\Library\ArraySet;
 use ast\Node;
 
 class UnionType implements \Serializable
 {
-    use \Phan\Memoize;
-
     /**
      * @var string
      * A list of one or more types delimited by the '|'
@@ -35,31 +34,33 @@ class UnionType implements \Serializable
         . '(\|' . Type::type_regex . ')*';
 
     /**
-     * @var Set
+     * @var Type[]
      */
     private $type_set;
 
     /**
      * @param Type[]|\Iterator|null $type_list
+     * @param bool $is_an_array_set - Whether or not this is already a set. Only set to true within UnionSet code.
+     *
      * An optional list of types represented by this union
      */
-    public function __construct($type_list = null)
+    public function __construct($type_list = null, bool $is_an_array_set = false)
     {
-        $this->type_set = new Set($type_list);
+        if ($is_an_array_set) {
+            // Disable asserts in production
+            /**
+            assert(is_array($type_list),
+                   'should be an array array');
+            assert(ArraySet::is_array_set($type_list),
+                   'Should be an array set');
+             */
+            $this->type_set = $type_list;
+            return;
+        }
+        $this->type_set = ArraySet::from_list($type_list);
     }
 
-    /**
-     * After a clone is called on this object, clone our
-     * deep objects.
-     *
-     * @return null
-     */
-    public function __clone()
-    {
-        $set = new Set();
-        $set->addAll($this->type_set);
-        $this->type_set = $set;
-    }
+    // __clone of $this->type_set would be a no-op due to copy on write semantics.
 
     /**
      * @param string $fully_qualified_string
@@ -75,11 +76,17 @@ class UnionType implements \Serializable
             return new UnionType();
         }
 
-        return new UnionType(
-            \array_map(function (string $type_name) {
+        static $memoize_map = [];
+        $types_set = $memoize_map[$fully_qualified_string] ?? null;
+
+        if (!isset($types_set)) {
+            $types_set = ArraySet::from_list(\array_map(function (string $type_name) {
                 return Type::fromFullyQualifiedString($type_name);
-            }, \explode('|', $fully_qualified_string))
-        );
+            }, \explode('|', $fully_qualified_string)));
+            $memoize_map[$fully_qualified_string] = $types_set;
+        }
+
+        return new UnionType($types_set, true);
     }
 
     /**
@@ -232,8 +239,6 @@ class UnionType implements \Serializable
     public static function internalFunctionSignatureMapForFQSEN(
         $function_fqsen
     ) : array {
-        $context = new Context;
-
         $map = self::internalFunctionSignatureMap();
 
         if ($function_fqsen instanceof FullyQualifiedMethodName) {
@@ -251,6 +256,27 @@ class UnionType implements \Serializable
         $function_name_original = $function_name;
         $alternate_id = 0;
 
+        /**
+         * @param string|null $type_name
+         * @return UnionType|null
+         */
+        $get_for_global_context = function($type_name) {
+            if (!$type_name) {
+                return null;
+            }
+
+            static $internal_fn_cache = [];
+
+
+            $result = $internal_fn_cache[$type_name] ?? null;
+            if ($result === null) {
+                $context = new Context;
+                $result = UnionType::fromStringInContext($type_name, $context, Type::FROM_PHPDOC);
+                $internal_fn_cache[$type_name] = $result;
+            }
+            return clone($result);
+        };
+
         $configurations = [];
         while (isset($map[$function_name])) {
 
@@ -263,17 +289,13 @@ class UnionType implements \Serializable
 
             // Figure out the return type
             $return_type_name = \array_shift($type_name_struct);
-            $return_type = $return_type_name
-                ? UnionType::fromStringInContext($return_type_name, $context, Type::FROM_PHPDOC)
-                : null;
+            $return_type = $get_for_global_context($return_type_name);
 
             $name_type_name_map = $type_name_struct;
             $parameter_name_type_map = [];
 
             foreach ($name_type_name_map as $name => $type_name) {
-                $parameter_name_type_map[$name] = empty($type_name)
-                    ? new UnionType()
-                    : UnionType::fromStringInContext($type_name, $context, Type::FROM_PHPDOC);
+                $parameter_name_type_map[$name] = $get_for_global_context($type_name) ?? new UnionType();
             }
 
             $configurations[] = [
@@ -289,11 +311,11 @@ class UnionType implements \Serializable
     }
 
     /**
-     * @return Set
+     * @return Type[]
      * The set of simple types associated with this
-     * union type.
+     * union type. The key is based on runkit_object_id()
      */
-    public function getTypeSet() : Set
+    public function getTypeSet() : array
     {
         return $this->type_set;
     }
@@ -305,7 +327,7 @@ class UnionType implements \Serializable
      */
     public function addType(Type $type)
     {
-        $this->type_set->attach($type);
+        $this->type_set[\runkit_object_id($type)] = $type;
     }
 
     /**
@@ -315,7 +337,7 @@ class UnionType implements \Serializable
      */
     public function removeType(Type $type)
     {
-        $this->type_set->detach($type);
+        unset($this->type_set[\runkit_object_id($type)]);
     }
 
     /**
@@ -325,7 +347,7 @@ class UnionType implements \Serializable
      */
     public function hasType(Type $type) : bool
     {
-        return $this->type_set->contains($type);
+        return ArraySet::contains($this->type_set, $type);
     }
 
     /**
@@ -335,9 +357,12 @@ class UnionType implements \Serializable
      */
     public function addUnionType(UnionType $union_type)
     {
-        $this->type_set->addAll(
-            $union_type->getTypeSet()
-        );
+        if (count($this->type_set) === 0) {
+            // take advantage of array copy-on-write to save a bit of memory
+            $this->type_set = $union_type->type_set;
+        } else {
+            $this->type_set += $union_type->type_set;
+        }
     }
 
     /**
@@ -348,11 +373,21 @@ class UnionType implements \Serializable
      */
     public function hasSelfType() : bool
     {
-        return (false !==
-            $this->type_set->find(function (Type $type) : bool {
-                return $type->isSelfType();
-            })
-        );
+        return ArraySet::exists($this->type_set, function (Type $type) : bool {
+            return $type->isSelfType();
+        });
+    }
+
+    /**
+     * @return bool
+     * True if this union type has any types that are generic
+     * types.
+     */
+    private function hasGenericType() : bool
+    {
+        return ArraySet::exists($this->type_set, function (Type $type) : bool {
+            return $type->hasTemplateParameterTypes();
+        });
     }
 
     /**
@@ -366,7 +401,7 @@ class UnionType implements \Serializable
             return [];
         }
 
-        return \array_reduce($this->getTypeSet()->toArray(),
+        return \array_reduce($this->type_set,
             function (array $map, Type $type) {
                 return \array_merge(
                     $type->getTemplateParameterTypeList(),
@@ -395,7 +430,7 @@ class UnionType implements \Serializable
             return [];
         }
 
-        return \array_reduce($this->getTypeSet()->toArray(),
+        return \array_reduce($this->type_set,
             function (array $map, Type $type) use ($code_base) {
                 return \array_merge(
                     $type->getTemplateParameterTypeMap($code_base),
@@ -420,14 +455,14 @@ class UnionType implements \Serializable
     ) : UnionType {
 
         $concrete_type_list = [];
-        foreach ($this->getTypeSet() as $i => $type) {
+        foreach ($this->type_set as $type) {
             if ($type instanceof TemplateType
                 && isset($template_parameter_type_map[$type->getName()])
             ) {
                 $union_type =
                     $template_parameter_type_map[$type->getName()];
 
-                foreach ($union_type->getTypeSet() as $concrete_type) {
+                foreach ($union_type->type_set as $concrete_type) {
                     $concrete_type_list[] = $concrete_type;
                 }
             } else {
@@ -445,11 +480,9 @@ class UnionType implements \Serializable
      */
     public function hasTemplateType() : bool
     {
-        return (false !==
-            $this->type_set->find(function (Type $type) : bool {
-                return ($type instanceof TemplateType);
-            })
-        );
+        return ArraySet::exists($this->type_set, function (Type $type) : bool {
+            return ($type instanceof TemplateType);
+        });
     }
 
     /**
@@ -459,14 +492,14 @@ class UnionType implements \Serializable
      */
     public function hasStaticType() : bool
     {
-        static $static_type;
-        static $static_nullable_type;
-        if ($static_type === null) {
-            $static_type = StaticType::instance(false);
-            $static_nullable_type = StaticType::instance(true);
+        static $static_types = null;
+        if ($static_types === null) {
+            $static_types = [
+                StaticType::instance(false),
+                StaticType::instance(true),
+            ];
         }
-        return $this->type_set->contains($static_type) ||
-            $this->type_set->contains($static_nullable_type);
+        return ArraySet::containsAny($this->type_set, $static_types);
     }
 
     /**
@@ -491,8 +524,8 @@ class UnionType implements \Serializable
             $static_nullable_type = StaticType::instance(true);
         }
 
-        $has_static_type = $this->type_set->contains($static_type);
-        $has_static_nullable_type = $this->type_set->contains($static_nullable_type);
+        $has_static_type = ArraySet::contains($this->type_set, $static_type);
+        $has_static_nullable_type = ArraySet::contains($this->type_set, $static_nullable_type);
 
         // If this doesn't reference 'static', there's nothing to do.
         if (!($has_static_type || $has_static_nullable_type)) {
@@ -531,7 +564,7 @@ class UnionType implements \Serializable
             return false;
         }
 
-        return $this->type_set->contains($type);
+        return ArraySet::contains($this->type_set, $type);
     }
 
     /**
@@ -545,11 +578,9 @@ class UnionType implements \Serializable
             return false;
         }
 
-        return (false ===
-            $this->type_set->find(function (Type $type) : bool {
-                return !$type->isNativeType();
-            })
-        );
+        return !ArraySet::exists($this->type_set, function (Type $type) : bool {
+            return !$type->isNativeType();
+        });
     }
 
     /**
@@ -559,13 +590,17 @@ class UnionType implements \Serializable
      */
     public function isEqualTo(UnionType $union_type) : bool
     {
-        $type_set = $this->getTypeSet();
-        $other_type_set = $union_type->getTypeSet();
-        if (count($type_set) !== count($other_type_set)) {
+        $type_set = $this->type_set;
+        $other_type_set = $union_type->type_set;
+        /**
+        assert(ArraySet::is_array_set($type_set));
+        assert(ArraySet::is_array_set($other_type_set));
+         */
+        if (\count($type_set) !== \count($other_type_set)) {
             return false;
         }
-        foreach ($type_set as $type) {
-            if (!$other_type_set->contains($type)) {
+        foreach ($type_set as $type_id => $type) {
+            if (!isset($other_type_set[$type_id])) {
                 return false;
             }
         }
@@ -577,7 +612,7 @@ class UnionType implements \Serializable
      */
     public function containsNullable() : bool
     {
-        foreach ($this->getTypeSet() as $type) {
+        foreach ($this->type_set as $type) {
             if ($type->getIsNullable()) {
                 return true;
             }
@@ -588,7 +623,7 @@ class UnionType implements \Serializable
     public function nonNullableClone() : UnionType
     {
         $result = new UnionType();
-        foreach ($this->getTypeSet() as $type) {
+        foreach ($this->type_set as $type) {
             if (!$type->getIsNullable()) {
                 $result->addType($type);
                 continue;
@@ -605,7 +640,7 @@ class UnionType implements \Serializable
     public function nullableClone() : UnionType
     {
         $result = new UnionType();
-        foreach ($this->getTypeSet() as $type) {
+        foreach ($this->type_set as $type) {
             if ($type->getIsNullable()) {
                 $result->addType($type);
                 continue;
@@ -692,7 +727,7 @@ class UnionType implements \Serializable
      */
     public function hasAnyType(array $type_list) : bool
     {
-        return $this->type_set->containsAny($type_list);
+        return ArraySet::containsAny($this->type_set, $type_list);
     }
 
     /**
@@ -701,11 +736,9 @@ class UnionType implements \Serializable
      */
     public function hasIterable() : bool
     {
-        return (false !==
-            $this->type_set->find(function (Type $type) : bool {
-                return $type->isIterable();
-            })
-        );
+        return ArraySet::exists($this->type_set, function (Type $type) : bool {
+            return $type->isIterable();
+        });
     }
 
     /**
@@ -714,7 +747,7 @@ class UnionType implements \Serializable
      */
     public function typeCount() : int
     {
-        return $this->type_set->count();
+        return count($this->type_set);
     }
 
     /**
@@ -811,12 +844,14 @@ class UnionType implements \Serializable
         // Check conversion on the cross product of all
         // type combinations and see if any can cast to
         // any.
-        foreach ($this->getTypeSet() as $source_type) {
+        foreach ($this->type_set as $source_type) {
+            // TODO Noop?
             if (empty($source_type)) {
                 continue;
             }
 
-            foreach ($target->getTypeSet() as $target_type) {
+            foreach ($target->type_set as $target_type) {
+                // TODO noop?
                 if (empty($target_type)) {
                     continue;
                 }
@@ -845,11 +880,9 @@ class UnionType implements \Serializable
             return false;
         }
 
-        return (false ===
-            $this->type_set->find(function (Type $type) : bool {
-                return !$type->isScalar();
-            })
-        );
+        return !ArraySet::exists($this->type_set, function (Type $type) : bool {
+            return !$type->isScalar();
+        });
     }
 
     /**
@@ -863,11 +896,10 @@ class UnionType implements \Serializable
             return false;
         }
 
-        return (false ===
-            $this->type_set->find(function (Type $type) : bool {
-                return !$type->isArrayLike();
-            })
-        );
+        // TODO: change check to "any", not "each"?
+        return !ArraySet::exists($this->type_set, function (Type $type) : bool {
+            return !$type->isArrayLike();
+        });
     }
 
     /**
@@ -881,11 +913,10 @@ class UnionType implements \Serializable
             return false;
         }
 
-        return (false ===
-            $this->type_set->find(function (Type $type) : bool {
-                return !$type->isArrayAccess();
-            })
-        );
+        // TODO: change check to "any", not "each"?
+        return ArraySet::exists($this->type_set, function (Type $type) : bool {
+            return $type->isArrayAccess();
+        });
     }
 
     /**
@@ -900,14 +931,9 @@ class UnionType implements \Serializable
             return false;
         }
 
-        return \array_reduce($this->getTypeSet()->toArray(),
-            function (bool $is_exclusively_array, Type $type) : bool {
-                return (
-                    $is_exclusively_array
-                    && $type->isArrayLike()
-                    && !$type->getIsNullable()
-                );
-            }, true);
+        return !ArraySet::exists($this->type_set, function (Type $type) : bool {
+            return !$type->isArrayLike() || $type->getIsNullable();
+        });
     }
 
     /**
@@ -921,16 +947,9 @@ class UnionType implements \Serializable
             return false;
         }
 
-        return \array_reduce($this->getTypeSet()->toArray(),
-            function (bool $is_exclusively_array, Type $type) : bool {
-                return (
-                    $is_exclusively_array
-                    && (
-                        $type === ArrayType::instance(false)
-                        || $type->isGenericArray()
-                    )
-                );
-            }, true);
+        return !ArraySet::exists($this->type_set, function (Type $type) : bool {
+            return $type !== ArrayType::instance(false) && !$type->isGenericArray();
+        });
     }
 
     /**
@@ -939,11 +958,21 @@ class UnionType implements \Serializable
      */
     public function nonNativeTypes() : UnionType
     {
-        return new UnionType(
-            $this->type_set->filter(function (Type $type) {
-                return !$type->isNativeType();
-            })
-        );
+        return $this->makeFromFilter(function (Type $type) {
+            return !$type->isNativeType();
+        });
+    }
+
+    /**
+     * A memory efficient way to create a UnionType from a filter operation.
+     * If this the filter preserves everything, calls clone() instead.
+     */
+    public function makeFromFilter(\Closure $cb) : UnionType {
+        $new_type_set = array_filter($this->type_set, $cb);
+        if (count($new_type_set) === count($this->type_set)) {
+            return clone($this);
+        }
+        return new UnionType($new_type_set, true);
     }
 
     /**
@@ -975,7 +1004,7 @@ class UnionType implements \Serializable
     ) {
         // Iterate over each viable class type to see if any
         // have the constant we're looking for
-        foreach ($this->nonNativeTypes()->getTypeSet() as $class_type) {
+        foreach ($this->nonNativeTypes()->type_set as $class_type) {
 
             // Get the class FQSEN
             $class_fqsen = $class_type->asFQSEN();
@@ -1027,10 +1056,11 @@ class UnionType implements \Serializable
     ) {
         // Iterate over each viable class type to see if any
         // have the constant we're looking for
-        foreach ($this->nonNativeTypes()->getTypeSet() as $class_type) {
+        foreach ($this->nonNativeTypes()->type_set as $class_type) {
 
             // Get the class FQSEN
             $class_fqsen = $class_type->asFQSEN();
+            \assert($class_fqsen instanceof FullyQualifiedClassName);
 
             if ($class_type->isStaticType()) {
                 if (!$context->isInClassScope()) {
@@ -1071,13 +1101,9 @@ class UnionType implements \Serializable
      */
     public function nonGenericArrayTypes() : UnionType
     {
-        return new UnionType(
-            $this->type_set->filter(
-                function (Type $type) : bool {
-                    return !$type->isGenericArray();
-                }
-            )
-        );
+        return $this->makeFromFilter(function (Type $type) : bool {
+            return !$type->isGenericArray();
+        });
     }
 
     /**
@@ -1091,13 +1117,9 @@ class UnionType implements \Serializable
      */
     public function genericArrayTypes() : UnionType
     {
-        return new UnionType(
-            $this->type_set->filter(
-                function (Type $type) : bool {
-                    return $type->isGenericArray();
-                }
-            )
-        );
+        return $this->makeFromFilter(function (Type $type) : bool {
+            return $type->isGenericArray();
+        });
     }
 
     /**
@@ -1111,13 +1133,9 @@ class UnionType implements \Serializable
      */
     public function objectTypes() : UnionType
     {
-        return new UnionType(
-            $this->type_set->filter(
-                function (Type $type) : bool {
-                    return $type->isObject();
-                }
-            )
-        );
+        return $this->makeFromFilter(function (Type $type) : bool {
+            return $type->isObject();
+        });
     }
 
     /**
@@ -1132,16 +1150,16 @@ class UnionType implements \Serializable
      */
     public function scalarTypes() : UnionType
     {
-        $types = $this->type_set->filter(
-            function (Type $type) : bool {
-                return $type->isScalar();
-            }
-        );
-        $nullType = NullType::instance(false);
-        if (!$types->contains($nullType) && $this->containsNullable()) {
-            $types->attach($nullType);
+        $types = \array_filter($this->type_set, function (Type $type) : bool {
+            return $type->isScalar();
+        });
+        $null_type = NullType::instance(false);
+        $null_type_id = \runkit_object_id($null_type);
+        if (!\array_key_exists($null_type_id, $types) && $this->containsNullable()) {
+            // E.g. if this has `?stdClass`, add `null` to the resulting set of scalar types.
+            $types[\runkit_object_id($null_type)] = $null_type;
         }
-        return new UnionType($types);
+        return new UnionType($types, true);
     }
 
     /**
@@ -1155,13 +1173,15 @@ class UnionType implements \Serializable
      */
     public function nonArrayTypes() : UnionType
     {
+
         return new UnionType(
-            $this->type_set->filter(
+            array_filter($this->type_set,
                 function (Type $type) : bool {
                     return !$type->isGenericArray()
                         && $type !== ArrayType::instance(false);
                 }
-            )
+            ),
+            true
         );
     }
 
@@ -1175,11 +1195,9 @@ class UnionType implements \Serializable
             return false;
         }
 
-        return (false ===
-            $this->type_set->find(function (Type $type) : bool {
-                return !$type->isGenericArray();
-            })
-        );
+        return !ArraySet::exists($this->type_set, function (Type $type) : bool {
+            return !$type->isGenericArray();
+        });
     }
 
     /**
@@ -1192,11 +1210,9 @@ class UnionType implements \Serializable
             return false;
         }
 
-        return (false !==
-            $this->type_set->find(function (Type $type) : bool {
-                return $type->isGenericArray();
-            })
-        );
+        return ArraySet::exists($this->type_set, function (Type $type) : bool {
+            return $type->isGenericArray();
+        });
     }
 
     /**
@@ -1208,9 +1224,9 @@ class UnionType implements \Serializable
     public function genericArrayElementTypes() : UnionType
     {
         $union_type = new UnionType(
-            $this->type_set->filter(function (Type $type) : bool {
+            ArraySet::map(array_filter($this->type_set, function (Type $type) : bool {
                 return $type->isGenericArray();
-            })->map(function (Type $type) : Type {
+            }), function (Type $type) : Type {
                 return $type->genericArrayElementType();
             })
         );
@@ -1244,7 +1260,7 @@ class UnionType implements \Serializable
      */
     public function asMappedUnionType(\Closure $closure) : UnionType
     {
-        return new UnionType($this->type_set->map($closure));
+        return new UnionType(ArraySet::map($this->type_set, $closure), true);
     }
 
     /**
@@ -1321,8 +1337,8 @@ class UnionType implements \Serializable
      */
     public function unserialize($serialized)
     {
-        $this->type_set = new Set(
-            \array_map(function (string $type_name) {
+        $this->type_set = ArraySet::from_list(
+            \array_map(function (string $type_name) : Type {
                 return Type::fromFullyQualifiedString($type_name);
             }, \explode('|', $serialized ?? ''))
         );
@@ -1337,10 +1353,11 @@ class UnionType implements \Serializable
     {
         // Create a new array containing the string
         // representations of each type
+        $types = $this->type_set;
         $type_name_list =
             \array_map(function (Type $type) : string {
                 return (string)$type;
-            }, $this->getTypeSet()->toArray());
+            }, $types);
 
         // Sort the types so that we get a stable
         // representation

--- a/src/Phan/Library/ArraySet.php
+++ b/src/Phan/Library/ArraySet.php
@@ -1,0 +1,148 @@
+<?php declare(strict_types=1);
+namespace Phan\Library;
+
+use Phan\Language\Type;
+
+/**
+ * An alternative to Phan\Library\Set.
+ * This is useful when sets are small (0 or 1 elements), and frequently cloned.
+ * Because of copy on write, cloning the generated arrays is done automatically and efficiently.
+ */
+final class ArraySet {
+    // This is a collection of utilities. It cannot be instantiated.
+    private function __construct() { }
+
+    /**
+     * @param Type $object
+     * @return Type[]
+     */
+    public static function singleton($object) : array
+    {
+        return [
+            \runkit_object_id($object) => $object,
+        ];
+    }
+
+    /**
+     * @param Type[]|\Iterator|null $object_list
+     * @return Type[]
+     */
+    public static function from_list($object_list = null) : array
+    {
+        $result = [];
+        foreach ($object_list ?? [] as $object) {
+            \assert(\is_object($object),
+                   'ArraySet should contain only objects');
+            $result[\runkit_object_id($object)] = $object;
+        }
+        return $result;
+    }
+
+    /**
+     * @param Type[] $object_set
+     * @param \Closure $cb - Closure mapping Type to boolean.
+     * @return bool
+     */
+    public static function exists(array $object_set, \Closure $cb) {
+        foreach ($object_set as $e) {
+            if ($cb($e)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @param Type[] $array
+     * @param \Closure $cb
+     * @return Type|false
+     */
+    public static function find(array $array, \Closure $cb) {
+        foreach ($array as $e) {
+            if ($cb($e)) {
+                return $e;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @param Type[] $object_set - Map from object id to Type
+     * @param Type[] $candidate_type_list - List of Type
+     */
+    public static function containsAny(array $object_set, array $candidate_type_list) : bool {
+        foreach ($candidate_type_list as $type) {
+            if (isset($object_set[\runkit_object_id($type)])) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Just use array_filter - array_filter preserves keys.
+     * @param Type[] $object_set
+     * @param \Closure $cb
+     */
+    public static function filter(array $object_set, \Closure $cb) : array {
+        return \array_filter($object_set, $cb);
+    }
+
+    /**
+     * @param Type[] $object_set
+     * @param \Closure $cb - Maps Type -> Type
+     * @return Type[] $object_set
+     */
+    public static function map(array $object_set, \Closure $cb) : array {
+        $result = [];
+        foreach ($object_set as $object) {
+            $new_object = $cb($object);
+            \assert(\is_object($new_object),
+                   'ArraySet should contain only objects');
+            $result[\runkit_object_id($new_object)] = $new_object;
+        }
+        return $result;
+    }
+
+    /**
+     * @param Type[] $object_set
+     * @param Type $object - object to search for
+     * @return bool
+     */
+    public static function contains(array $object_set, $object) : bool {
+        return isset($object_set[\runkit_object_id($object)]);
+    }
+
+    /**
+     * @param Type[][] $sets
+     * @return Type[] - A set of Type made for efficient lookup
+     */
+    public static function unionAll(array $sets) {
+        if (\count($sets) === 1) {
+            return \reset($sets);
+        }
+        $result = [];
+        foreach ($sets as $set) {
+            if (\count($result) === 0) {
+                $result = $set;
+            } else {
+                $result += $set;
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * Helper function for assertions.
+     * @param Type[] $object_set
+     * @return bool - Whether or not this is an object set.
+     */
+    public static function is_array_set(array $object_set) {
+        foreach ($object_set as $key => $object) {
+            if (!\is_object($object) || \runkit_object_id($object) !== $key) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/runkit.php
+++ b/src/runkit.php
@@ -1,0 +1,38 @@
+<?php
+if (PHP_INT_SIZE === 8) {
+    /**
+     * See https://github.com/runkit7/runkit_object_id for a faster native version (Improves phan's speed by 10% or so).
+     * spl_object_hash() exists, but there's no such thing as spl_object_handle()/spl_object_id().
+     * Also, we currently get an object from var_dump(), but that isn't nicely exposed.
+     *
+     * @param object $object
+     * @return int
+     * @suppress PhanRedefineFunctionInternal
+     * @suppress PhanRedefineFunction
+     */
+    function runkit_object_id($object) {
+        $hash = spl_object_hash($object);
+        // Fit this into a php long (32-bit or 64-bit signed int).
+        // The first 16 hex digits (64 bytes) vary, the last 16 don't.
+        // Values are usually padded with 0s at the front.
+        return intval(substr($hash, 1, 15), 16);
+    }
+} else {
+    /**
+     * See https://github.com/runkit7/runkit_object_id for a faster native version (Improves phan's speed by 10% or so).
+     * spl_object_hash() exists, but there's no such thing as spl_object_handle()/spl_object_id().
+     * Also, we currently get an object from var_dump(), but that isn't nicely exposed.
+     *
+     * @param object $object
+     * @return int
+     * @suppress PhanRedefineFunctionInternal
+     * @suppress PhanRedefineFunction
+     */
+    function runkit_object_id($object) {
+        $hash = spl_object_hash($object);
+        // Fit this into a php long (32-bit or 64-bit signed int).
+        // The first 16 hex digits (64 bytes) vary, the last 16 don't.
+        // Values are usually padded with 0s at the front.
+        return intval(substr($hash, 1, 15), 16);
+    }
+}

--- a/test
+++ b/test
@@ -1,5 +1,5 @@
 #!/bin/sh
 if ! ./vendor/bin/phpunit ; then
     echo "Please run 'composer install' or 'composer update' if running tests fails" 1>&2
-	exit 1
+    exit 1
 fi

--- a/test
+++ b/test
@@ -1,3 +1,5 @@
 #!/bin/sh
-./vendor/bin/phpunit || \
-    echo "Please run 'composer install' or 'composer update' if running tests fails"
+if ! ./vendor/bin/phpunit ; then
+    echo "Please run 'composer install' or 'composer update' if running tests fails" 1>&2
+	exit 1
+fi

--- a/tests/Phan/BaseTest.php
+++ b/tests/Phan/BaseTest.php
@@ -5,7 +5,16 @@ namespace Phan\Tests;
 use PHPUnit\Framework\TestCase;
 /**
  * Any common initialization or configuration should go here
- * (E.g. may want to change https://phpunit.de/manual/current/en/fixtures.html#fixtures.global-state in some classes)
+ * (E.g. this changes https://phpunit.de/manual/current/en/fixtures.html#fixtures.global-state for some classes)
  */
 class BaseTest extends TestCase {
+    // Needed to prevent phpunit from backing up these private static variables.
+    // See https://phpunit.de/manual/current/en/fixtures.html#fixtures.global-state
+    protected $backupStaticAttributesBlacklist = [
+        'Phan\Language\Type' => [
+            'canonical_object_map',
+            'internal_fn_cache',
+            'singleton_map',
+        ],
+    ];
 }


### PR DESCRIPTION
Performance improvement for phan self-testing (single threaded):
- 3.68s before this change
- 3.60s after this change, with php implementation of runkit_object_id()
- 3.36s (~10% speedup) after this change, with native C implementation of runkit_object_id()

Memory usage reported by PHP decreased by 10%, with or without the native C
implementation.
- Helpful if phan is meant to run in daemon mode
- Should help users to be able to use more processes to analyze large projects if memory is limited

The UnionType implementation details of the Set are rarely important outside
of a few Phan classes.
Having SplObjectStorage is inefficient for memory usage - An empty
SplObjectStorage requires more memory than an empty array,
and if it's cloned, a clone of the empty SplObjectStorage must be made
In contrast, creating a clone of an array is easy due to copy on write
semantics in php (`$x = $y`)

This uses an array, with the object id(int) as an array key, and the object itself
as a value.
- The only pecl I'm aware of that has the desired functionality
  (an integer id for any object, unique for the lifetime of that object)
  is runkit (undocumented, but there for a long time).
  This has a fork in php7 as well.
  This change should work with/without a stripped down module providing
  only the function `runkit_object_id(object $x) : int`
  See https://github.com/runkit7/runkit_object_id , which is intended as an optional dependency

Fix bug in suppressing PhanRedefineFunctionInternal
- We check if PhanRedefineFunction was suppressed, but should have
  checked PhanRedefineFunctionInternal

Add BaseTest, so that static properties can be preserved without being
touched between test runs. Without the special use properties,
PHPUnit would modify the private static properties.

The type of getTypeSet() changed to an array

---

This contains debugging code, which will be cleaned up later (More interested in the feedback on the change in general)
Also, there are some commented out type assertions (which would pass)