### PR TITLE
Allow parsing $x = array() in @method declaration

### DIFF
--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -511,7 +511,9 @@ class Comment
         // Syntax:
         //    @method [return type] [name]([[type] [parameter]<, ...>]) [<description>]
         //    Assumes the parameters end at the first ")" after "("
-        if (preg_match('/@method(\s+(static))?((\s+(' . UnionType::union_type_regex . '))?)\s+' . self::word_regex . '\s*\(([^()]*)\)\s*(.*)/', $line, $match)) {
+        //    As an exception, allows one level of matching brackets
+        //    to support old style arrays such as $x = array(), $x = array(2) (Default values are ignored)
+        if (preg_match('/@method(\s+(static))?((\s+(' . UnionType::union_type_regex . '))?)\s+' . self::word_regex . '\s*\((([^()]|\([()]*\))*)\)\s*(.*)/', $line, $match)) {
             $is_static = $match[2] === 'static';
             $return_union_type_string = $match[4];
             if ($return_union_type_string !== '') {

--- a/tests/files/expected/0281_magic_method_support.php.expected
+++ b/tests/files/expected/0281_magic_method_support.php.expected
@@ -1,20 +1,23 @@
-%s:35 PhanUndeclaredMethod Call to undeclared method \A281::undeclaredMagicMethod
-%s:36 PhanTypeVoidAssignment Cannot assign void return value
-%s:38 PhanParamTooMany Call with 1 arg(s) to \A281::fooWithReturnType() which only takes 0 arg(s) defined at %s:17
-%s:39 PhanTypeMismatchArgument Argument 1 (x) is int but \expects_a281() takes \A281 defined at %s:28
-%s:43 PhanTypeMismatchArgument Argument 2 (b) is null but \A281::fooWithOptionalSecondParam() takes int defined at %s:17
-%s:44 PhanParamTooFew Call with 0 arg(s) to \A281::fooWithOptionalSecondParam() which requires 1 arg(s) defined at %s:17
-%s:45 PhanStaticCallToNonStatic Static call to non-static method \A281::fooWithOptionalSecondParam() defined at %s:17
-%s:50 PhanTypeMismatchArgument Argument 1 (x) is int but \A281::fooWithOptionalNullableParam() takes ?string defined at %s:17
-%s:52 PhanTypeMismatchArgument Argument 1 (x) is int but \expects_a281() takes \A281 defined at %s:28
-%s:55 PhanTypeMismatchArgument Argument 1 (x) is \A281 but \expects_int281() takes int defined at %s:31
-%s:56 PhanParamTooMany Call with 1 arg(s) to \A281::static_foo_with_return_type_of_static() which only takes 0 arg(s) defined at %s:17
-%s:59 PhanParamTooFew Call with 0 arg(s) to \A281::myMethodWithParams() which requires 1 arg(s) defined at %s:17
-%s:60 PhanTypeMismatchArgument Argument 1 (x) is string but \A281::myMethodWithParams() takes int defined at %s:17
-%s:63 PhanParamTooFew Call with 0 arg(s) to \A281::myMethodWithUntypedParams() which requires 1 arg(s) defined at %s:17
-%s:66 PhanTypeMismatchArgument Argument 1 (x) is string but \A281::myMethodWithPHPDocParams() takes float defined at %s:17
-%s:66 PhanTypeMismatchArgument Argument 2 (y) is null but \A281::myMethodWithPHPDocParams() takes object defined at %s:17
-%s:68 PhanTypeMismatchArgument Argument 4 (x) is float but \A281::myMethodWithVariadicParams() takes int|string defined at %s:17
-%s:70 PhanTypeMismatchArgument Argument 1 (x) is int|string but \expects_a281() takes \A281 defined at %s:28
-%s:75 PhanUndeclaredMethod Call to undeclared method \C281::undeclaredMagicMethod
-%s:76 PhanTypeVoidAssignment Cannot assign void return value
+%s:37 PhanUndeclaredMethod Call to undeclared method \A281::undeclaredMagicMethod
+%s:38 PhanTypeVoidAssignment Cannot assign void return value
+%s:40 PhanParamTooMany Call with 1 arg(s) to \A281::fooWithReturnType() which only takes 0 arg(s) defined at %s:19
+%s:41 PhanTypeMismatchArgument Argument 1 (x) is int but \expects_a281() takes \A281 defined at %s:30
+%s:45 PhanTypeMismatchArgument Argument 2 (b) is null but \A281::fooWithOptionalSecondParam() takes int defined at %s:19
+%s:46 PhanParamTooFew Call with 0 arg(s) to \A281::fooWithOptionalSecondParam() which requires 1 arg(s) defined at %s:19
+%s:47 PhanStaticCallToNonStatic Static call to non-static method \A281::fooWithOptionalSecondParam() defined at %s:19
+%s:52 PhanTypeMismatchArgument Argument 1 (x) is int but \A281::fooWithOptionalNullableParam() takes ?string defined at %s:19
+%s:54 PhanTypeMismatchArgument Argument 1 (x) is int but \expects_a281() takes \A281 defined at %s:30
+%s:57 PhanTypeMismatchArgument Argument 1 (x) is \A281 but \expects_int281() takes int defined at %s:33
+%s:58 PhanParamTooMany Call with 1 arg(s) to \A281::static_foo_with_return_type_of_static() which only takes 0 arg(s) defined at %s:19
+%s:61 PhanParamTooFew Call with 0 arg(s) to \A281::myMethodWithParams() which requires 1 arg(s) defined at %s:19
+%s:62 PhanTypeMismatchArgument Argument 1 (x) is string but \A281::myMethodWithParams() takes int defined at %s:19
+%s:65 PhanParamTooFew Call with 0 arg(s) to \A281::myMethodWithUntypedParams() which requires 1 arg(s) defined at %s:19
+%s:68 PhanTypeMismatchArgument Argument 1 (x) is string but \A281::myMethodWithPHPDocParams() takes float defined at %s:19
+%s:68 PhanTypeMismatchArgument Argument 2 (y) is null but \A281::myMethodWithPHPDocParams() takes object defined at %s:19
+%s:70 PhanTypeMismatchArgument Argument 4 (x) is float but \A281::myMethodWithVariadicParams() takes int|string defined at %s:19
+%s:72 PhanTypeMismatchArgument Argument 1 (x) is int|string but \expects_a281() takes \A281 defined at %s:30
+%s:74 PhanTypeMismatchArgument Argument 2 (b) is int but \A281::fooWithOptionalArrayParam() takes array defined at %s:19
+%s:75 PhanTypeMismatchArgument Argument 2 (b) is int but \A281::fooWithOptionalArrayParam2() takes array defined at %s:19
+%s:75 PhanTypeMismatchArgument Argument 3 (c) is string but \A281::fooWithOptionalArrayParam2() takes int defined at %s:19
+%s:80 PhanUndeclaredMethod Call to undeclared method \C281::undeclaredMagicMethod
+%s:81 PhanTypeVoidAssignment Cannot assign void return value

--- a/tests/files/src/0281_magic_method_support.php
+++ b/tests/files/src/0281_magic_method_support.php
@@ -5,6 +5,8 @@
  * @method int fooWithReturnType()
  * @method fooWithOptionalSecondParam(int, int $b=2) - Phan doesn't check if the default is valid, just for the presence
  * @method fooWithOptionalNullableParam(string $x=  null  )This is a nullable string, the only time we check the default
+ * @method fooWithOptionalArrayParam(int, array $b=[]) - Phan doesn't check if the default is valid, just for the presence
+ * @method fooWithOptionalArrayParam2(int, array $b=array(), int $c) - Phan doesn't check if the default is valid, just for the presence
  * @method static static_foo()
  * @method static int static_foo_with_return_type()
  * @method static static static_foo_with_return_type_of_static()
@@ -68,6 +70,9 @@ function testA281(A281 $a) {
     $v = $a->myMethodWithVariadicParams(2, 'str', 2, 4.2);  // 4.2 is not valid, but int|string is.
     expects_int281($v);
     expects_a281($v);  // invalid, $v is int|string
+
+    $a->fooWithOptionalArrayParam(2, 3);  // invalid, $b is array
+    $a->fooWithOptionalArrayParam2(2, 3, 'x');  // invalid, $b is array, and $c is int
 }
 
 // a quick check that support also works for abstract classes, not just interfaces


### PR DESCRIPTION
Previously, this wouldn't allow brackets within the `@method` parameter defaults, so those were unparseable.
Change this to allow one level of matching brackets (Don't attempt to tokenize the defaults, just assume it's all right)