### PR TITLE
Fix for analysis of parameter type in method inherited by many places

### DIFF
--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -1114,6 +1114,15 @@ class Clazz extends AddressableElement
             $method->setDefiningFQSEN($method->getFQSEN());
             $method->setFQSEN($method_fqsen);
 
+            // Clone the parameter list, so that modifying the parameters on the first call won't modify the others.
+            // TODO: Make the parameter list immutable and have immutable types (e.g. getPhpdocParameterList(), setPhpdocParameterList()
+            // and use a clone of all of the parameters for analysis (quick_mode=false has different values).
+            // TODO: If they're immutable, they can be shared without cloning with less worry.
+            $method->setParameterList(
+                array_map(function (Parameter $parameter) : Parameter {
+                    return clone($parameter);
+                }, $method->getParameterList()));
+
             // If we have a parent type defined, map the method's
             // return type and parameter types through it
             if ($type_option->isDefined()) {


### PR DESCRIPTION
PostOrderAnalysisVisitor currently does several things when analyzing a
call to a method in thorough mode (quick_mode = false)

1. Fetches original parameter list into one variable, and clones the original parameter list to a new variable
   (Maybe should be changed to be the other way around, so we have long
   lived objects)
2. Modifies the parameters of the **first** (original) variable
3. Analyzes
4. Calls method->setParameterList(with the unchanged clone)

Step 2 was the cause of issue #754 , this PR fixes it
(The parameters weren't cloned when the method was inherited,
so other classes inheriting the method get overly specific types from
the first time a parameter list was analyzed)

Followup work could be to have immutable (e.g. just by ) getPhpdocParameterList and setPhpdocParameterList, and to clone/set the passed in parameters

- This allows re-using UnionType for parameter lists if you're sure they'll be unchanged
  (ImmutableUnionType could be a subclass, enforcing that restriction at runtime)