### PR TITLE
Fix #787: calls to private static methods aren't recognized

### DIFF
--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1041,6 +1041,12 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 }
             }
 
+            $this->analyzeMethodVisibility(
+                $this->code_base,
+                $method,
+                $node
+            );
+
             // Make sure the parameters look good
             $this->analyzeCallToMethod(
                 $this->code_base,
@@ -1341,43 +1347,11 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             return $this->context;
         }
 
-        // Make sure the magic method is accessible
-        if ($method->isPrivate()
-            && !$method->getDefiningClass($this->code_base)->isTrait()
-            && (!$this->context->isInClassScope()
-                || $this->context->getClassFQSEN() != $method->getDefiningClassFQSEN()
-            )
-        ) {
-            $this->emitIssue(
-                Issue::AccessMethodPrivate,
-                $node->lineno ?? 0,
-                (string)$method->getFQSEN(),
-                $method->getFileRef()->getFile(),
-                (string)$method->getFileRef()->getLineNumberStart()
-            );
-        } else if ($method->isProtected()
-            && !$method->getDefiningClass($this->code_base)->isTrait()
-            && (!$this->context->isInClassScope()
-            || (!$this->context->getClassFQSEN()->asType()->canCastToType(
-                    $method->getClassFQSEN()->asType()
-                )
-                && !$this->context->getClassFQSEN()->asType()->isSubclassOf(
-                        $this->code_base,
-                        $method->getDefiningClassFQSEN()->asType()
-                    )
-                )
-                && $this->context->getClassFQSEN() != $method->getDefiningClassFQSEN()
-            )
-        ) {
-
-            $this->emitIssue(
-                Issue::AccessMethodProtected,
-                $node->lineno ?? 0,
-                (string)$method->getFQSEN(),
-                $method->getFileRef()->getFile(),
-                (string)$method->getFileRef()->getLineNumberStart()
-            );
-        }
+        $this->analyzeMethodVisibility(
+            $this->code_base,
+            $method,
+            $node
+        );
 
         // Check the call for paraemter and argument types
         $this->analyzeCallToMethod(
@@ -1576,6 +1550,62 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         }
 
         return $this->context;
+    }
+
+    /**
+     * Analyze whether a method is callable
+     *
+     * @param CodeBase $code_base
+     * @param Method $method
+     * @param Node $node
+     *
+     * @return void
+     */
+    private function analyzeMethodVisibility(
+        CodeBase $code_base,
+        Method $method,
+        Node $node
+    ) {
+        if (
+            $method->isPrivate()
+            && !$method->getDefiningClass($code_base)->isTrait()
+            && (
+                !$this->context->isInClassScope()
+                || $this->context->getClassFQSEN() != $method->getDefiningClassFQSEN()
+            )
+        ) {
+            $this->emitIssue(
+                Issue::AccessMethodPrivate,
+                $node->lineno ?? 0,
+                (string)$method->getFQSEN(),
+                $method->getFileRef()->getFile(),
+                (string)$method->getFileRef()->getLineNumberStart()
+            );
+        } else if (
+            $method->isProtected()
+            && !$method->getDefiningClass($code_base)->isTrait()
+            && (
+                !$this->context->isInClassScope()
+                || (
+                    !$this->context->getClassFQSEN()->asType()->canCastToType(
+                        $method->getClassFQSEN()->asType()
+                    )
+                    && !$this->context->getClassFQSEN()->asType()->isSubclassOf(
+                        $code_base,
+                        $method->getDefiningClassFQSEN()->asType()
+                    )
+                )
+                && $this->context->getClassFQSEN() != $method->getDefiningClassFQSEN()
+            )
+        ) {
+            $this->emitIssue(
+                Issue::AccessMethodProtected,
+                $node->lineno ?? 0,
+                (string)$method->getFQSEN(),
+                $method->getFileRef()->getFile(),
+                (string)$method->getFileRef()->getLineNumberStart()
+            );
+        }
     }
 
     /**

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -1111,7 +1111,7 @@ class Clazz extends AddressableElement
 
         if ($method->getFQSEN() !== $method_fqsen) {
             $method = clone($method);
-            $method->setDefiningFQSEN($method->getFQSEN());
+            $method->setDefiningFQSEN($method->getDefiningFQSEN());
             $method->setFQSEN($method_fqsen);
 
             // Clone the parameter list, so that modifying the parameters on the first call won't modify the others.

--- a/tests/files/expected/0292_priv_prot_static_methods.php.expected
+++ b/tests/files/expected/0292_priv_prot_static_methods.php.expected
@@ -1,0 +1,5 @@
+%s:12 PhanAccessMethodPrivate Cannot access private method \B292::priv defined at %s:4
+%s:17 PhanAccessMethodPrivate Cannot access private method \A292::priv defined at %s:4
+%s:18 PhanAccessMethodProtected Cannot access protected method \A292::prot defined at %s:5
+%s:21 PhanAccessMethodPrivate Cannot access private method \B292::priv defined at %s:4
+%s:22 PhanAccessMethodProtected Cannot access protected method \B292::prot defined at %s:5

--- a/tests/files/src/0292_priv_prot_static_methods.php
+++ b/tests/files/src/0292_priv_prot_static_methods.php
@@ -1,0 +1,23 @@
+<?php
+
+class A292 {
+    private static function priv() {}
+    protected static function prot() {}
+    public static function pub() {}
+}
+
+class B292 extends A292 {
+    public static function all() {
+        self::prot();
+        self::priv();
+        self::pub();
+    }
+}
+
+A292::priv();
+A292::prot();
+A292::pub();
+
+B292::priv();
+B292::prot();
+B292::pub();

--- a/tests/files/src/0293_prot_static_method_called_through_child.php
+++ b/tests/files/src/0293_prot_static_method_called_through_child.php
@@ -1,0 +1,15 @@
+<?php
+
+class A293 {
+    protected static function prot() {}
+
+    public static function pub() {
+        C293::prot();
+    }
+}
+
+abstract class B293 extends A293 {}
+
+class C293 extends B293 {}
+
+A293::pub();


### PR DESCRIPTION
This resolves the issue as described. After making the changes to `PostOrderAnalysisVisitor`, I found the issue tested by 293 by running Phan on itself. That prompted the change to `Clazz`. It seemed better to carry through the defining FQSEN than to alter the logic in `PostOrderAnalysisVisitor::analyzeMethodVisibility()`. @morria added the line I touched in `Clazz` to resolve #300, FWIW.