### PR TITLE
Fix expectation for plugin tests (PhanUndeclaredClassInstanceof for undeclared class \object)

### DIFF
--- a/tests/plugin_test/expected/all_output.expected
+++ b/tests/plugin_test/expected/all_output.expected
@@ -1,4 +1,5 @@
 src/000_plugins.php:4 PhanPluginInstanceOfObject Cannot call instanceof against `object`
+src/000_plugins.php:4 PhanUndeclaredClassInstanceof Checking instanceof against undeclared class \object
 src/000_plugins.php:10 PhanPluginDollarDollar $$ Variables are not allowed.
 src/000_plugins.php:17 PhanPluginDuplicateArrayKey Duplicate/Equivalent array key literal(0) detected in array - the earlier entry will be ignored.
 src/000_plugins.php:21 PhanPluginMixedKeyNoKey Should not mix array entries of the form [key => value,] with entries of the form [value,].


### PR DESCRIPTION
Now that `\object` is treated as a class name, this error message is emitted, and makes sense to emit 