### PR TITLE
Remove runkit.superglobal mention from .phan/config.php

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -87,10 +87,6 @@ return [
     // nodes.
     'should_visit_all_nodes' => true,
 
-    // Override if runkit.superglobal ini directive is used.
-    // See Phan\Config.
-    'runkit_superglobals' => [],
-
     // Override to hardcode existence and types of (non-builtin) globals.
     // Class names must be prefixed with '\\'.
     'globals_type_map' => [],


### PR DESCRIPTION
This functionality is rarely ever used in PHP projects
(except for one project I needed it for,
which already has Phan setup).
It's still mentioned in src/Phan/Config.php and phan Issues.

.phan/config.php should mention common settings,
but not extremely uncommon settings or settings
that aren't meant to be changed.