### PR TITLE
Make file listing deterministic **within a directory**

### DIFF
--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -596,6 +596,13 @@ EOB;
         } catch (\Exception $exception) {
             error_log($exception->getMessage());
         }
+        usort($file_list, function(string $a, string $b) : int {
+            // Sort lexicographically by paths **within the results for a directory**,
+            // to work around some file systems not returning results lexicographically.
+            // Keep directories together by replacing directory separators with the null byte
+            // (E.g. "a.b" is lexicographically less than "a/b", but "aab" is greater than "a/b")
+            return strcmp(preg_replace("@[/\\\\]+@", "\0", $a), preg_replace("@[/\\\\]+@", "\0", $b));
+        });
 
         return $file_list;
     }


### PR DESCRIPTION
List them lexicographically, and group results for directories together.

This differs from consistent_hashing_file_order=true in that it only
affects processing within a directory, not across all directories.

Some file systems return files in an order other than lexicographically,
which would make Phan's output less consistent (E.g. if one file would
cause phan to infer a type for a property, and another file used that
inferred type)