### PR TITLE
Verify that abstract methods of non-abstract classes are implemented.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -28,6 +28,8 @@ New Features (Analysis)
   the phpdoc `@param` is out of sync with the code,
   or if the phpdoc annotation doesn't apply to an element type (Issue #778)
 + Allow inferring the type of variables from `===` conditionals such as `if ($x === true)`
++ Add issue type for non-abstract classes containing abstract methods from itself or its ancestors
+  (`PhanClassContainsAbstractMethod`, `PhanClassContainsAbstractMethodInternal`)
 
 New Features (CLI, Configs)
 + (Linux/Unix only) Add Experimental Phan Daemon mode (PR #563 for Issue #22), which allows phan to run in the background, and accept TCP requests to analyze single files.

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1287,7 +1287,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             && $function->getUnionType()->isEmpty()
         ) {
             $map = UnionType::internalFunctionSignatureMapForFQSEN(
-                $function->getFQSEN()
+                $function_fqsen
             );
 
             return $map[$function_name] ?? new UnionType();

--- a/src/Phan/Analysis/AbstractMethodAnalyzer.php
+++ b/src/Phan/Analysis/AbstractMethodAnalyzer.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+namespace Phan\Analysis;
+
+use Phan\CodeBase;
+use Phan\Exception\IssueException;
+use Phan\Issue;
+use Phan\Language\Element\Clazz;
+use Phan\Language\Element\Parameter;
+use Phan\Language\FQSEN;
+use Phan\Language\UnionType;
+
+/**
+ * This verifies that the inherited abstract methods are all implemented on non-abstract clases.
+ * NOTE: This step must be run after adding methods from this class and each of its ancestors.
+ */
+class AbstractMethodAnalyzer
+{
+
+    /**
+     * Check to see if signatures match
+     *
+     * @return void
+     */
+    public static function analyzeAbstractMethodsAreImplemented(
+        CodeBase $code_base,
+        Clazz $class
+    ) {
+        // Don't worry about internal classes
+        if ($class->isPHPInternal()) {
+            return;
+        }
+        // Don't worry about traits or abstract classes, those can have abstract methods
+        if ($class->isAbstract() || $class->isTrait() || $class->isInterface()) {
+            return;
+        }
+        foreach ($class->getMethodMap($code_base) as $method) {
+            if ($method->isAbstract()) {
+                if ($method->isPHPInternal()) {
+                    Issue::maybeEmit(
+                        $code_base,
+                        $class->getContext(),
+                        Issue::ClassContainsAbstractMethodInternal,
+                        $class->getFileRef()->getLineNumberStart(),
+                        (string)$class->getFQSEN(),
+                        (string)$method->getDefiningFQSEN()
+                    );
+                } else {
+                    Issue::maybeEmit(
+                        $code_base,
+                        $class->getContext(),
+                        Issue::ClassContainsAbstractMethod,
+                        $class->getFileRef()->getLineNumberStart(),
+                        (string)$class->getFQSEN(),
+                        (string)$method->getDefiningFQSEN(),
+                        $method->getFileRef()->getFile(),
+                        $method->getFileRef()->getLineNumberStart()
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -33,6 +33,8 @@ class Issue
     const UndeclaredTypeParameter   = 'PhanUndeclaredTypeParameter';
     const UndeclaredTypeProperty    = 'PhanUndeclaredTypeProperty';
     const UndeclaredVariable        = 'PhanUndeclaredVariable';
+    const ClassContainsAbstractMethod = 'PhanClassContainsAbstractMethod';
+    const ClassContainsAbstractMethodInternal = 'PhanClassContainsAbstractMethodInternal';
 
     // Issue::CATEGORY_TYPE
     const NonClassMethodCall        = 'PhanNonClassMethodCall';
@@ -511,6 +513,22 @@ class Issue
                 "Reference to undeclared class {CLASS} in PhanClosureScope",
                 self::REMEDIATION_B,
                 1021
+            ),
+            new Issue(
+                self::ClassContainsAbstractMethod,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_NORMAL,
+                "non-abstract class {CLASS} contains abstract method {METHOD} declared at {FILE}:{LINE}",
+                self::REMEDIATION_B,
+                1022
+            ),
+            new Issue(
+                self::ClassContainsAbstractMethodInternal,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_NORMAL,
+                "non-abstract class {CLASS} contains abstract internal method {METHOD}",
+                self::REMEDIATION_B,
+                1023
             ),
 
             // Issue::CATEGORY_ANALYSIS

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -118,6 +118,15 @@ class Method extends ClassElement implements FunctionInterface
 
     /**
      * @return bool
+     * True if this is the `__construct` method
+     * (Does not return true for php4 constructors)
+     */
+    public function getIsNewConstructor() : bool {
+        return strcasecmp('__construct', $this->getName()) === 0;
+    }
+
+    /**
+     * @return bool
      * True if this is the magic `__call` method
      */
     public function getIsMagicCall() : bool {

--- a/tests/files/expected/0188_prop_array_access.php.expected
+++ b/tests/files/expected/0188_prop_array_access.php.expected
@@ -1,0 +1,4 @@
+%s:2 PhanClassContainsAbstractMethodInternal non-abstract class \C188 contains abstract internal method \ArrayAccess::offsetExists
+%s:2 PhanClassContainsAbstractMethodInternal non-abstract class \C188 contains abstract internal method \ArrayAccess::offsetGet
+%s:2 PhanClassContainsAbstractMethodInternal non-abstract class \C188 contains abstract internal method \ArrayAccess::offsetSet
+%s:2 PhanClassContainsAbstractMethodInternal non-abstract class \C188 contains abstract internal method \ArrayAccess::offsetUnset

--- a/tests/files/expected/0229_property_assignment.php.expected
+++ b/tests/files/expected/0229_property_assignment.php.expected
@@ -1,0 +1,4 @@
+%s:3 PhanClassContainsAbstractMethodInternal non-abstract class \A254 contains abstract internal method \ArrayAccess::offsetExists
+%s:3 PhanClassContainsAbstractMethodInternal non-abstract class \A254 contains abstract internal method \ArrayAccess::offsetGet
+%s:3 PhanClassContainsAbstractMethodInternal non-abstract class \A254 contains abstract internal method \ArrayAccess::offsetSet
+%s:3 PhanClassContainsAbstractMethodInternal non-abstract class \A254 contains abstract internal method \ArrayAccess::offsetUnset

--- a/tests/files/expected/0292_undefined_abstract_method.php.expected
+++ b/tests/files/expected/0292_undefined_abstract_method.php.expected
@@ -1,0 +1,3 @@
+%s:3 PhanClassContainsAbstractMethodInternal non-abstract class \Foo292 contains abstract internal method \Serializable::unserialize
+%s:13 PhanClassContainsAbstractMethod non-abstract class \B292 contains abstract method \A292::f2 declared at %s:9
+%s:42 PhanClassContainsAbstractMethod non-abstract class \ClassExtendingInterface292 contains abstract method \Interface292::myFunction declared at %s:38

--- a/tests/files/src/0188_prop_array_access.php
+++ b/tests/files/src/0188_prop_array_access.php
@@ -1,9 +1,9 @@
 <?php
-class C implements ArrayAccess {}
-$v = new C;
+class C188 implements ArrayAccess {}
+$v = new C188;
 $v['key'] = 42;
-class E {
-    /** @var C */
+class E188 {
+    /** @var C188 */
     private $p;
     function f() {
         $this->p['key'] = 42;

--- a/tests/files/src/0292_undefined_abstract_method.php
+++ b/tests/files/src/0292_undefined_abstract_method.php
@@ -1,0 +1,44 @@
+<?php
+
+class Foo292 implements Serializable {
+    public function serialize() { return ''; }
+}
+
+abstract class A292 {
+    public abstract function f1(int $x);
+    public abstract function f2(int $x);
+}
+
+// Should warn, did not implement f2
+class B292 extends A292 {
+    public function f1(int $x) {
+    }
+}
+
+// This is abstract, should not warn
+abstract class C292 extends A292 {
+    public function f2(int $x) { }
+}
+
+// Should not warn, implements f1 and f2
+class D292 extends C292 {
+    public function f1(int $x) { }
+}
+
+class ETrait292 {
+    public function f1(int $x) { }
+}
+
+// should not warn, ETrait292 provides f1
+class E292 extends C292 {
+    use ETrait292;
+}
+
+interface Interface292 {
+    function myFunction();
+    function myImplementedFunction();
+}
+
+class ClassExtendingInterface292 implements Interface292 {
+    function myImplementedFunction() {}
+}


### PR DESCRIPTION
This is done after adding abstract and non-abstract methods from the
parent class, interfaces, and traits.

This helps if classes are spread across multiple files.
It also helps when detecting unimplemented abstract methods from internal
interfaces (e.g. `Serializable`)

The checks if the overriding and overridden methods are abstract or constructors in
Clazz were needed for phan self-tests to continue to work.

Add tests, update existing tests which didn't implement ArrayAccess.

Performance impact was negligible
(time needed increased from 3.82s to 3.88s for self-test)