### PR TITLE
Add related code changes from #729, without changing UnionType representation

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1740,10 +1740,10 @@ class UnionTypeVisitor extends AnalysisVisitor
 
         // Iterate over each viable class type to see if any
         // have the constant we're looking for
-        foreach ($union_type->nonNativeTypes()->getTypeSet()
-        as $class_type) {
+        foreach ($union_type->nonNativeTypes()->getTypeSet() as $class_type) {
             // Get the class FQSEN
             $class_fqsen = $class_type->asFQSEN();
+            assert($class_fqsen instanceof FullyQualifiedClassName, 'Parsing a class node must return a class name fqsen');
 
             // See if the class exists
             if (!$this->code_base->hasClassWithFQSEN($class_fqsen)) {

--- a/src/Phan/Analysis/DuplicateFunctionAnalyzer.php
+++ b/src/Phan/Analysis/DuplicateFunctionAnalyzer.php
@@ -46,8 +46,8 @@ class DuplicateFunctionAnalyzer
 
         $method_name = $method->getName();
 
-        if (!$method->hasSuppressIssue(Issue::RedefineFunction)) {
-            if ($original_method->isPHPInternal()) {
+        if ($original_method->isPHPInternal()) {
+            if (!$method->hasSuppressIssue(Issue::RedefineFunctionInternal)) {
                 Issue::maybeEmit(
                     $code_base,
                     $method->getContext(),
@@ -57,7 +57,9 @@ class DuplicateFunctionAnalyzer
                     $method->getFileRef()->getFile(),
                     $method->getFileRef()->getLineNumberStart()
                 );
-            } else {
+            }
+        } else {
+            if (!$method->hasSuppressIssue(Issue::RedefineFunction)) {
                 Issue::maybeEmit(
                     $code_base,
                     $method->getContext(),

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -8,6 +8,7 @@ use Phan\Language\Element\Clazz;
 use Phan\Language\Element\FunctionInterface;
 use Phan\Language\Element\Method;
 use Phan\Language\Element\Parameter;
+use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\Type\IterableType;
 use Phan\Language\Type\MixedType;
 use Phan\Language\Type\TemplateType;
@@ -53,6 +54,7 @@ class ParameterTypesAnalyzer
                 } else {
                     // Make sure the class exists
                     $type_fqsen = $type->asFQSEN();
+                    assert($type_fqsen instanceof FullyQualifiedClassName, 'non-native types must be class names');
                     if (!$code_base->hasClassWithFQSEN($type_fqsen)) {
                         Issue::maybeEmit(
                             $code_base,

--- a/src/Phan/Analysis/PropertyTypesAnalyzer.php
+++ b/src/Phan/Analysis/PropertyTypesAnalyzer.php
@@ -5,6 +5,7 @@ use Phan\CodeBase;
 use Phan\Exception\IssueException;
 use Phan\Issue;
 use Phan\Language\Element\Clazz;
+use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\Type\TemplateType;
 
 class PropertyTypesAnalyzer
@@ -52,6 +53,7 @@ class PropertyTypesAnalyzer
 
                     // Make sure the class exists
                     $type_fqsen = $type->asFQSEN();
+                    assert($type_fqsen instanceof FullyQualifiedClassName, 'fqsens of non-native types must be class names');
 
                     if (!$code_base->hasClassWithFQSEN($type_fqsen)
                         && !($type instanceof TemplateType)

--- a/tests/Phan/AbstractPhanFileTest.php
+++ b/tests/Phan/AbstractPhanFileTest.php
@@ -9,7 +9,7 @@ use Phan\Phan;
 use Symfony\Component\Console\Output\BufferedOutput;
 
 abstract class AbstractPhanFileTest
-    extends \PHPUnit_Framework_TestCase
+    extends BaseTest
     implements CodeBaseAwareTestInterface
 {
     const EXPECTED_SUFFIX = '.expected';

--- a/tests/Phan/AnalyzerTest.php
+++ b/tests/Phan/AnalyzerTest.php
@@ -17,7 +17,7 @@ use Phan\Config;
 use Phan\Language\Context;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
 
-class AnalyzerTest extends \PHPUnit_Framework_TestCase {
+class AnalyzerTest extends BaseTest {
 
     private $class_name_list;
     private $interface_name_list;

--- a/tests/Phan/BaseTest.php
+++ b/tests/Phan/BaseTest.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Phan\Tests;
+
+/**
+ * Any common initialization or configuration should go here
+ * (E.g. may want to change https://phpunit.de/manual/current/en/fixtures.html#fixtures.global-state in some classes)
+ */
+class BaseTest extends \PHPUnit_Framework_TestCase {
+}

--- a/tests/Phan/ForkPoolTest.php
+++ b/tests/Phan/ForkPoolTest.php
@@ -1,12 +1,12 @@
 <?php declare(strict_types = 1);
-namespace Phan\Test;
+namespace Phan\Tests;
 
 use Phan\ForkPool;
 
 /**
  * @requires extension pcntl
  */
-class ForkPoolTest extends \PHPUnit_Framework_TestCase
+class ForkPoolTest extends BaseTest
 {
     /**
      * Test that workers are able to send their data back

--- a/tests/Phan/Language/ContextTest.php
+++ b/tests/Phan/Language/ContextTest.php
@@ -9,9 +9,10 @@ use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\FQSEN\FullyQualifiedMethodName;
 use Phan\Language\Scope\ClassScope;
 use Phan\Language\Scope\FunctionLikeScope;
+use Phan\Tests\BaseTest;
 use Phan\Parse\ParseVisitor;
 
-class ContextTest extends \PHPUnit_Framework_TestCase {
+class ContextTest extends BaseTest {
 
     /** @var CodeBase|null */
     protected $code_base = null;

--- a/tests/Phan/Language/FQSENTest.php
+++ b/tests/Phan/Language/FQSENTest.php
@@ -10,8 +10,9 @@ use Phan\Language\FQSEN\FullyQualifiedFunctionName;
 use Phan\Language\FQSEN\FullyQualifiedGlobalConstantName;
 use Phan\Language\FQSEN\FullyQualifiedMethodName;
 use Phan\Language\FQSEN\FullyQualifiedPropertyName;
+use Phan\Tests\BaseTest;
 
-class FQSENTest extends \PHPUnit_Framework_TestCase {
+class FQSENTest extends BaseTest {
 
     /** @var Context|null */
     protected $context = null;

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -19,8 +19,9 @@ use Phan\CodeBase;
 use Phan\Config;
 use Phan\Language\Context;
 use Phan\Language\UnionType;
+use Phan\Tests\BaseTest;
 
-class UnionTypeTest extends \PHPUnit_Framework_TestCase {
+class UnionTypeTest extends BaseTest {
 
     /** @var Context|null */
     protected $context = null;

--- a/tests/Phan/Library/TupleTest.php
+++ b/tests/Phan/Library/TupleTest.php
@@ -1,10 +1,10 @@
 <?php declare(strict_types = 1);
-namespace Phan\Test;
+namespace Phan\Tests;
 
 
 /**
  */
-class TupleTest extends \PHPUnit_Framework_TestCase
+class TupleTest extends BaseTest
 {
     public function testSimple()
     {

--- a/tests/Phan/Output/Printer/CSVPrinterTest.php
+++ b/tests/Phan/Output/Printer/CSVPrinterTest.php
@@ -5,10 +5,11 @@ namespace Phan\Tests\Output\Printer;
 use Phan\Issue;
 use Phan\IssueInstance;
 use Phan\Output\Printer\CSVPrinter;
+use Phan\Tests\BaseTest;
 use PHPUnit_Framework_TestCase;
 use Symfony\Component\Console\Output\BufferedOutput;
 
-class CSVPrinterTest extends PHPUnit_Framework_TestCase {
+class CSVPrinterTest extends BaseTest {
 
     public function testHeaderCorrespondsToData() {
         $output = new BufferedOutput();

--- a/tests/Phan/Output/Printer/CheckstylePrinterTest.php
+++ b/tests/Phan/Output/Printer/CheckstylePrinterTest.php
@@ -5,10 +5,11 @@ namespace Phan\Tests\Output\Printer;
 use Phan\Issue;
 use Phan\IssueInstance;
 use Phan\Output\Printer\CheckstylePrinter;
+use Phan\Tests\BaseTest;
 use PHPUnit_Framework_TestCase;
 use Symfony\Component\Console\Output\BufferedOutput;
 
-class CheckstylePrinterTest extends PHPUnit_Framework_TestCase {
+class CheckstylePrinterTest extends BaseTest {
 
     /**
      * @param string $string String to check against

--- a/tests/files/expected/0188_prop_array_access.php.expected
+++ b/tests/files/expected/0188_prop_array_access.php.expected
@@ -2,3 +2,4 @@
 %s:2 PhanClassContainsAbstractMethodInternal non-abstract class \C188 contains abstract internal method \ArrayAccess::offsetGet
 %s:2 PhanClassContainsAbstractMethodInternal non-abstract class \C188 contains abstract internal method \ArrayAccess::offsetSet
 %s:2 PhanClassContainsAbstractMethodInternal non-abstract class \C188 contains abstract internal method \ArrayAccess::offsetUnset
+%s:10 PhanUndeclaredProperty Reference to undeclared property \C188->key

--- a/tests/files/src/0188_prop_array_access.php
+++ b/tests/files/src/0188_prop_array_access.php
@@ -7,5 +7,6 @@ class E188 {
     private $p;
     function f() {
         $this->p['key'] = 42;
+        $this->p->key = 43;
     }
 }

--- a/tests/files/src/0225_internal_tostring_parameter_strict.php
+++ b/tests/files/src/0225_internal_tostring_parameter_strict.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 try {
     throw new Exception("message");
-} catch(\Exception $e) {
-    error_log($e);
+} catch(\Exception $e225) {
+    error_log($e225);
 }

--- a/tests/files/src/0290_internal_types_are_phpdoc_types.php
+++ b/tests/files/src/0290_internal_types_are_phpdoc_types.php
@@ -1,4 +1,4 @@
 <?php
 
-$result = filter_id('not-a-filter');
-$result->doSomething();
+$result290 = filter_id('not-a-filter');
+$result290->doSomething();


### PR DESCRIPTION
And add test of ArrayAccess implementation, to avoid regression.
Add a common base test class, to make common configuration easier in
future PRs.

These changes were taken directly from #729 (tidied up code comments, removed unused imports, no changes otherwise)