### PR TITLE
Fixes #777: Make regex for a var/param match valid identifiers

### DIFF
--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -337,7 +337,7 @@ class Comment
         bool $is_var
     ) {
         $match = [];
-        if (preg_match('/@(param|var)\s+(' . UnionType::union_type_regex . ')(\s+(\.\.\.)?\s*(\\$\S+))?/', $line, $match)) {
+        if (preg_match('/@(param|var)\s+(' . UnionType::union_type_regex . ')(\s+(\.\.\.)?\s*(\\$' . self::word_regex . '))?/', $line, $match)) {
             $type = $match[2];
 
             $is_variadic = ($match[29] ?? '') === '...';
@@ -345,8 +345,7 @@ class Comment
             if ($is_var && $is_variadic) {
                 $variable_name = '';  // "@var int ...$x" is nonsense and invalid phpdoc.
             } else {
-                $variable_name =
-                    empty($match[30]) ? '' : trim($match[30], '$');
+                $variable_name = $match[31] ?? '';
             }
 
             // If the type looks like a variable name, make it an
@@ -566,11 +565,10 @@ class Comment
         // Note that the type of a property can be left out (@property $myVar) - This is equivalent to @property mixed $myVar
         // TODO: properly handle duplicates...
         // TODO: support read-only/write-only checks elsewhere in the codebase?
-        if (preg_match('/@(property|property-read|property-write)(\s+' . UnionType::union_type_regex . ')?(\s+(\\$\S+))/', $line, $match)) {
+        if (preg_match('/@(property|property-read|property-write)(\s+' . UnionType::union_type_regex . ')?(\s+(\\$' . self::word_regex . '))/', $line, $match)) {
             $type = ltrim($match[2] ?? '');
 
-            $property_name =
-                empty($match[29]) ? '' : trim($match[29], '$');
+            $property_name = $match[30] ?? '';
             if ($property_name === '') {
                 return null;
             }

--- a/tests/files/expected/0291_word_regex_ignores_nonword.php.expected
+++ b/tests/files/expected/0291_word_regex_ignores_nonword.php.expected
@@ -1,0 +1,2 @@
+%s:8 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is array but \intdiv() takes int
+%s:9 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int

--- a/tests/files/src/0291_word_regex_ignores_nonword.php
+++ b/tests/files/src/0291_word_regex_ignores_nonword.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * @param string $y, the second arg
+ * @param array $x: the first arg
+ */
+function phpdocCheck291($x, $y) {
+    intdiv($x, 2);  // emits error about x being an array
+    intdiv($y, 2);  // emits error about y being a string
+}


### PR DESCRIPTION
instead of any non-space.
Also add that check to magic properties.
Magic methods already use Comment::word_regex