### PR TITLE
Support checks against literals and constants in ConditionVisitor

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -27,6 +27,7 @@ New Features (Analysis)
 + Emit low severity issues if Phan can't extract types from phpdoc,
   the phpdoc `@param` is out of sync with the code,
   or if the phpdoc annotation doesn't apply to an element type (Issue #778)
++ Allow inferring the type of variables from `===` conditionals such as `if ($x === true)`
 
 New Features (CLI, Configs)
 + (Linux/Unix only) Add Experimental Phan Daemon mode (PR #563 for Issue #22), which allows phan to run in the background, and accept TCP requests to analyze single files.

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -96,8 +96,8 @@ class ConditionVisitor extends KindVisitorImplementation
     }
 
     /**
-     * @param Node $left
-     * @param Node|int|float|string $right
+     * @param Node $varNode
+     * @param Node|int|float|string $expr
      * @return Context - Constant after inferring type from an expression such as `if ($x === 'literal')`
      */
     private function analyzeVarIsIdentical(Node $varNode, $expr) : Context

--- a/tests/files/expected/0292_strict_equality.php.expected
+++ b/tests/files/expected/0292_strict_equality.php.expected
@@ -1,0 +1,6 @@
+%s:10 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
+%s:13 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string[] but \intdiv() takes int
+%s:16 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is float but \intdiv() takes int
+%s:22 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is null but \intdiv() takes int
+%s:25 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is bool but \intdiv() takes int
+%s:28 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is bool but \intdiv() takes int

--- a/tests/files/src/0292_strict_equality.php
+++ b/tests/files/src/0292_strict_equality.php
@@ -1,0 +1,30 @@
+<?php
+
+const A292 = ['key'];
+class B292 {
+    const X = 1.5;
+}
+
+function foo292($x, $y, $z) {
+    if ($x === 'key') {
+        intdiv($x, 2);
+    }
+    if ($y === A292) {
+        intdiv($y, 2);
+    }
+    if ($z === B292::X) {
+        intdiv($z, 2);
+    }
+}
+
+function bar292($x, $y, $z) {
+    if ($x === null) {
+        intdiv($x, 2);
+    }
+    if ($y === false) {
+        intdiv($y, 2);
+    }
+    if ($z === true) {
+        intdiv($z, 2);
+    }
+}


### PR DESCRIPTION
Infer that `$x` is a `bool` from expressions such as
`if ($x === false)`, `$x === SOME_BOOL_CONST`, etc.

Unrelated: inline UnionType::fromNode to
UnionTypeVisitor::unionTypeFromNode within UnionTypeVisitor