### PR TITLE
Fix bugs in daemon mode, and in the JSON output printer

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -51,6 +51,7 @@ Bug Fixes
 - Existence of __get() no longer affects analyzing static properties. (Issue #610)
 - Phan can now detect the declaration of constants relative to a `use`d namespace (Issue #509)
 - Phan can now detect the declaration of functions relative to a `use`d namespace (Issue #510)
+- Fix bug where JSON output printer accidentally escaped some output ("<"), causing invalid JSON.
 
 Backwards Incompatible Changes
 - Declarations of user-defined constants are now consistently

--- a/phan_client
+++ b/phan_client
@@ -188,11 +188,21 @@ class PhanPHPLinter {
     /**
      * @param array[] $response
      * @param string[] $file_mapping
+     * @return void
      */
     private static function dumpJSONIssues(array $response, array $file_mapping) {
         $did_debug = false;
         // if ($response['issue_count'] > 0)
-        foreach ($response['issues'] as $issue) {
+        $issues = $response['issues'];
+        if (!is_array($issues)) {
+            if (is_string($issues)) {
+                self::debugError(sprintf("Invalid issues response from phan: %s\n", $issues));
+            } else {
+                self::debugError(sprintf("Invalid type for issues response from phan: %s\n", gettype($issues)));
+            }
+            return;
+        }
+        foreach ($issues as $issue) {
             if ($issue['type'] !== 'issue') {
                 continue;
             }

--- a/src/Phan/Daemon/Request.php
+++ b/src/Phan/Daemon/Request.php
@@ -88,7 +88,7 @@ class Request {
         if (($this->config[self::PARAM_FORMAT] ?? null) === 'json') {
             $issues = json_decode($rawIssues, true);
             if (!is_array($issues)) {
-                $issues = "(Failed to decode) " . $rawIssues;
+                $issues = "(Failed to decode) " . json_last_error_msg() . ': ' . $rawIssues;
             }
         } else {
             $issues = $rawIssues;

--- a/src/Phan/Output/Printer/CodeClimatePrinter.php
+++ b/src/Phan/Output/Printer/CodeClimatePrinter.php
@@ -64,10 +64,8 @@ final class CodeClimatePrinter implements BufferedPrinterInterface
         // See https://github.com/codeclimate/spec/blob/master/SPEC.md#output
         // for details on the CodeClimate output format
         foreach ($this->messages as $message) {
-            $this->output->write(
-                json_encode($message, JSON_UNESCAPED_SLASHES, JSON_UNESCAPED_UNICODE)
-                . chr(0)
-            );
+            $encodedMessage = json_encode($message, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "\0";
+            $this->output->write($encodedMessage, false, OutputInterface::OUTPUT_RAW);
         }
         $this->messages = [];
     }

--- a/src/Phan/Output/Printer/JSONPrinter.php
+++ b/src/Phan/Output/Printer/JSONPrinter.php
@@ -39,7 +39,10 @@ final class JSONPrinter implements BufferedPrinterInterface
     /** flush printer buffer */
     public function flush()
     {
-        $this->output->write(json_encode($this->messages, JSON_UNESCAPED_SLASHES, JSON_UNESCAPED_UNICODE));
+        // NOTE: Need to use OUTPUT_RAW for JSON.
+        // Otherwise, error messages such as "...Unexpected << (T_SL)" don't get formatted properly (They get escaped into unparseable JSON)
+        $encodedMessage = json_encode($this->messages, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $this->output->write($encodedMessage, false, OutputInterface::OUTPUT_RAW);
         $this->messages = [];
     }
 


### PR DESCRIPTION
Noticed that "Unexpected << (T_SL)" was being converted to "Unexpected \ (T_SL)" when the JSON output format was used (Because the output formatter does escaping).

JSON shouldn't be escaped by symfony (as HTML?), whether or not daemon mode is used. The default of the symfony formatter is to escape output.