### PR TITLE
Preserve known array types and object types in is_array()/is_object()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -33,6 +33,10 @@ New Features (Analysis)
 + Partial support for handling trait adaptations (`as`/`insteadof`) when using traits (Issue #312)
 + Start checking if uses of private/protected class methods *defined in a trait* are visible outside of that class.
   Before, Phan would always assume they were visible, to reduce false positives.
++ If Phan has inferred/been provided generic array types for a variable (e.g. `int[]`),
+  then analysis of the code within `if (is_array($x))` will act as though the type is `int[]`.
+  The checks `is_object` and `is_scalar` now also preserve known sub-types of the group of types.
+  (If Phan isn't aware of any sub-types, it will infer the generic version, e.g. `object`)
 
 New Features (CLI, Configs)
 + (Linux/Unix only) Add Experimental Phan Daemon mode (PR #563 for Issue #22), which allows phan to run in the background, and accept TCP requests to analyze single files.

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -9,6 +9,8 @@ use Phan\Langauge\Type;
 use Phan\Language\Context;
 use Phan\Language\Type\ArrayType;
 use Phan\Language\Type\NullType;
+use Phan\Language\Type\ObjectType;
+use Phan\Language\Element\Variable;
 use Phan\Language\UnionType;
 use ast\Node;
 
@@ -333,12 +335,119 @@ class ConditionVisitor extends KindVisitorImplementation
     private static function isCallStringWithSingleVariableArgument(Node $node) : bool
     {
         $args = $node->children['args']->children;
-        return count($args) === 1
-            && $args[0] instanceof Node
-            && $args[0]->kind === \ast\AST_VAR
-            && $node->children['expr'] instanceof Node
-            && !empty($node->children['expr']->children['name'] ?? null)
-            && is_string($node->children['expr']->children['name']);
+        if (count($args) === 1) {
+            $arg = $args[0];
+            if (($arg instanceof Node) && ($arg->kind === \ast\AST_VAR)) {
+                $expr = $node->children['expr'];
+                if ($expr instanceof Node) {
+                    $name = $expr->children['name'] ?? null;
+                    if (is_string($name) && $name) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * This function is called once, and returns closures to modify the types of variables.
+     *
+     * This contains Phan's logic for inferring the resulting union types of variables, e.g. in is_array($x).
+     *
+     * @return \Closure[] - The closures to call for a given
+     */
+    private static function initTypeModifyingClosuresForVisitCall() : array
+    {
+        $make_basic_assertion_callback = function(string $union_type_string) : \Closure
+        {
+            $type = UnionType::fromFullyQualifiedString(
+                $union_type_string
+            );
+
+            /** @return void */
+            return function(Variable $variable) use($type)
+            {
+                // Otherwise, overwrite the type for any simple
+                // primitive types.
+                $variable->setUnionType(clone($type));
+            };
+        };
+
+        /** @return void */
+        $array_callback = function(Variable $variable)
+        {
+            // Change the type to match the is_a relationship
+            // If we already have generic array types, then keep those
+            // (E.g. T[]|false becomes T[], ?array|null becomes array
+            $newType = $variable->getUnionType()->genericArrayTypes();
+            if ($newType->isEmpty()) {
+                $newType->addType(ArrayType::instance(false));
+            } else {
+                // Convert inferred (?T)[] to T[], ?array to array
+                if ($newType->containsNullable()) {
+                    $newType = $newType->nonNullableClone();
+                }
+            }
+            $variable->setUnionType($newType);
+        };
+
+        /** @return void */
+        $object_callback = function(Variable $variable) : void
+        {
+            // Change the type to match the is_a relationship
+            // If we already have the `object` type or generic object types, then keep those
+            // (E.g. T|false becomes T, object|T[]|iterable|null becomes object)
+            $newType = $variable->getUnionType()->objectTypes();
+            if ($newType->isEmpty()) {
+                $newType->addType(ObjectType::instance(false));
+            } else {
+                // Convert inferred ?MyClass to MyClass, ?object to object
+                if ($newType->containsNullable()) {
+                    $newType = $newType->nonNullableClone();
+                }
+            }
+            $variable->setUnionType($newType);
+        };
+        $scalar_callback = function(Variable $variable) : void
+        {
+            // Change the type to match the is_a relationship
+            // If we already have possible scalar types, then keep those
+            // (E.g. T|false becomes bool, T becomes int|float|bool|string|null)
+            $newType = $variable->getUnionType()->scalarTypes();
+            if ($newType->isEmpty() || $newType->isType(NullType::instance(false))) {
+                // If there are no inferred types, or the only type we saw was 'null',
+                // assume there this can be any possible scalar.
+                // (Excludes `resource`, which is technically a scalar)
+                $newType = UnionType::fromFullyQualifiedString('int|float|bool|string|null');
+            }
+            $variable->setUnionType($newType);
+        };
+
+        $float_callback = $make_basic_assertion_callback('float');
+        $int_callback = $make_basic_assertion_callback('int');
+        $null_callback = $make_basic_assertion_callback('null');
+        // Note: isset() is handled in visitIsset()
+
+        return [
+            'is_array' => $array_callback,
+            'is_bool' => $make_basic_assertion_callback('bool'),
+            'is_callable' => $make_basic_assertion_callback('callable'),
+            'is_double' => $float_callback,
+            'is_float' => $float_callback,
+            'is_int' => $int_callback,
+            'is_integer' => $int_callback,
+            'is_iterable' => $make_basic_assertion_callback('iterable'),  // TODO: Could keep basic array types and classes extending iterable
+            'is_long' => $int_callback,
+            'is_null' => $null_callback,
+            'is_numeric' => $make_basic_assertion_callback('string|int|float'),
+            'is_object' => $object_callback,
+            'is_real' => $float_callback,
+            'is_resource' => $make_basic_assertion_callback('resource'),
+            'is_scalar' => $scalar_callback,
+            'is_string' => $make_basic_assertion_callback('string'),
+            'empty' => $null_callback,
+        ];
     }
 
     /**
@@ -361,34 +470,16 @@ class ConditionVisitor extends KindVisitorImplementation
         }
 
         // Translate the function name into the UnionType it asserts
-        $map = array(
-            'is_array' => 'array',
-            'is_bool' => 'bool',
-            'is_callable' => 'callable',
-            'is_double' => 'float',
-            'is_float' => 'float',
-            'is_int' => 'int',
-            'is_integer' => 'int',
-            'is_iterable' => 'iterable',
-            'is_long' => 'int',
-            'is_null' => 'null',
-            'is_numeric' => 'string|int|float',
-            'is_object' => 'object',
-            'is_real' => 'float',
-            'is_resource' => 'resource',
-            'is_scalar' => 'int|float|bool|string|null',
-            'is_string' => 'string',
-            'empty' => 'null',
-        );
-
-        $function_name = $node->children['expr']->children['name'];
-        if (!isset($map[$function_name])) {
-            return $this->context;
+        static $map = null;
+        if (empty($map)) {
+             $map = self::initTypeModifyingClosuresForVisitCall();
         }
 
-        $type = UnionType::fromFullyQualifiedString(
-            $map[$function_name]
-        );
+        $function_name = strtolower($node->children['expr']->children['name']);
+        $type_modification_callback = $map[$function_name] ?? null;
+        if ($type_modification_callback === null) {
+            return $this->context;
+        }
 
         $context = $this->context;
 
@@ -409,23 +500,8 @@ class ConditionVisitor extends KindVisitorImplementation
             // Make a copy of the variable
             $variable = clone($variable);
 
-            $variable->setUnionType(
-                clone($variable->getUnionType())
-            );
-
-            // Change the type to match the is_a relationship
-            if ($type->isType(ArrayType::instance(false))
-                && $variable->getUnionType()->hasGenericArray()
-            ) {
-                // If the variable is already a generic array,
-                // note that it can be an arbitrary array without
-                // erasing the existing generic type.
-                $variable->getUnionType()->addUnionType($type);
-            } else {
-                // Otherwise, overwrite the type for any simple
-                // primitive types.
-                $variable->setUnionType($type);
-            }
+            // Modify the types of that variable.
+            $type_modification_callback($variable);
 
             // Overwrite the variable with its new type in this
             // scope without overwriting other scopes

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -938,7 +938,7 @@ class Type
 
     /**
      * @return bool
-     * True if all types in this union are scalars
+     * True if this type is scalar.
      *
      * @see \Phan\Deprecated\Util::type_scalar
      * Formerly `function type_scalar`
@@ -946,6 +946,15 @@ class Type
     public function isScalar() : bool
     {
         return false;  // Overridden in subclass ScalarType
+    }
+
+    /**
+     * @return bool
+     * True if this type is an object (or the phpdoc `object`)
+     */
+    public function isObject() : bool
+    {
+        return true;  // Overridden in various subclasses
     }
 
     /**

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -52,6 +52,11 @@ abstract class NativeType extends Type
         return false;
     }
 
+    public function isObject() : bool
+    {
+        return false;
+    }
+
     /**
      * @return bool
      * True if this Type can be cast to the given Type

--- a/src/Phan/Language/Type/StaticType.php
+++ b/src/Phan/Language/Type/StaticType.php
@@ -53,6 +53,11 @@ final class StaticType extends Type
         return true;
     }
 
+    public function isObject() : bool
+    {
+        return true;
+    }
+
     public function __toString() : string
     {
         $string = $this->name;

--- a/src/Phan/Language/Type/TemplateType.php
+++ b/src/Phan/Language/Type/TemplateType.php
@@ -45,4 +45,10 @@ class TemplateType extends Type
         return '';
     }
 
+    public function isObject() : bool
+    {
+        // Return true because we don't know, it may or may not be an object.
+        // Not sure if this will be called.
+        return true;
+    }
 }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -15,6 +15,7 @@ use Phan\Language\Type\FloatType;
 use Phan\Language\Type\IntType;
 use Phan\Language\Type\MixedType;
 use Phan\Language\Type\NullType;
+use Phan\Language\Type\ObjectType;
 use Phan\Language\Type\TemplateType;
 use Phan\Library\Set;
 use ast\Node;
@@ -965,7 +966,7 @@ class UnionType implements \Serializable
      * Takes "a|b[]|c|d[]|e" and returns "a|c|e"
      *
      * @return UnionType
-     * A UnionType with generic types filtered out
+     * A UnionType with generic array types filtered out
      *
      * @see \Phan\Deprecated\Pass2::nongenerics
      * Formerly `function nongenerics`
@@ -979,6 +980,70 @@ class UnionType implements \Serializable
                 }
             )
         );
+    }
+
+    /**
+     * Takes "a|b[]|c|d[]|e" and returns "b[]|d[]"
+     *
+     * @return UnionType
+     * A UnionType with generic array types kept, other types filtered out.
+     *
+     * @see nonGenericArrayTypes
+     * @see genericArrayElementTypes
+     */
+    public function genericArrayTypes() : UnionType
+    {
+        return new UnionType(
+            $this->type_set->filter(
+                function (Type $type) : bool {
+                    return $type->isGenericArray();
+                }
+            )
+        );
+    }
+
+    /**
+     * Takes "MyClass|int|array|?object" and returns "MyClass|?object"
+     *
+     * @return UnionType
+     * A UnionType with known object types kept, other types filtered out.
+     *
+     * @see nonGenericArrayTypes
+     * @see genericArrayElementTypes
+     */
+    public function objectTypes() : UnionType
+    {
+        return new UnionType(
+            $this->type_set->filter(
+                function (Type $type) : bool {
+                    return $type->isObject();
+                }
+            )
+        );
+    }
+
+    /**
+     * Takes "MyClass|int|?bool|array|?object" and returns "int|?bool"
+     * Takes "?MyClass" and returns "null"
+     *
+     * @return UnionType
+     * A UnionType with known object types kept, other types filtered out.
+     *
+     * @see nonGenericArrayTypes
+     * @see genericArrayElementTypes
+     */
+    public function scalarTypes() : UnionType
+    {
+        $types = $this->type_set->filter(
+            function (Type $type) : bool {
+                return $type->isScalar();
+            }
+        );
+        $nullType = NullType::instance(false);
+        if (!$types->contains($nullType) && $this->containsNullable()) {
+            $types->attach($nullType);
+        }
+        return new UnionType($types);
     }
 
     /**

--- a/tests/files/expected/0174_is_a_generic.php.expected
+++ b/tests/files/expected/0174_is_a_generic.php.expected
@@ -1,5 +1,5 @@
 %s:7 PhanTypeMismatchArgument Argument 1 (var) is array but \f() takes resource defined at %s:3
-%s:7 PhanTypeMismatchArgument Argument 1 (var) is array|string[] but \f() takes resource defined at %s:3
+%s:7 PhanTypeMismatchArgument Argument 1 (var) is string[] but \f() takes resource defined at %s:3
 %s:9 PhanTypeMismatchArgument Argument 1 (var) is bool but \f() takes resource defined at %s:3
 %s:12 PhanTypeMismatchReturn Returning type array|bool|null but g() is declared to return resource
-%s:12 PhanTypeMismatchReturn Returning type array|bool|string[] but g() is declared to return resource
+%s:12 PhanTypeMismatchReturn Returning type bool|string[] but g() is declared to return resource

--- a/tests/files/expected/0291_is_array_preserve_types.php.expected
+++ b/tests/files/expected/0291_is_array_preserve_types.php.expected
@@ -1,0 +1,5 @@
+%s:7 PhanNonClassMethodCall Call to method badMethodCall on non-class type int[]|null
+%s:10 PhanNonClassMethodCall Call to method badMethodCall on non-class type int
+%s:21 PhanUndeclaredMethod Call to undeclared method \ArrayAccess::offsetExisssssssts
+%s:22 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \ArrayAccess but \intdiv() takes int
+%s:31 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is bool but \intdiv() takes int

--- a/tests/files/src/0291_is_array_preserve_types.php
+++ b/tests/files/src/0291_is_array_preserve_types.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @param int[]|null $x
+ */
+function arrayCheck291($x) {
+    $x->badMethodCall();
+    if (is_array($x)) {
+        foreach ($x as $element) {
+            $element->badMethodCall();
+        }
+    }
+}
+
+/**
+ * @param ArrayAccess|null $x
+ */
+function objectCheck291($x) {
+    if (is_object($x)) {
+        $x->offsetExists('key');
+        $x->offsetExisssssssts('key');
+        intdiv($x, 2);  // make Phan show inferred union type of \ArrayAccess
+    }
+}
+
+/**
+ * @param stdClass|false $x
+ */
+function scalarCheck291($x) {
+    if (is_scalar($x)) {
+        intdiv($x, 2);  // make Phan show inferred union type of bool
+    }
+}


### PR DESCRIPTION
and is_scalar()

If there are no known types, then default to the object/phpdoc object
types, as before.

This may cause a few more new errors to show up in non-quick mode,
e.g. for is_object().
Adding @param for parameters with bad inferences or suppress
may be needed to hide those, now that there's no way to set something to
`object` or `array` unconditionally

- An ugly alternative may be to add tags to the optional
  assertion message (`assert(is_object($x), '@phan-generic-object')`)
- In many cases, there are interfaces, etc. that could be checked against
  if an object needed to be passed to a function or have a property
  modified.
- Wrong set of subtypes may be inferred for loop variables
- May be overestimating how often this would be a problem

Fixes #591