### PR TITLE
Use word_regex for getting issue type from @suppress

### DIFF
--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -437,7 +437,7 @@ class Comment
     private static function suppressIssueFromCommentLine(
         string $line
     ) : string {
-        if (preg_match('/@suppress\s+([^\s]+)/', $line, $match)) {
+        if (preg_match('/@suppress\s+' . self::word_regex . '/', $line, $match)) {
             return $match[1];
         }
 


### PR DESCRIPTION
This allows parsing `@suppress PhanIssueType: reason` and ignoring the `:`