### PR TITLE
Switch to ast_version 40

### DIFF
--- a/src/Phan/AST/Visitor/Element.php
+++ b/src/Phan/AST/Visitor/Element.php
@@ -237,6 +237,8 @@ class Element
                 return $visitor->visitBinaryBoolAnd($this->node);
             case \ast\flags\BINARY_BOOL_OR:
                 return $visitor->visitBinaryBoolOr($this->node);
+            case \ast\flags\BINARY_COALESCE:
+                return $visitor->visitBinaryCoalesce($this->node);
             case \ast\flags\BINARY_IS_GREATER:
                 return $visitor->visitBinaryIsGreater($this->node);
             case \ast\flags\BINARY_IS_GREATER_OR_EQUAL:

--- a/src/Phan/AST/Visitor/FlagVisitor.php
+++ b/src/Phan/AST/Visitor/FlagVisitor.php
@@ -295,7 +295,7 @@ interface FlagVisitor
     public function visitUnaryBitwiseNot(Node $node);
 
     /**
-     * Visit a node with flag `\ast\flags\UNARYbOOL_NOT`
+     * Visit a node with flag `\ast\flags\UNARY_BOOL_NOT`
      */
     public function visitUnaryBoolNot(Node $node);
 
@@ -309,6 +309,10 @@ interface FlagVisitor
      */
     public function visitBinaryBoolOr(Node $node);
 
+    /**
+     * Visit a node with flag `\ast\flags\AST_COALESCE`
+     */
+    public function visitBinaryCoalesce(Node $node);
     /**
      * Visit a node with flag `\ast\flags\BINARY_IS_GREATER`
      */

--- a/src/Phan/AST/Visitor/FlagVisitorImplementation.php
+++ b/src/Phan/AST/Visitor/FlagVisitorImplementation.php
@@ -312,6 +312,11 @@ abstract class FlagVisitorImplementation implements FlagVisitor
         return $this->visit($node);
     }
 
+    public function visitBinaryCoalesce(Node $node)
+    {
+        return $this->visit($node);
+    }
+
     public function visitBinaryIsGreater(Node $node)
     {
         return $this->visit($node);

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -236,7 +236,7 @@ class Config
 
         // The vesion of the AST (defined in php-ast)
         // we're using
-        'ast_version' => 35,
+        'ast_version' => 40,
 
         // Set to true to emit profiling data on how long various
         // parts of Phan took to run. You likely don't care to do

--- a/src/Phan/Language/Element/Variable.php
+++ b/src/Phan/Language/Element/Variable.php
@@ -176,10 +176,11 @@ class Variable extends TypedElement
             );
         }
 
-        if (array_key_exists($name, Config::get()->globals_type_map)
-            || in_array($name, Config::get()->runkit_superglobals)
+        $config = Config::get();
+        if (array_key_exists($name, $config->globals_type_map)
+            || in_array($name, $config->runkit_superglobals)
         ) {
-            $type_string = Config::get()->globals_type_map[$name] ?? '';
+            $type_string = $config->globals_type_map[$name] ?? '';
             // Want to allow 'resource' or 'mixed' as a type here,
             return UnionType::fromStringInContext($type_string, $context, Type::FROM_PHPDOC);
         }


### PR DESCRIPTION
- tests and self-analysis work for both of php-ast 1.0.4 and 1.0.5-dev
- We already depend on php-ast 1.0.4
- Version 40 is more consistent in generating statement lists
  (instead of single nodes, or null, or scalars).
  It's probably possible to clean up some of the checks for
  non-statement lists or non-Nodes in future PRs
- Move the coalesce implementation, because coalesce is now a binary operation

See https://github.com/nikic/php-ast#40-current for release notes