### PR TITLE
Partial support for trait adaptations in classes using traits

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -30,6 +30,9 @@ New Features (Analysis)
 + Allow inferring the type of variables from `===` conditionals such as `if ($x === true)`
 + Add issue type for non-abstract classes containing abstract methods from itself or its ancestors
   (`PhanClassContainsAbstractMethod`, `PhanClassContainsAbstractMethodInternal`)
++ Partial support for handling trait adaptations (`as`/`insteadof`) when using traits (Issue #312)
++ Start checking if uses of private/protected class methods *defined in a trait* are visible outside of that class.
+  Before, Phan would always assume they were visible, to reduce false positives.
 
 New Features (CLI, Configs)
 + (Linux/Unix only) Add Experimental Phan Daemon mode (PR #563 for Issue #22), which allows phan to run in the background, and accept TCP requests to analyze single files.

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1568,7 +1568,6 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
     ) {
         if (
             $method->isPrivate()
-            && !$method->getDefiningClass($code_base)->isTrait()
             && (
                 !$this->context->isInClassScope()
                 || $this->context->getClassFQSEN() != $method->getDefiningClassFQSEN()
@@ -1583,7 +1582,6 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             );
         } else if (
             $method->isProtected()
-            && !$method->getDefiningClass($code_base)->isTrait()
             && (
                 !$this->context->isInClassScope()
                 || (

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -11,14 +11,19 @@ class Issue
     const SyntaxError               = 'PhanSyntaxError';
 
     // Issue::CATEGORY_UNDEFINED
+    const AmbiguousTraitAliasSource = 'AmbiguousTraitAliasSource';
+    const ClassContainsAbstractMethodInternal = 'PhanClassContainsAbstractMethodInternal';
+    const ClassContainsAbstractMethod = 'PhanClassContainsAbstractMethod';
     const EmptyFile                 = 'PhanEmptyFile';
     const ParentlessClass           = 'PhanParentlessClass';
+    const RequiredTraitNotAdded     = 'PhanRequiredTraitNotAdded';
     const TraitParentReference      = 'PhanTraitParentReference';
-    const UndeclaredClass           = 'PhanUndeclaredClass';
+    const UndeclaredAliasedMethodOfTrait = 'PhanUndeclaredAliasedMethodOfTrait';
     const UndeclaredClassCatch      = 'PhanUndeclaredClassCatch';
     const UndeclaredClassConstant   = 'PhanUndeclaredClassConstant';
     const UndeclaredClassInstanceof = 'PhanUndeclaredClassInstanceof';
     const UndeclaredClassMethod     = 'PhanUndeclaredClassMethod';
+    const UndeclaredClass           = 'PhanUndeclaredClass';
     const UndeclaredClassReference  = 'PhanUndeclaredClassReference';
     const UndeclaredClosureScope    = 'PhanUndeclaredClosureScope';
     const UndeclaredConstant        = 'PhanUndeclaredConstant';
@@ -33,8 +38,6 @@ class Issue
     const UndeclaredTypeParameter   = 'PhanUndeclaredTypeParameter';
     const UndeclaredTypeProperty    = 'PhanUndeclaredTypeProperty';
     const UndeclaredVariable        = 'PhanUndeclaredVariable';
-    const ClassContainsAbstractMethod = 'PhanClassContainsAbstractMethod';
-    const ClassContainsAbstractMethodInternal = 'PhanClassContainsAbstractMethodInternal';
 
     // Issue::CATEGORY_TYPE
     const NonClassMethodCall        = 'PhanNonClassMethodCall';
@@ -529,6 +532,30 @@ class Issue
                 "non-abstract class {CLASS} contains abstract internal method {METHOD}",
                 self::REMEDIATION_B,
                 1023
+            ),
+            new Issue(
+                self::UndeclaredAliasedMethodOfTrait,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_CRITICAL,
+                "Alias {METHOD} was defined for a method {METHOD} which does not exist in trait {TRAIT}",
+                self::REMEDIATION_B,
+                1024
+            ),
+            new Issue(
+                self::RequiredTraitNotAdded,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_NORMAL,
+                "Required trait {TRAIT} for trait adaptation was not added to class",
+                self::REMEDIATION_B,
+                1025
+            ),
+            new Issue(
+                self::AmbiguousTraitAliasSource,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_NORMAL,
+                "Trait alias {METHOD} has an ambiguous source method {METHOD} with more than one possible source trait. Possibilities: {TRAIT}",
+                self::REMEDIATION_B,
+                1026
             ),
 
             // Issue::CATEGORY_ANALYSIS

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -193,6 +193,67 @@ class Method extends ClassElement implements FunctionInterface
     }
 
     /**
+     * @param int $new_visibility_flags (0 if unchanged)
+     * @return Method
+     * An alias from a trait use
+     */
+    public function createUseAlias(
+        Clazz $clazz,
+        CodeBase $code_base,
+        string $alias_method_name,
+        int $new_visibility_flags
+    ) : Method {
+
+        $method_fqsen = FullyQualifiedMethodName::make(
+            $clazz->getFQSEN(),
+            $alias_method_name
+        );
+
+        $method = new Method(
+            $this->getContext(),
+            $alias_method_name,
+            $this->getUnionType(),
+            $this->getFlags(),
+            $method_fqsen
+        );
+        switch ($new_visibility_flags) {
+        case \ast\flags\MODIFIER_PUBLIC:
+        case \ast\flags\MODIFIER_PROTECTED:
+        case \ast\flags\MODIFIER_PRIVATE:
+            // Replace the visibility with the new visibility.
+            $method->setFlags(Flags::bitVectorWithState(
+                Flags::bitVectorWithState(
+                    $method->getFlags(),
+                    \ast\flags\MODIFIER_PUBLIC | \ast\flags\MODIFIER_PROTECTED | \ast\flags\MODIFIER_PRIVATE,
+                    false
+                ),
+                $new_visibility_flags,
+                true
+            ));
+            break;
+        default:
+            break;
+        }
+
+        // Workaround: If you import a trait's method as private, it becomes private **to the class which used the trait**
+        // (But preserving the defining FQSEN is fine for this)
+        if (!Flags::bitVectorHasState($method->getFlags(), \ast\flags\MODIFIER_PRIVATE)) {
+            $method->setDefiningFQSEN($method_fqsen);
+        }
+
+        // TODO: setDefiningFQSEN?
+
+        // TODO: Update and add setNumberOfRealRequiredParameters once other PR is merged?
+        $parameter_list = $this->getParameterList();
+        $method->setParameterList($parameter_list);
+        $method->setRealParameterList($parameter_list);
+        $method->setNumberOfRequiredParameters($this->getNumberOfRequiredParameters());
+        $method->setNumberOfOptionalParameters($this->getNumberOfOptionalParameters());
+
+        return $method;
+    }
+
+    /**
      * @param Context $context
      * The context in which the node appears
      *

--- a/src/Phan/Language/Element/TraitAdaptations.php
+++ b/src/Phan/Language/Element/TraitAdaptations.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+namespace Phan\Language\Element;
+
+use Phan\Language\FQSEN;
+use Phan\Language\FQSEN\FullyQualifiedClassName;
+
+/**
+ * This contains info for a single sub-node of a node of type \ast\AST_USE_TRAIT
+ * (Which aliases of methods exist for this trait, which `insteadof` exist, etc)
+ */
+class TraitAdaptations
+{
+    /**
+     * @var FQSEN
+     */
+    private $trait_fqsen;
+
+    /**
+     * @var TraitAliasSource[] maps alias methods from this trait
+     *                         to the info about the source method
+     */
+    public $alias_methods;
+
+    /**
+     * @var bool[] Has an entry mapping name to true if a method with a given name is hidden.
+     */
+    public $hidden_methods;
+
+    public function __construct(FQSEN $trait_fqsen)
+    {
+        $this->trait_fqsen = $trait_fqsen;
+    }
+
+    /**
+     * Gets the FQSEN
+     *
+     * @return FQSEN the trait's FQSEN
+     */
+    public function getTraitFQSEN() : FQSEN
+    {
+        return $this->trait_fqsen;
+    }
+}

--- a/src/Phan/Language/Element/TraitAliasSource.php
+++ b/src/Phan/Language/Element/TraitAliasSource.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+namespace Phan\Language\Element;
+
+/**
+ * This contains info for the source method of a trait alias.
+ */
+class TraitAliasSource
+{
+    /**
+     * @var int line number where this trait method alias was created
+     * (in the class using traits).
+     */
+    private $alias_lineno;
+
+    /**
+     * @var string source method name
+     */
+    private $source_method_name;
+
+    /**
+     * @var int the overriden visibility modifier, or 0 if the visibility didn't change
+     */
+    private $alias_visibility_flags;
+
+    public function __construct(string $source_method_name, int $alias_lineno, int $alias_visibility_flags)
+    {
+        $this->source_method_name = $source_method_name;
+        $this->alias_lineno = $alias_lineno;
+        $this->alias_visibility_flags = $alias_visibility_flags;
+    }
+
+    public function getSourceMethodName() : string
+    {
+        return $this->source_method_name;
+    }
+
+    public function getAliasLineno() : int
+    {
+        return $this->alias_lineno;
+    }
+
+    public function getAliasVisibilityFlags() : int
+    {
+        return $this->alias_visibility_flags;
+    }
+}

--- a/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
@@ -147,7 +147,7 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
         Context $context
     ) {
         // Check to see if we're fully qualified
-        if ($fqsen_string[0] === '\\') {
+        if (($fqsen_string[0] ?? '') === '\\') {
             return static::fromFullyQualifiedString($fqsen_string);
         }
         $namespace_map_type = static::getNamespaceMapType();

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -257,20 +257,27 @@ class ParseVisitor extends ScopeVisitor
         // Bomb out if we're not in a class context
         $class = $this->getContextClass();
 
-        $trait_fqsen_string_list = (new ContextNode(
+        $trait_fqsen_list = (new ContextNode(
             $this->code_base,
             $this->context,
             $node->children['traits']
-        ))->getQualifiedNameList();
+        ))->getTraitFQSENList();
 
         // Add each trait to the class
-        foreach ($trait_fqsen_string_list as $trait_fqsen_string) {
-            $trait_fqsen = FullyQualifiedClassName::fromStringInContext(
-                $trait_fqsen_string,
-                $this->context
-            );
-
+        foreach ($trait_fqsen_list as $trait_fqsen) {
             $class->addTraitFQSEN($trait_fqsen);
+        }
+
+        // Get the adaptations for those traits
+        // Pass in the corresponding FQSENs for those traits.
+        $trait_adaptations_map = (new ContextNode(
+            $this->code_base,
+            $this->context,
+            $node->children['adaptations']
+        ))->getTraitAdaptationsMap($trait_fqsen_list);
+
+        foreach ($trait_adaptations_map as $trait_adaptations) {
+            $class->addTraitAdaptations($trait_adaptations);
         }
 
         return $this->context;

--- a/tests/files/expected/0176_trait_private_method.php.expected
+++ b/tests/files/expected/0176_trait_private_method.php.expected
@@ -1,0 +1,1 @@
+%s:26 PhanAccessMethodPrivate Cannot access private method \D176::f2 defined at %s:5

--- a/tests/files/expected/0294_trait_as_and_insteadof.php.expected
+++ b/tests/files/expected/0294_trait_as_and_insteadof.php.expected
@@ -1,0 +1,4 @@
+%s:32 PhanTypeMismatchArgument Argument 1 (x) is int but \ClassUsingTrait294::foO() takes string defined at %s:14
+%s:34 PhanUndeclaredMethod Call to undeclared method \ClassUsingTrait294::foo3
+%s:36 PhanTypeMismatchArgument Argument 1 (x) is string but \ClassUsingTrait294::foo2() takes int defined at %s:5
+%s:37 PhanTypeMismatchArgument Argument 1 (x) is float but \ClassUsingTrait294::bAr() takes array defined at %s:17

--- a/tests/files/expected/0295_bad_trait_adaptations.php.expected
+++ b/tests/files/expected/0295_bad_trait_adaptations.php.expected
@@ -1,0 +1,5 @@
+%s:13 PhanUndeclaredAliasedMethodOfTrait Alias \A295::bar was defined for a method \Trait295::foo which does not exist in trait Trait295
+%s:14 PhanRequiredTraitNotAdded Required trait \Trait295B for trait adaptation was not added to class
+%s:15 PhanRequiredTraitNotAdded Required trait \Trait295C for trait adaptation was not added to class
+%s:22 PhanUndeclaredMethod Call to undeclared method \A295::bar
+%s:23 PhanUndeclaredMethod Call to undeclared method \A295::foo

--- a/tests/files/expected/0296_private_trait_adaptations.php.expected
+++ b/tests/files/expected/0296_private_trait_adaptations.php.expected
@@ -1,0 +1,9 @@
+%s:29 PhanAccessMethodPrivate Cannot access private method \A296::asPrivateAlias defined at %s:5
+%s:38 PhanAccessMethodPrivate Cannot access private method \B296::asPrivateAlias defined at %s:5
+%s:55 PhanAccessMethodPrivate Cannot access private method \A296::fPrivateAsPublic defined at %s:10
+%s:56 PhanAccessMethodPrivate Cannot access private method \A296::fPrivateAsProtected defined at %s:11
+%s:57 PhanAccessMethodProtected Cannot access protected method \A296::fProtectedAsPublic defined at %s:12
+%s:62 PhanAccessMethodProtected Cannot access protected method \A296::asProtectedAlias defined at %s:6
+%s:63 PhanAccessMethodPrivate Cannot access private method \A296::asPrivateAlias defined at %s:5
+%s:65 PhanUndeclaredMethod Call to undeclared method \A296::fMissing
+%s:67 PhanAccessMethodPrivate Cannot access private method \A296::privateNonTrait defined at %s:32

--- a/tests/files/expected/0297_ambiguous_trait_source.php.expected
+++ b/tests/files/expected/0297_ambiguous_trait_source.php.expected
@@ -1,0 +1,1 @@
+%s:7 AmbiguousTraitAliasSource Trait alias bar has an ambiguous source method foo with more than one possible source trait. Possibilities: [\X297, \Y297]

--- a/tests/files/src/0176_trait_private_method.php
+++ b/tests/files/src/0176_trait_private_method.php
@@ -1,12 +1,32 @@
 <?php
 
-trait T {
-    private function f() {}
+trait T176 {
+    protected function f1() {}
+    private function f2() {}
 }
 
-class C {
-    use T;
-    function g() {
-        return $this->f();
+class C176 {
+    use T176;
+    function g1() {
+        return $this->f1();
+    }
+    function g2() {
+        echo "Calling f2\n";
+        return $this->f2();
     }
 }
+
+class D176 extends C176{
+    function methodOfSubclass1() {
+        echo "Calling f1 from subclass\n";
+        return $this->f1();
+    }
+    function methodOfSubclass2() {
+        echo "Calling f2 from subclass\n";
+        return $this->f2();
+    }
+}
+(new D176())->g1();  // for demonstrative purposes. This is fine.
+(new D176())->g2();  // for demonstrative purposes. This is fine.
+(new D176())->methodOfSubclass1();  // for demonstrative purposes. This is fine.
+(new D176())->methodOfSubclass2();  // for demonstrative purposes. This will throw an Error

--- a/tests/files/src/0294_trait_as_and_insteadof.php
+++ b/tests/files/src/0294_trait_as_and_insteadof.php
@@ -1,0 +1,40 @@
+<?php
+
+// Test that the code is case insensitive
+trait ATrait294 {
+    public function Foo(int $x) {
+    }
+
+    public function baR(float $x) {
+    }
+}
+
+// Test that the code is case insensitive
+trait BTrait294 {
+    public function foO(string $x) {
+    }
+
+    public function bAr(array $x) {
+    }
+}
+
+// Test that the code is case insensitive
+class ClassUsingTrait294 {
+    use ATrait294, BTRAIT294 {
+        ATrait294::foo as foo2;
+        BTrait294::fOo insteadof aTrait294;
+        BTrait294::Bar insteadof ATrait294;
+    }
+}
+
+function testUsingTrait294() {
+    $x = new ClassUsingTrait294();
+    $x->foo(42);
+    $x->foo2(42);
+    $x->foo3(42);
+    $x->foo("?");
+    $x->foo2("?");
+    $x->bar(4.2);
+    $x->bar([4.2]);
+}
+testUsingTrait294();

--- a/tests/files/src/0295_bad_trait_adaptations.php
+++ b/tests/files/src/0295_bad_trait_adaptations.php
@@ -1,0 +1,24 @@
+<?php
+// Phan should detect and catch some types of misuse of trait adaptations(`insteadof`/`as`)
+
+trait Trait295 {
+    public function baz() { }
+    public function xyz() { }
+}
+trait Trait295B {
+}
+
+class A295 {
+    use Trait295 {
+        Trait295::foo as bar;
+        Trait295B::xyz insteadof Trait295;
+        Trait295C::zz as zzAlias;
+    }
+}
+
+function test295() {
+    $x = new A295();
+    $x->baz();
+    $x->bar();
+    $x->foo();
+}

--- a/tests/files/src/0296_private_trait_adaptations.php
+++ b/tests/files/src/0296_private_trait_adaptations.php
@@ -1,0 +1,69 @@
+<?php
+// Phan should detect and catch some types of misuse of trait adaptations(`insteadof`/`as`)
+
+trait Trait296 {
+    public function fPrivate() { }
+    public function fProtected() { }
+    public function fPublic() { }
+    public function fRegular() { }
+
+    private function fPrivateAsPublic() {}
+    private function fPrivateAsProtected() {}
+    protected function fProtectedAsPublic() {}
+}
+
+trait Trait296B {
+}
+
+class A296 {
+    use Trait296 {
+        fPrivate as private asPrivateAlias;
+        fProtected as protected asProtectedAlias;
+        fPublic as public asPublicAlias;
+        fPrivateAsPublic as public asPublicAliasFromPrivate;
+        fPrivateAsProtected as protected asProtectedAliasFromPrivate;
+        fProtectedAsPublic as public asPublicAliasFromProtected;
+    }
+
+    public function accessAPrivate() {
+        return $this->asPrivateAlias();
+    }
+
+    private function privateNonTrait() {
+    }
+}
+
+class B296 extends A296 {
+    public function accessParentPrivate() {
+        return $this->asPrivateAlias();
+    }
+
+    public function accessParentProtected() {
+        $this->asProtectedAliasFromPrivate();
+        return $this->asProtectedAlias();
+    }
+}
+
+function test296() {
+    $x = new A296();
+    // should not warn, the originals are still public
+    $x->fPublic();
+    $x->fProtected();
+    $x->fPrivate();
+    $x->fRegular();
+
+    $x->fPrivateAsPublic(); // warn, source visibility does not change
+    $x->fPrivateAsProtected(); // warn
+    $x->fProtectedAsPublic(); // warn
+
+    // but the new visibilities should be applied
+    $x->asPublicAliasFromPrivate();
+    $x->asPublicAlias();
+    $x->asProtectedAlias();  // warn about bad access
+    $x->asPrivateAlias();  // warn about bad access
+
+    $x->fMissing();
+
+    $x->privateNonTrait();  // continue warning about private methods that aren't part of traits
+}
+test296();

--- a/tests/files/src/0297_ambiguous_trait_source.php
+++ b/tests/files/src/0297_ambiguous_trait_source.php
@@ -1,0 +1,12 @@
+<?php
+
+class Foo297 {
+    use X297, Y297 {
+        // Could be from X297 or Y297, and Phan may not have finished parsing,
+        // so just give up on analyzing and warn for now.
+        foo as bar;
+    }
+}
+
+trait X297{}
+trait Y297{}


### PR DESCRIPTION
Related to https://github.com/etsy/phan/issues/312

Adaptations (terminology from php-ast) are `as`/`insteadof` commands.

This does the following:

- Skip over a method from a trait if it is mentioned in (the right hand side of) `insteadof`
- Add aliases of a method if it is mentioned in `as` (And check if the source exists while resolving it)
  (This is what `as` does, it preserves the original unless there is an
  `insteadof`)
- Check if a trait that wasn't `use`d was mentioned in an adaptation.
- Uses case insensitive lookups for trait names and method names.
- Basic unit tests

Remaining tasks, to be addressed later in separate PRs:

- Check compatibility in inheritance (have to figure out what the rules are)
- Check for conflicts in trait definitions
- Support changing visibility (`use TraitName {foo as protected;}`)
- Support analyzing abstract trait members
- Check that trait properties are compatible (visibility, default values)