### PR TITLE
Optimize BlockAnalysisVisitor

### DIFF
--- a/src/Phan/AST/Visitor/Element.php
+++ b/src/Phan/AST/Visitor/Element.php
@@ -131,14 +131,17 @@ class Element
     /**
      * Accepts a visitor that differentiates on the kind value
      * of the AST node.
+     *
+     * NOTE: This was turned into a static method for performance
+     * because it was called extremely frequently.
      */
-    public function acceptKindVisitor(KindVisitor $visitor)
+    public static function acceptNodeAndKindVisitor(Node $node, KindVisitor $visitor)
     {
-        $fn_name = self::VISIT_LOOKUP_TABLE[$this->node->kind] ?? null;
+        $fn_name = self::VISIT_LOOKUP_TABLE[$node->kind] ?? null;
         if (is_string($fn_name)) {
-            return $visitor->{$fn_name}($this->node);
+            return $visitor->{$fn_name}($node);
         } else {
-            Debug::printNode($this->node);
+            Debug::printNode($node);
             assert(false, 'All node kinds must match');
         }
     }

--- a/src/Phan/AST/Visitor/KindVisitorImplementation.php
+++ b/src/Phan/AST/Visitor/KindVisitorImplementation.php
@@ -19,7 +19,7 @@ abstract class KindVisitorImplementation implements KindVisitor
      */
     public function __invoke(Node $node)
     {
-        return (new Element($node))->acceptKindVisitor($this);
+        return Element::acceptNodeAndKindVisitor($node, $this);
     }
 
     public function visitArgList(Node $node)


### PR DESCRIPTION
Move recursion into BlockAnalysisVisitor->recurse()
- It was repetitive and required changing multiple invocations to add extra parameters
- If BlockAnalysisVisitor's child visitors ended up having a lot of properties that didn't vary (e.g. if blockexitstatus was added, more config values were added), copying would be inefficient
- Speed self-analysis from 3.90 to 3.80 seconds

Convert acceptKindVisitor into a static method
- It is called extremely frequently.
  (Leave the other methods alone)

PHP can cache the memory address of a static method,
but I don't think it can cache the memory address of an instance method.
Also, invoking the constructor and creating a temporary object adds
extra work.

Time savings for self-analysis (around 4%)

- 3.9s originally
- 3.8s after implementing recurse()
- 3.7s after converting acceptNodeAndKindVisitor to a static method.