### PR TITLE
Remove inaccurate comment

### DIFF
--- a/src/Phan/Library/Map.php
+++ b/src/Phan/Library/Map.php
@@ -3,8 +3,7 @@ namespace Phan\Library;
 
 /**
  * A map from object to object with key comparisons
- * based on spl_object_hash, which I believe its the zval's
- * memory address.
+ * based on spl_object_hash.
  */
 class Map extends \SplObjectStorage
 {


### PR DESCRIPTION
Key comparisons use this function, but this isn't strictly speaking true because of the random element:
https://github.com/php/php-src/blob/master/ext/spl/php_spl.c#L798