### PR TITLE
Treat internal types as phpdoc types

### DIFF
--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -715,10 +715,6 @@ class Type
             return self::fromInternalTypeName($type_name, $is_nullable, $source);
         }
 
-        if ($source === Type::FROM_PHPDOC && ($namespace ?: '\\') === '\\') {
-            $type_name = self::canonicalNameFromName($type_name);
-        }
-
         // Things like `self[]` or `$this[]`
         if ($is_generic_array_type
             && self::isSelfTypeString($non_generic_array_type_name)

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -266,7 +266,7 @@ class UnionType implements \Serializable
             // Figure out the return type
             $return_type_name = array_shift($type_name_struct);
             $return_type = $return_type_name
-                ? UnionType::fromStringInContext($return_type_name, $context, Type::FROM_TYPE)
+                ? UnionType::fromStringInContext($return_type_name, $context, Type::FROM_PHPDOC)
                 : null;
 
             $name_type_name_map = $type_name_struct;
@@ -275,7 +275,7 @@ class UnionType implements \Serializable
             foreach ($name_type_name_map as $name => $type_name) {
                 $parameter_name_type_map[$name] = empty($type_name)
                     ? new UnionType()
-                    : UnionType::fromStringInContext($type_name, $context, Type::FROM_TYPE);
+                    : UnionType::fromStringInContext($type_name, $context, Type::FROM_PHPDOC);
             }
 
             $configurations[] = [

--- a/tests/files/expected/0289_check_incorrect_soft_types.php.expected
+++ b/tests/files/expected/0289_check_incorrect_soft_types.php.expected
@@ -1,5 +1,5 @@
 %s:3 PhanUndeclaredTypeParameter Parameter of undeclared type \resource
 %s:4 PhanTypeMismatchArgumentInternal Argument 1 (fp) is \resource but \fread() takes resource
-%s:10 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \bool|resource but \intdiv() takes int
+%s:10 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is bool|resource but \intdiv() takes int
 %s:14 PhanUndeclaredTypeParameter Parameter of undeclared type \object
 %s:18 PhanUndeclaredTypeParameter Parameter of undeclared type \mixed

--- a/tests/files/expected/0290_internal_types_are_phpdoc_types.php.expected
+++ b/tests/files/expected/0290_internal_types_are_phpdoc_types.php.expected
@@ -1,0 +1,1 @@
+%s:4 PhanNonClassMethodCall Call to method doSomething on non-class type bool|int

--- a/tests/files/src/0290_internal_types_are_phpdoc_types.php
+++ b/tests/files/src/0290_internal_types_are_phpdoc_types.php
@@ -1,0 +1,4 @@
+<?php
+
+$result = filter_id('not-a-filter');
+$result->doSomething();


### PR DESCRIPTION
In #559 (and potentially earlier), any type in the `Type::canonicalNameFromName` map used in the internal function signature map would result in them being treated as a globally namespaced class. For example, the `fopen` function returns `resource|false`, which ends up becoming `\bool|resource`. It even showed up in 98b5f99691bd5407ecee87d956548e40fe136d63, but wasn't obvious that this was an error.

This PR treats function signatures in the internal function signature map as phpdoc types, and so `false` rightly becomes `bool`.

I've also included a test case that currently fails on master with the following issue:
```
PhanUndeclaredClassMethod Call to method doSomething from undeclared class \bool
```

Finally, there appear to be a number of extraneous calls to `Type::canonicalNameFromName` - I've removed one that I am very confident is safe, but the others might require a bit more digging. 

- https://github.com/etsy/phan/blob/7349420d895a29d3c26a9bbb10ec511fbe09f40e/src/Phan/Language/Type.php#L207-L209
- https://github.com/etsy/phan/blob/7349420d895a29d3c26a9bbb10ec511fbe09f40e/src/Phan/Language/Type.php#L250-L253

Thanks!
