### PR TITLE
Emit issues if Phan can't parse union type of a doc comment, or if doc comment doesn't correspond to code

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -24,6 +24,9 @@ New Features (Analysis)
 + Make conditionals such as `is_string` start applying to the condition in ternary operators (`$a ? $b : $c`)
 + Treat `resource`, `object`, and `mixed` as native types only when they occur in phpdoc.
   Outside of phpdoc (e.g. `$x instanceof resource`), analyze those names as if they were class names.
++ Emit low severity issues if Phan can't extract types from phpdoc,
+  the phpdoc `@param` is out of sync with the code,
+  or if the phpdoc annotation doesn't apply to an element type (Issue #778)
 
 New Features (CLI, Configs)
 + (Linux/Unix only) Add Experimental Phan Daemon mode (PR #563 for Issue #22), which allows phan to run in the background, and accept TCP requests to analyze single files.

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -135,7 +135,7 @@ class Analysis
     /**
      * @see self::parseNodeInContext
      *
-     * @param bool $shouldVisitEverything - Whether or not all AST nodes should be parsed.
+     * @param bool $should_visit_everything - Whether or not all AST nodes should be parsed.
      */
     private static function parseNodeInContextInner(CodeBase $code_base, Context $context, Node $node, bool $should_visit_everything) {
         // Save a reference to the outer context

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -241,7 +241,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
             $function->getInternalScope()
         );
 
-        // Parse the comment above the method to get
+        // Parse the comment above the function to get
         // extra meta information about the method.
         $comment = Comment::fromStringInContext(
             $node->docComment ?? '',

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -140,7 +140,10 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         // extra meta information about the method.
         $comment = Comment::fromStringInContext(
             $node->docComment ?? '',
-            $this->context
+            $this->code_base,
+            $this->context,
+            $node->lineno ?? 0,
+            Comment::ON_METHOD
         );
 
         $context = $this->context->withScope(
@@ -242,7 +245,10 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         // extra meta information about the method.
         $comment = Comment::fromStringInContext(
             $node->docComment ?? '',
-            $this->context
+            $this->code_base,
+            $this->context,
+            $node->lineno ?? 0,
+            Comment::ON_FUNCTION
         );
 
         // For any @var references in the method declaration,

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -644,10 +644,6 @@ EOB;
      * @param float $p
      * The percentage to display
      *
-     * @param float $sample_rate
-     * How frequently we should update the progress
-     * bar, randomly sampled
-     *
      * @return void
      */
     public static function progress(

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -256,7 +256,8 @@ class CodeBase
     }
 
     /**
-     * @param string[] $new_file_list
+     * @param string $file_name
+     * @param string $new_file_contents
      * @return bool - true if caller should replace contents
      */
     public function beforeReplaceFileContents(string $file_name, string $new_file_contents) {

--- a/src/Phan/CodeBase/UndoTracker.php
+++ b/src/Phan/CodeBase/UndoTracker.php
@@ -172,7 +172,8 @@ class UndoTracker {
 
     /**
      * @param CodeBase $code_base - code base owning this tracker
-     * @param string[] $new_file_list
+     * @param string $file_path
+     * @param string $new_file_contents
      * @return bool - true if the file existed
      */
     public function beforeReplaceFileContents(CodeBase $code_base, string $file_path, string $new_file_contents) {

--- a/src/Phan/Daemon/Request.php
+++ b/src/Phan/Daemon/Request.php
@@ -153,7 +153,6 @@ class Request {
      * Currently supports only JSON.
      * TODO: HTTP protocol.
      *
-     * @param resource $conn
      * @param array $response
      * @return void
      */
@@ -225,7 +224,7 @@ class Request {
 
     /**
      * @param CodeBase $code_base
-     * @param \Closure $file_path_list
+     * @param \Closure $file_path_lister
      * @param resource $conn
      * @return Request|null - non-null if this is a worker process with work to do. null if request failed or this is the master.
      */

--- a/src/Phan/ForkPool.php
+++ b/src/Phan/ForkPool.php
@@ -14,12 +14,9 @@ class ForkPool {
     private $read_streams = [];
 
     /**
-     * @param int $pool_size
-     * The number of worker processes to create
-     *
-     * @param array $task_data_iterator
+     * @param array $process_task_data_iterator
      * An array of task data items to be divided up among the
-     * workers
+     * workers. The size of this is the number of forked processes.
      *
      * @param \Closure $startup_closure
      * A closure to execute upon starting a child

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -164,6 +164,12 @@ class Issue
     const GenericGlobalVariable     = 'PhanGenericGlobalVariable';
     const GenericConstructorTypes   = 'PhanGenericConstructorTypes';
 
+    // Issue::CATEGORY_COMMENT
+    const InvalidCommentForDeclarationType = 'PhanInvalidCommentForDeclarationType';
+    const MisspelledAnnotation             = 'PhanMisspelledAnnotation';
+    const UnextractableAnnotation          = 'PhanUnextractableAnnotation';
+    const UnextractableAnnotationPart      = 'PhanUnextractableAnnotationPart';
+
     const CATEGORY_ACCESS            = 1 << 1;
     const CATEGORY_ANALYSIS          = 1 << 2;
     const CATEGORY_COMPATIBLE        = 1 << 3;
@@ -179,6 +185,7 @@ class Issue
     const CATEGORY_PLUGIN            = 1 << 13;
     const CATEGORY_GENERIC           = 1 << 14;
     const CATEGORY_INTERNAL          = 1 << 15;
+    const CATEGORY_COMMENT           = 1 << 16;
 
     const CATEGORY_NAME = [
         self::CATEGORY_ACCESS            => 'AccessError',
@@ -216,6 +223,7 @@ class Issue
     // Keep sorted and in sync with Colorizing::default_color_for_template
     const uncolored_format_string_for_template = [
         'CLASS'         => '%s',
+        'COMMENT'       => '%s',
         'CONST'         => '%s',
         'COUNT'         => '%d',
         'FILE'          => '%s',
@@ -505,7 +513,7 @@ class Issue
             // Issue::CATEGORY_ANALYSIS
             new Issue(
                 self::Unanalyzable,
-                self::CATEGORY_UNDEFINED,
+                self::CATEGORY_ANALYSIS,
                 self::SEVERITY_LOW,
                 "Expression is unanalyzable or feature is unimplemented. Please create an issue at https://github.com/etsy/phan/issues/new.",
                 self::REMEDIATION_B,
@@ -1362,6 +1370,40 @@ class Issue
                 "Cannot access internal method {METHOD} defined at {FILE}:{LINE}",
                 self::REMEDIATION_B,
                 15004
+            ),
+
+            // Issue::CATEGORY_COMMENT
+            new Issue(
+                self::InvalidCommentForDeclarationType,
+                self::CATEGORY_COMMENT,
+                self::SEVERITY_LOW,
+                "The phpdoc comment for {COMMENT} cannot occur on a {TYPE}",
+                self::REMEDIATION_B,
+                16000
+            ),
+            new Issue(
+                self::MisspelledAnnotation,
+                self::CATEGORY_COMMENT,
+                self::SEVERITY_LOW,
+                "Saw misspelled annotation {COMMENT}, should be {COMMENT}",
+                self::REMEDIATION_B,
+                16001
+            ),
+            new Issue(
+                self::UnextractableAnnotation,
+                self::CATEGORY_COMMENT,
+                self::SEVERITY_LOW,
+                "Saw unextractable annotation for comment {COMMENT}",
+                self::REMEDIATION_B,
+                16002
+            ),
+            new Issue(
+                self::UnextractableAnnotationPart,
+                self::CATEGORY_COMMENT,
+                self::SEVERITY_LOW,
+                "Saw unextractable annotation for a fragment of comment {COMMENT}: {COMMENT}",
+                self::REMEDIATION_B,
+                16003
             ),
         ];
 

--- a/src/Phan/Language/Element/AddressableElement.php
+++ b/src/Phan/Language/Element/AddressableElement.php
@@ -29,14 +29,14 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
      * @param Context $context
      * The context in which the structural element lives
      *
-     * @param string $name,
+     * @param string $name
      * The name of the typed structural element
      *
-     * @param UnionType $type,
+     * @param UnionType $type
      * A '|' delimited set of types satisfyped by this
      * typed structural element.
      *
-     * @param int $flags,
+     * @param int $flags
      * The flags property contains node specific flags. It is
      * always defined, but for most nodes it is always zero.
      * ast\kind_uses_flags() can be used to determine whether

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -57,14 +57,14 @@ class Clazz extends AddressableElement
      * @param Context $context
      * The context in which the structural element lives
      *
-     * @param string $name,
+     * @param string $name
      * The name of the typed structural element
      *
-     * @param UnionType $type,
+     * @param UnionType $type
      * A '|' delimited set of types satisfied by this
      * typed structural element.
      *
-     * @param int $flags,
+     * @param int $flags
      * The flags property contains node specific flags. It is
      * always defined, but for most nodes it is always zero.
      * ast\kind_uses_flags() can be used to determine whether
@@ -1447,9 +1447,7 @@ class Clazz extends AddressableElement
     }
 
     /**
-     * Forbid undeclared magic properties
-     * @param bool $forbid - set to true to forbid.
-     * @return void
+     * Check if this class or its ancestors forbids undeclared magic properties.
      */
     public function getForbidUndeclaredMagicProperties(CodeBase $code_base) : bool {
         return (
@@ -1469,7 +1467,7 @@ class Clazz extends AddressableElement
     /**
      * Set whether undeclared magic properties are forbidden
      * (properties accessed through __get or __set, with no (at)property annotation on parent class)
-     * @param bool $forbid - set to true to forbid.
+     * @param bool $forbid_undeclared_dynamic_properties - set to true to forbid.
      * @return void
      */
     public function setForbidUndeclaredMagicProperties(
@@ -1483,9 +1481,7 @@ class Clazz extends AddressableElement
     }
 
     /**
-     * Forbid undeclared magic methods
-     * @param bool $forbid - set to true to forbid.
-     * @return void
+     * Check if this class or its ancestors forbids undeclared magic methods.
      */
     public function getForbidUndeclaredMagicMethods(CodeBase $code_base) : bool {
         return (
@@ -1505,7 +1501,7 @@ class Clazz extends AddressableElement
     /**
      * Set whether undeclared magic methods are forbidden
      * (methods accessed through __call or __callStatic, with no (at)method annotation on class)
-     * @param bool $forbid - set to true to forbid.
+     * @param bool $forbid_undeclared_magic_methods - set to true to forbid.
      * @return void
      */
     public function setForbidUndeclaredMagicMethods(

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -2,7 +2,9 @@
 declare(strict_types=1);
 namespace Phan\Language\Element;
 
+use Phan\CodeBase;
 use Phan\Config;
+use Phan\Issue;
 use Phan\Language\Context;
 use Phan\Language\Element\Comment\Parameter as CommentParameter;
 use Phan\Language\Element\Comment\Method as CommentMethod;
@@ -21,6 +23,44 @@ use Phan\Library\Some;
  */
 class Comment
 {
+    const ON_CLASS      = 1;
+    const ON_VAR        = 2;
+    const ON_PROPERTY   = 3;
+    const ON_CONST      = 4;
+    // TODO: Handle closure.
+    const ON_METHOD     = 5;
+    const ON_FUNCTION   = 6;
+
+    // List of types that are method-like
+    const FUNCTION_LIKE = [
+        self::ON_METHOD,
+        self::ON_FUNCTION,
+    ];
+
+    const HAS_VAR_ANNOTATION = [
+        self::ON_METHOD,
+        self::ON_FUNCTION,
+        self::ON_VAR,
+        self::ON_PROPERTY,
+        self::ON_CLASS,
+        self::ON_CONST,
+    ];
+
+    const VAR_LIKE = [
+        self::ON_VAR,
+        self::ON_PROPERTY,
+        self::ON_CLASS
+    ];
+
+    const NAME_FOR_TYPE = [
+        self::ON_CLASS      => 'class',
+        self::ON_VAR        => 'variable',
+        self::ON_PROPERTY   => 'property',
+        self::ON_CONST      => 'constant',
+        self::ON_METHOD     => 'method',
+        self::ON_FUNCTION   => 'function',
+    ];
+
     const word_regex = '([a-zA-Z_\x7f-\xff\\\][a-zA-Z0-9_\x7f-\xff\\\]*)';
 
     /**
@@ -59,13 +99,13 @@ class Comment
     /**
      * @var Option<Type>|null
      * Classes may specify their inherited type explicitly
-     * via `@inherits Type`.
+     * via `(at)inherits Type`.
      */
     private $inherited_type = null;
 
     /**
      * @var UnionType|null
-     * A UnionType defined by a @return directive
+     * A UnionType defined by an (at)return directive
      */
     private $return_union_type = null;
 
@@ -89,7 +129,7 @@ class Comment
 
     /**
      * @var Option<Type>
-     * An optional class name defined by a @PhanClosureScope directive.
+     * An optional class name defined by an (at)PhanClosureScope directive.
      * (overrides the class in which it is analyzed)
      */
     private $closure_scope;
@@ -180,13 +220,20 @@ class Comment
     }
 
     /**
+     * @param string $comment full text of doc comment
+     * @param CodeBase $code_base
+     * @param Context $context
+     * @param int $comment_type self::ON_* (the type of comment this is)
      * @return Comment
      * A comment built by parsing the given doc block
      * string.
      */
     public static function fromStringInContext(
         string $comment,
-        Context $context
+        CodeBase $code_base,
+        Context $context,
+        int $lineno,
+        int $comment_type
     ) : Comment {
 
         if (!Config::get()->read_type_annotations) {
@@ -208,18 +255,39 @@ class Comment
 
         $lines = explode("\n", $comment);
 
+        /**
+         * @param int[] $validTypes
+         * @return void
+         */
+        $check_compatible = function(string $paramName, array $validTypes) use($code_base, $context, $comment_type, $lineno) {
+            if (!in_array($comment_type, $validTypes, true)) {
+                self::emitInvalidCommentForDeclarationType(
+                    $code_base,
+                    $context,
+                    $paramName,
+                    $comment_type,
+                    $lineno
+                );
+            }
+        };
+
         foreach ($lines as $line) {
 
-            if (strpos($line, '@param') !== false) {
-                $parameter_list[] =
-                    self::parameterFromCommentLine($context, $line, false);
-            } elseif (stripos($line, '@var') !== false) {
+            if (stripos($line, '@param') !== false) {
+                if (preg_match('/@param\b/i', $line)) {
+                    $check_compatible('@param', Comment::FUNCTION_LIKE);
+                    $parameter_list[] =
+                        self::parameterFromCommentLine($code_base, $context, $line, false, $lineno);
+                }
+            } elseif (stripos($line, '@var') !== false && preg_match('/@var\b/i', $line)) {
+                $check_compatible('@var', Comment::HAS_VAR_ANNOTATION);
                 $variable_list[] =
-                    self::parameterFromCommentLine($context, $line, true);
+                    self::parameterFromCommentLine($code_base, $context, $line, true, $lineno);
             } elseif (stripos($line, '@template') !== false) {
 
                 // Make sure support for generic types is enabled
                 if (Config::get()->generic_types_enabled) {
+                    $check_compatible('@template', [Comment::ON_CLASS]);
                     if (($template_type =
                         self::templateTypeFromCommentLine($context, $line))
                     ) {
@@ -227,21 +295,35 @@ class Comment
                     }
                 }
             } elseif (stripos($line, '@inherits') !== false) {
+                $check_compatible('@inherits', [Comment::ON_CLASS]);
                 // Make sure support for generic types is enabled
                 if (Config::get()->generic_types_enabled) {
                     $inherited_type =
                         self::inheritsFromCommentLine($context, $line);
                 }
             } elseif (stripos($line, '@return') !== false) {
-                $return_union_type =
-                    self::returnTypeFromCommentLine($context, $line);
+                if (preg_match('/@return\b/i', $line)) {
+                    $check_compatible('@return', Comment::FUNCTION_LIKE);
+                    $return_union_type =
+                        self::returnTypeFromCommentLine($code_base, $context, $line, $lineno);
+                } else if (stripos($line, '@returns') !== false) {
+                    Issue::maybeEmit(
+                        $code_base,
+                        $context,
+                        Issue::MisspelledAnnotation,
+                        $lineno,
+                        '@returns',
+                        '@return'
+                    );
+                }
             } elseif (stripos($line, '@suppress') !== false) {
                 $suppress_issue_list[] =
                     self::suppressIssueFromCommentLine($line);
             } elseif (strpos($line, '@property') !== false) {
+                $check_compatible('@property', [Comment::ON_CLASS]);
                 // Make sure support for magic properties is enabled.
                 if (Config::get()->read_magic_property_annotations) {
-                    $magic_property = self::magicPropertyFromCommentLine($context, $line);
+                    $magic_property = self::magicPropertyFromCommentLine($code_base, $context, $line, $lineno);
                     if ($magic_property !== null) {
                         $magic_property_list[] = $magic_property;
                     }
@@ -249,17 +331,31 @@ class Comment
             } elseif (strpos($line, '@method') !== false) {
                 // Make sure support for magic methods is enabled.
                 if (Config::get()->read_magic_method_annotations) {
-                    $magic_method = self::magicMethodFromCommentLine($context, $line);
+                    $check_compatible('@method', [Comment::ON_CLASS]);
+                    $magic_method = self::magicMethodFromCommentLine($code_base, $context, $line, $lineno);
                     if ($magic_method !== null) {
                         $magic_method_list[] = $magic_method;
                     }
                 }
             } elseif (stripos($line, '@PhanClosureScope') !== false) {
+                // TODO: different type for closures
+                $check_compatible('@PhanClosureScope', Comment::FUNCTION_LIKE);
                 $closure_scope = self::getPhanClosureScopeFromCommentLine($context, $line);
             } elseif (stripos($line, '@phan-forbid-undeclared-magic-properties') !== false) {
+                $check_compatible('@phan-forbid-undeclared-magic-properties', [Comment::ON_CLASS]);
                 $comment_flags |= Flags::CLASS_FORBID_UNDECLARED_MAGIC_PROPERTIES;
             } elseif (stripos($line, '@phan-forbid-undeclared-magic-methods') !== false) {
+                $check_compatible('@phan-forbid-undeclared-magic-methods', [Comment::ON_CLASS]);
                 $comment_flags |= Flags::CLASS_FORBID_UNDECLARED_MAGIC_METHODS;
+            } else if (stripos($line, '@phan-') !== false && preg_match('/@phan-\S*/', $line, $match)) {
+                Issue::maybeEmit(
+                    $code_base,
+                    $context,
+                    Issue::MisspelledAnnotation,
+                    $lineno,
+                    $match[0],
+                    '@phan-forbid-undeclared-magic-methods @phan-forbid-undeclared-magic-properties'
+                );
             }
 
             if (stripos($line, '@deprecated') !== false) {
@@ -290,23 +386,54 @@ class Comment
     }
 
     /**
+     * @return void
+     */
+    private static function emitInvalidCommentForDeclarationType(
+        CodeBase $code_base,
+        Context $context,
+        string $annotationType,
+        int $comment_type,
+        int $lineno
+    ) {
+        Issue::maybeEmit(
+            $code_base,
+            $context,
+            Issue::InvalidCommentForDeclarationType,
+            $lineno,
+            $annotationType,
+            self::NAME_FOR_TYPE[$comment_type]
+        );
+    }
+
+    /**
+     * @param CodeBase $code_base
+     * Used for extracting issues.
+     *
      * @param Context $context
      * The context in which the comment line appears
      *
      * @param string $line
      * An individual line of a comment
      *
+     * @param int $lineno
+     * The line number of the element that comment annotates
+     *
      * @return UnionType
      * The declared return type
      */
     private static function returnTypeFromCommentLine(
+        CodeBase $code_base,
         Context $context,
-        string $line
+        string $line,
+        int $lineno
     ) {
         $return_union_type_string = '';
 
-        if (preg_match('/@return\s+(' . UnionType::union_type_regex . '+)/', $line, $match)) {
-            $return_union_type_string = $match[1];
+        if (preg_match('/@return\s+/', $line)) {
+            if (preg_match('/@return\s+(' . UnionType::union_type_regex . '+)/', $line, $match)) {
+                $return_union_type_string = $match[1];
+            }
+            // Not emitting any issues about failing to extract, e.g. `@return - Description of what this returns` is a valid comment.
         }
         $return_union_type = UnionType::fromStringInContext(
             $return_union_type_string,
@@ -318,6 +445,9 @@ class Comment
     }
 
     /**
+     * @param CodeBase $code_base
+     * CodeBase, for emitting issues.
+     *
      * @param Context $context
      * The context in which the comment line appears
      *
@@ -327,14 +457,21 @@ class Comment
      * @param bool $is_var
      * True if this is parsing a variable, false if parsing a parameter.
      *
+     * @param int $lineno
+     * The line number of the element this comment annotates.
+     *
      * @return CommentParameter
      * A CommentParameter associated with a line that has a var
      * or param reference.
+     *
+     * TODO: account for difference between (at)var and (at)param
      */
     private static function parameterFromCommentLine(
+        CodeBase $code_base,
         Context $context,
         string $line,
-        bool $is_var
+        bool $is_var,
+        int $lineno
     ) {
         $match = [];
         if (preg_match('/@(param|var)\s+(' . UnionType::union_type_regex . ')(\s+(\.\.\.)?\s*(\\$' . self::word_regex . '))?/', $line, $match)) {
@@ -368,6 +505,20 @@ class Comment
                 $union_type,
                 $is_variadic
             );
+        } else {
+            // Don't warn about @param $x Description of $x goes here
+            // TODO: extract doc comment of @param &$x?
+            // TODO: Use the right for the name of the comment parameter?
+            //       (don't see a benefit, would create a type if it was (at)var on a function-like)
+            if (!preg_match('/@(param|var)\s+(\.\.\.)?\s*(\\$\S+)/', $line)) {
+                Issue::maybeEmit(
+                    $code_base,
+                    $context,
+                    Issue::UnextractableAnnotation,
+                    $lineno,
+                    $line
+                );
+            }
         }
 
         return  new CommentParameter('', new UnionType());
@@ -490,6 +641,7 @@ class Comment
     }
 
     /**
+     * @param CodeBase $code_base
      * @param Context $context
      * @param string $line
      * An individual line of a comment
@@ -498,8 +650,10 @@ class Comment
      * magic method with the parameter types, return types, and name.
      */
     private static function magicMethodFromCommentLine(
+        CodeBase $code_base,
         Context $context,
-        string $line
+        string $line,
+        int $lineno
     ) {
         // Note that the type of a property can be left out (@property $myVar) - This is equivalent to @property mixed $myVar
         // TODO: properly handle duplicates...
@@ -535,16 +689,37 @@ class Comment
             if ($arg_list !== '') {
                 // TODO: Would need to use a different approach if templates were ever supported
                 $params_strings = explode(',', $arg_list);
+                $failed = false;
                 foreach ($params_strings as $i => $param_string) {
                     $param = self::magicParamFromMagicMethodParamString($context, $param_string, $i);
                     if ($param === null) {
-                        return null;
+                        Issue::maybeEmit(
+                            $code_base,
+                            $context,
+                            Issue::UnextractableAnnotationPart,
+                            $lineno,
+                            $line,
+                            $param_string
+                        );
+                        $failed = true;
                     }
                     $comment_params[] = $param;
+                }
+                if ($failed) {
+                    // Emit everything that was wrong with the parameters of the @method annotation at once, then reject it.
+                    return null;
                 }
             }
 
             return new CommentMethod($method_name, $return_union_type, $comment_params, $is_static);
+        } else {
+            Issue::maybeEmit(
+                $code_base,
+                $context,
+                Issue::UnextractableAnnotation,
+                $lineno,
+                $line
+            );
         }
 
         return null;
@@ -561,8 +736,10 @@ class Comment
      * magic property with the union type.
      */
     private static function magicPropertyFromCommentLine(
+        CodeBase $code_base,
         Context $context,
-        string $line
+        string $line,
+        int $lineno
     ) {
         // Note that the type of a property can be left out (@property $myVar) - This is equivalent to @property mixed $myVar
         // TODO: properly handle duplicates...
@@ -592,6 +769,14 @@ class Comment
             return new CommentParameter(
                 $property_name,
                 $union_type
+            );
+        } else {
+            Issue::maybeEmit(
+                $code_base,
+                $context,
+                Issue::UnextractableAnnotation,
+                $lineno,
+                $line
             );
         }
 

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -516,7 +516,7 @@ class Comment
                     $context,
                     Issue::UnextractableAnnotation,
                     $lineno,
-                    $line
+                    trim($line)
                 );
             }
         }
@@ -698,7 +698,7 @@ class Comment
                             $context,
                             Issue::UnextractableAnnotationPart,
                             $lineno,
-                            $line,
+                            trim($line),
                             $param_string
                         );
                         $failed = true;
@@ -718,7 +718,7 @@ class Comment
                 $context,
                 Issue::UnextractableAnnotation,
                 $lineno,
-                $line
+                trim($line)
             );
         }
 
@@ -776,7 +776,7 @@ class Comment
                 $context,
                 Issue::UnextractableAnnotation,
                 $lineno,
-                $line
+                trim($line)
             );
         }
 
@@ -888,13 +888,23 @@ class Comment
     }
 
     /**
-     * @return CommentParameter[]
+     * @return CommentParameter[] (The leftover parameters without a name)
      *
      * @suppress PhanUnreferencedMethod
      */
     public function getParameterList() : array
     {
         return $this->parameter_list;
+    }
+
+    /**
+     * @return CommentParameter[] (maps the names of parameters to their values. Does not include parameters which didn't provide names)
+     *
+     * @suppress PhanUnreferencedMethod
+     */
+    public function getParameterMap() : array
+    {
+        return $this->parameter_map;
     }
 
     /**

--- a/src/Phan/Language/Element/Func.php
+++ b/src/Phan/Language/Element/Func.php
@@ -172,7 +172,10 @@ class Func extends AddressableElement implements FunctionInterface
         // extra meta information about the function.
         $comment = Comment::fromStringInContext(
             $node->docComment ?? '',
-            $context
+            $code_base,
+            $context,
+            $node->lineno ?? 0,
+            Comment::ON_FUNCTION
         );
 
         // Redefine the function's internal scope to point to the new class before adding any variables to the scope.

--- a/src/Phan/Language/Element/Func.php
+++ b/src/Phan/Language/Element/Func.php
@@ -31,17 +31,17 @@ class Func extends AddressableElement implements FunctionInterface
     protected $closure_scope = null;
 
     /**
-     * @param \phan\Context $context
+     * @param Context $context
      * The context in which the structural element lives
      *
-     * @param string $name,
+     * @param string $name
      * The name of the typed structural element
      *
-     * @param UnionType $type,
+     * @param UnionType $type
      * A '|' delimited set of types satisfyped by this
      * typed structural element.
      *
-     * @param int $flags,
+     * @param int $flags
      * The flags property contains node specific flags. It is
      * always defined, but for most nodes it is always zero.
      * ast\kind_uses_flags() can be used to determine whether

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -107,7 +107,7 @@ interface FunctionInterface extends AddressableElementInterface {
      *
      * @return void
      */
-    public function setHasYield(bool $has_return);
+    public function setHasYield(bool $has_yield);
 
     /**
      * @return Parameter[]

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -399,8 +399,6 @@ trait FunctionTrait {
     }
 
     /**
-     * @param Context $context
-     *
      * @return UnionType
      * The type of this method in its given context.
      */

--- a/src/Phan/Language/Element/GlobalConstant.php
+++ b/src/Phan/Language/Element/GlobalConstant.php
@@ -39,7 +39,8 @@ class GlobalConstant extends AddressableElement implements ConstantInterface
     }
 
     /**
-     * @param string $class_name
+     * @param CodeBase $code_base
+     * @param string $name
      * The name of a builtin constant to build a new GlobalConstant structural
      * element from.
      *

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -28,14 +28,14 @@ class Method extends ClassElement implements FunctionInterface
      * @param Context $context
      * The context in which the structural element lives
      *
-     * @param string $name,
+     * @param string $name
      * The name of the typed structural element
      *
-     * @param UnionType $type,
+     * @param UnionType $type
      * A '|' delimited set of types satisfyped by this
      * typed structural element.
      *
-     * @param int $flags,
+     * @param int $flags
      * The flags property contains node specific flags. It is
      * always defined, but for most nodes it is always zero.
      * ast\kind_uses_flags() can be used to determine whether
@@ -342,8 +342,6 @@ class Method extends ClassElement implements FunctionInterface
     }
 
     /**
-     * @param Context $context
-     *
      * @return UnionType
      * The type of this method in its given context.
      */

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -217,7 +217,10 @@ class Method extends ClassElement implements FunctionInterface
         // extra meta information about the method.
         $comment = Comment::fromStringInContext(
             $node->docComment ?? '',
-            $context
+            $code_base,
+            $context,
+            $node->lineno ?? 0,
+            Comment::ON_METHOD
         );
 
         // @var Parameter[]

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -35,14 +35,14 @@ class Parameter extends Variable
      * @param \phan\Context $context
      * The context in which the structural element lives
      *
-     * @param string $name,
+     * @param string $name
      * The name of the typed structural element
      *
-     * @param UnionType $type,
+     * @param UnionType $type
      * A '|' delimited set of types satisfyped by this
      * typed structural element.
      *
-     * @param int $flags,
+     * @param int $flags
      * The flags property contains node specific flags. It is
      * always defined, but for most nodes it is always zero.
      * ast\kind_uses_flags() can be used to determine whether
@@ -134,7 +134,6 @@ class Parameter extends Variable
     }
 
     /**
-     * @param string $value
      * If the value's default is null, or a constant evaluating to null,
      * then the parameter type should be converted to nullable
      * (E.g. `int $x = null` and `?int $x = null` are equivalent.

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -11,17 +11,17 @@ class Property extends ClassElement
     use ElementFutureUnionType;
 
     /**
-     * @param \phan\Context $context
+     * @param Context $context
      * The context in which the structural element lives
      *
-     * @param string $name,
+     * @param string $name
      * The name of the typed structural element
      *
-     * @param UnionType $type,
+     * @param UnionType $type
      * A '|' delimited set of types satisfyped by this
      * typed structural element.
      *
-     * @param int $flags,
+     * @param int $flags
      * The flags property contains node specific flags. It is
      * always defined, but for most nodes it is always zero.
      * ast\kind_uses_flags() can be used to determine whether

--- a/src/Phan/Language/Element/TypedElement.php
+++ b/src/Phan/Language/Element/TypedElement.php
@@ -58,14 +58,14 @@ abstract class TypedElement implements TypedElementInterface
      * @param Context $context
      * The context in which the structural element lives
      *
-     * @param string $name,
+     * @param string $name
      * The name of the typed structural element
      *
-     * @param UnionType $type,
+     * @param UnionType $type
      * A '|' delimited set of types satisfyped by this
      * typed structural element.
      *
-     * @param int $flags,
+     * @param int $flags
      * The flags property contains node specific flags. It is
      * always defined, but for most nodes it is always zero.
      * ast\kind_uses_flags() can be used to determine whether

--- a/src/Phan/Language/Element/Variable.php
+++ b/src/Phan/Language/Element/Variable.php
@@ -31,17 +31,17 @@ class Variable extends TypedElement
     ];
 
     /**
-     * @param \phan\Context $context
+     * @param Context $context
      * The context in which the structural element lives
      *
-     * @param string $name,
+     * @param string $name
      * The name of the typed structural element
      *
-     * @param UnionType $type,
+     * @param UnionType $type
      * A '|' delimited set of types satisfyped by this
      * typed structural element.
      *
-     * @param int $flags,
+     * @param int $flags
      * The flags property contains node specific flags. It is
      * always defined, but for most nodes it is always zero.
      * ast\kind_uses_flags() can be used to determine whether

--- a/src/Phan/Language/Scope.php
+++ b/src/Phan/Language/Scope.php
@@ -273,7 +273,7 @@ abstract class Scope
     }
 
     /**
-     * @param string $generic_type_identifier
+     * @param string $template_type_identifier
      * The identifier for a generic type
      *
      * @return TemplateType

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -65,7 +65,7 @@ class Type
      * A legal type identifier matching a type optionally with a []
      * indicating that it's a generic typed array (e.g. 'int[]',
      * 'string' or 'Set<DateTime>')
-     * TODO: change the regex so that '@return $this' will work (Currently not parsed, has empty regex)
+     * TODO: change the regex so that '(at)return $this' will work (Currently not parsed, has empty regex)
      */
     const type_regex =
         self::simple_type_with_template_parameter_list_regex . '(\[\])*';
@@ -115,7 +115,7 @@ class Type
     /** For types copied from another type, e.g. `$x = $y` gets types from $y */
     const FROM_TYPE = 1;
 
-    /** For types copied from phpdoc, e.g. `@param integer $x` */
+    /** For types copied from phpdoc, e.g. `(at)param integer $x` */
     const FROM_PHPDOC = 2;
 
     /**

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -173,12 +173,12 @@ class Type
     }
 
     /**
-     * @param string $name
-     * The name of the type such as 'int' or 'MyClass'
-     *
      * @param string $namespace
      * The (optional) namespace of the type such as '\'
      * or '\Phan\Language'.
+     *
+     * @param string $type_name
+     * The name of the type such as 'int' or 'MyClass'
      *
      * @param UnionType[] $template_parameter_type_list
      * A (possibly empty) list of template parameter types
@@ -548,10 +548,6 @@ class Type
     /**
      * @param string $fully_qualified_string
      * A fully qualified type name
-     *
-     * @param Context $context
-     * The context in which the type string was
-     * found
      *
      * @return Type
      */
@@ -1348,7 +1344,7 @@ class Type
     }
 
     /**
-     * @param string $type_name
+     * @param string $name
      * Any type name
      *
      * @return string

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -64,10 +64,6 @@ class UnionType implements \Serializable
      * A '|' delimited string representing a type in the form
      * 'int|string|null|ClassName'.
      *
-     * @param Context $context
-     * The context in which the type string was
-     * found
-     *
      * @return UnionType
      */
     public static function fromFullyQualifiedString(

--- a/src/Phan/Library/Set.php
+++ b/src/Phan/Library/Set.php
@@ -9,7 +9,7 @@ class Set extends \SplObjectStorage
 {
 
     /**
-     * @param \Iterator|array $elements
+     * @param \Iterator|array $element_iterator
      * An optional set of items to add to the set
      */
     public function __construct($element_iterator = null)

--- a/src/Phan/Output/Colorizing.php
+++ b/src/Phan/Output/Colorizing.php
@@ -88,7 +88,6 @@ class Colorizing {
     /**
      * @param string $template
      * @param int[]|string[] $template_parameters
-     * @param int $severity (Issue::SEVERITY_*)
      */
     public static function colorizeTemplate(
         string $template,

--- a/src/Phan/Output/Colorizing.php
+++ b/src/Phan/Output/Colorizing.php
@@ -60,6 +60,7 @@ class Colorizing {
     // In future PRs, it will be possible for users to add their own color schemes in .phan/config.php
     const default_color_for_template = [
         'CLASS'         => 'green',
+        'COMMENT'       => 'light_green',
         'CONST'         => 'light_red',
         'COUNT'         => 'light_magenta',
         'FILE'          => 'light_cyan',

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -131,7 +131,10 @@ class ParseVisitor extends ScopeVisitor
         // Get a comment on the class declaration
         $comment = Comment::fromStringInContext(
             $node->docComment ?? '',
-            $this->context
+            $this->code_base,
+            $this->context,
+            $node->lineno ?? 0,
+            Comment::ON_CLASS
         );
 
         // Add any template types parameterizing a generic class
@@ -395,7 +398,10 @@ class ParseVisitor extends ScopeVisitor
         // Get a comment on the property declaration
         $comment = Comment::fromStringInContext(
             $docComment,
-            $this->context
+            $this->code_base,
+            $this->context,
+            $node->lineno ?? 0,
+            Comment::ON_PROPERTY
         );
 
         foreach ($node->children ?? [] as $i => $child_node) {
@@ -540,7 +546,10 @@ class ParseVisitor extends ScopeVisitor
             // Get a comment on the declaration
             $comment = Comment::fromStringInContext(
                 $child_node->docComment ?? '',
-                $this->context
+                $this->code_base,
+                $this->context,
+                $child_node->lineno ?? 0,
+                Comment::ON_CONST
             );
 
             $line_number_start = $child_node->lineno ?? 0;
@@ -884,7 +893,10 @@ class ParseVisitor extends ScopeVisitor
         // Get a comment on the declaration
         $comment = Comment::fromStringInContext(
             $comment_string,
-            $this->context
+            $this->code_base,
+            $this->context,
+            $node->lineno ?? 0,
+            Comment::ON_CONST
         );
 
         $constant->setFutureUnionType(


### PR DESCRIPTION
And fix outdated/misspelled @param annotations in phan (some outstanding PRs also have bad annotations, and will need to be rebased and fixed)

Fixes issue #778

`@returns` is sometimes accidentally used by people familiar with JSDoc.
This PR also makes Phan note if an annotation occurs in a place it isn't expected to.
(E.g. `@param` on a class declaration)
(In the future, this may be configurable)

Fix various issues

Note: May want to do this differently if other analyzers are used
(e.g. if they use `<something:something>` in the types

`Comment::fromStringInContext()` had the declaration change, but I'm not aware of external plugins using it.