### PR TITLE
Partially fixes issue #795 :  analyze traits to see if the methods they implement are compatible 

### DIFF
--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -1076,7 +1076,7 @@ class Issue
                 self::ParamSignatureRealMismatchTooFewParameters,
                 self::CATEGORY_PARAMETER,
                 self::SEVERITY_NORMAL,
-                "Declaration of {METHOD} should be compatible with {METHOD} (the method override accepts {COUNT} parameters, but the overridden method can accept {COUNT}) defined in {FILE}:{LINE}",
+                "Declaration of {METHOD} should be compatible with {METHOD} (the method override accepts {COUNT} parameter(s), but the overridden method can accept {COUNT}) defined in {FILE}:{LINE}",
                 self::REMEDIATION_B,
                 7029
             ),
@@ -1084,7 +1084,7 @@ class Issue
                 self::ParamSignatureRealMismatchTooFewParametersInternal,
                 self::CATEGORY_PARAMETER,
                 self::SEVERITY_NORMAL,
-                "Declaration of {METHOD} should be compatible with internal {METHOD} (the method override accepts {COUNT} parameters, but the overridden method can accept {COUNT})",
+                "Declaration of {METHOD} should be compatible with internal {METHOD} (the method override accepts {COUNT} parameter(s), but the overridden method can accept {COUNT})",
                 self::REMEDIATION_B,
                 7030
             ),
@@ -1092,7 +1092,7 @@ class Issue
                 self::ParamSignatureRealMismatchTooManyRequiredParameters,
                 self::CATEGORY_PARAMETER,
                 self::SEVERITY_NORMAL,
-                "Declaration of {METHOD} should be compatible with {METHOD} (the method override requires {COUNT} parameters, but the overridden method requires only {COUNT}) defined in {FILE}:{LINE}",
+                "Declaration of {METHOD} should be compatible with {METHOD} (the method override requires {COUNT} parameter(s), but the overridden method requires only {COUNT}) defined in {FILE}:{LINE}",
                 self::REMEDIATION_B,
                 7031
             ),
@@ -1100,7 +1100,7 @@ class Issue
                 self::ParamSignatureRealMismatchTooManyRequiredParametersInternal,
                 self::CATEGORY_PARAMETER,
                 self::SEVERITY_NORMAL,
-                "Declaration of {METHOD} should be compatible with internal {METHOD} (the method override requires {COUNT} parameters, but the overridden method requires only {COUNT})",
+                "Declaration of {METHOD} should be compatible with internal {METHOD} (the method override requires {COUNT} parameter(s), but the overridden method requires only {COUNT})",
                 self::REMEDIATION_B,
                 7032
             ),

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -1117,6 +1117,8 @@ class Clazz extends AddressableElement
             $existing_method =
                 $code_base->getMethodByFQSEN($method_fqsen);
             if ($method->isAbstract() || !$existing_method->isAbstract() || $existing_method->getIsNewConstructor()) {
+                // TODO: What if both of these are abstract, and those get combined into an abstract class?
+                //       Should phan check compatibility of the abstract methods it inherits?
                 $existing_method->setIsOverride(true);
 
                 // Don't add the method

--- a/src/Phan/Language/Element/ElementFutureUnionType.php
+++ b/src/Phan/Language/Element/ElementFutureUnionType.php
@@ -22,7 +22,7 @@ trait ElementFutureUnionType
      * @param UnionType $type
      * Set the type of this element
      *
-     * @return null
+     * @return void
      */
     abstract public function setUnionType(UnionType $type);
 

--- a/tests/files/expected/0124_override_signature.php.expected
+++ b/tests/files/expected/0124_override_signature.php.expected
@@ -1,7 +1,7 @@
 %s:6 PhanParamSignatureMismatch Declaration of function f() should be compatible with function f(int $a) defined in %s:3
-%s:6 PhanParamSignatureRealMismatchTooFewParameters Declaration of function f() should be compatible with function f(int $a) (the method override accepts 0 parameters, but the overridden method can accept 1) defined in %s:3
+%s:6 PhanParamSignatureRealMismatchTooFewParameters Declaration of function f() should be compatible with function f(int $a) (the method override accepts 0 parameter(s), but the overridden method can accept 1) defined in %s:3
 %s:12 PhanParamSignatureMismatch Declaration of function f(int $a, int $b) should be compatible with function f(int $a) defined in %s:3
-%s:12 PhanParamSignatureRealMismatchTooManyRequiredParameters Declaration of function f(int $a, int $b) should be compatible with function f(int $a) (the method override requires 2 parameters, but the overridden method requires only 1) defined in ./tests/files/src/0124_override_signature.php:3
+%s:12 PhanParamSignatureRealMismatchTooManyRequiredParameters Declaration of function f(int $a, int $b) should be compatible with function f(int $a) (the method override requires 2 parameter(s), but the overridden method requires only 1) defined in ./tests/files/src/0124_override_signature.php:3
 %s:15 PhanParamSignatureMismatch Declaration of function f(string $a) should be compatible with function f(int $a) defined in %s:3
 %s:15 PhanParamSignatureRealMismatchParamType Declaration of function f(string $a) should be compatible with function f(int $a) (parameter #1 of type 'string' cannot replace original parameter of type 'int') defined in %s:3
 %s:18 PhanParamSignatureMismatch Declaration of function f($a) should be compatible with function f(int $a) defined in %s:3
@@ -11,11 +11,11 @@
 %s:28 PhanParamSignatureRealMismatch Declaration of function g() should be compatible with function g() : string (method returning '' cannot override method returning 'string') defined in %s:22
 %s:35 PhanParamSignatureRealMismatchHasParamType Declaration of function h(int $a) should be compatible with function h($a) (parameter #1 of has type 'int' cannot replace original parameter with no type) defined in %s:32
 %s:50 PhanParamSignatureMismatch Declaration of function i($a) should be compatible with function i($a, mixed|string $b = default) defined in %s:46
-%s:50 PhanParamSignatureRealMismatchTooFewParameters Declaration of function i($a) should be compatible with function i($a, $b = default) (the method override accepts 1 parameters, but the overridden method can accept 2) defined in ./tests/files/src/0124_override_signature.php:46
+%s:50 PhanParamSignatureRealMismatchTooFewParameters Declaration of function i($a) should be compatible with function i($a, $b = default) (the method override accepts 1 parameter(s), but the overridden method can accept 2) defined in ./tests/files/src/0124_override_signature.php:46
 %s:58 PhanParamSignatureMismatch Declaration of function j() should be compatible with function &j() defined in %s:54
 %s:67 PhanParamSignatureMismatch Declaration of function k(&$a) should be compatible with function k($a) defined in %s:62
 %s:67 PhanParamSignatureRealMismatchParamIsReference Declaration of function k(&$a) should be compatible with function k($a) (parameter #1 is a reference parameter overriding a non-reference parameter) defined in %s:62
 %s:68 PhanParamSignatureMismatch Declaration of function l($b) should be compatible with function l(&$b) defined in %s:63
 %s:68 PhanParamSignatureRealMismatchParamIsNotReference Declaration of function l($b) should be compatible with function l(&$b) (parameter #1 is a non-reference parameter overriding a reference parameter) defined in %s:63
 %s:76 PhanParamSignatureMismatch Declaration of function m($a) should be compatible with function m(mixed $a = null) defined in %s:72
-%s:76 PhanParamSignatureRealMismatchTooManyRequiredParameters Declaration of function m($a) should be compatible with function m($a = null) (the method override requires 1 parameters, but the overridden method requires only 0) defined in %s:72
+%s:76 PhanParamSignatureRealMismatchTooManyRequiredParameters Declaration of function m($a) should be compatible with function m($a = null) (the method override requires 1 parameter(s), but the overridden method requires only 0) defined in %s:72

--- a/tests/files/expected/0227_trait_class_interface.php.expected
+++ b/tests/files/expected/0227_trait_class_interface.php.expected
@@ -1,2 +1,2 @@
 %s:13 PhanParamSignatureMismatch Declaration of function f(array $a) should be compatible with function f(array $a, array $b) defined in %s:4
-%s:13 PhanParamSignatureRealMismatchTooFewParameters Declaration of function f(array $a) should be compatible with function f(array $a, array $b) (the method override accepts 1 parameters, but the overridden method can accept 2) defined in %s:4
+%s:13 PhanParamSignatureRealMismatchTooFewParameters Declaration of function f(array $a) should be compatible with function f(array $a, array $b) (the method override accepts 1 parameter(s), but the overridden method can accept 2) defined in %s:4

--- a/tests/files/expected/0279_should_check_variadic_mismatch.php.expected
+++ b/tests/files/expected/0279_should_check_variadic_mismatch.php.expected
@@ -1,10 +1,10 @@
 %s:21 PhanParamSignatureMismatch Declaration of function foo(int ...$args) should be compatible with function foo(int $args) defined in %s:4
 %s:21 PhanParamSignatureRealMismatchParamVariadic Declaration of function foo(int ...$args) should be compatible with function foo(int $args) (parameter #1 is a variadic parameter replacing a non-variadic parameter) defined in %s:4
 %s:23 PhanParamSignatureMismatch Declaration of function bar(int $args) should be compatible with function bar(int ...$args) defined in %s:6
-%s:23 PhanParamSignatureRealMismatchTooManyRequiredParameters Declaration of function bar(int $args) should be compatible with function bar(int ...$args) (the method override requires 1 parameters, but the overridden method requires only 0) defined in %s:6
+%s:23 PhanParamSignatureRealMismatchTooManyRequiredParameters Declaration of function bar(int $args) should be compatible with function bar(int ...$args) (the method override requires 1 parameter(s), but the overridden method requires only 0) defined in %s:6
 %s:27 PhanParamSignatureMismatch Declaration of function bag() should be compatible with function bag(int ...$args) defined in %s:10
-%s:27 PhanParamSignatureRealMismatchTooFewParameters Declaration of function bag() should be compatible with function bag(int ...$args) (the method override accepts 0 parameters, but the overridden method can accept 1) defined in %s:10
+%s:27 PhanParamSignatureRealMismatchTooFewParameters Declaration of function bag() should be compatible with function bag(int ...$args) (the method override accepts 0 parameter(s), but the overridden method can accept 1) defined in %s:10
 %s:32 PhanParamSignatureMismatch Declaration of function man(...$args) should be compatible with function man(array $args) defined in %s:15
 %s:32 PhanParamSignatureRealMismatchParamVariadic Declaration of function man(...$args) should be compatible with function man(array $args) (parameter #1 is a variadic parameter replacing a non-variadic parameter) defined in %s:15
 %s:34 PhanParamSignatureMismatch Declaration of function dog(array $args) should be compatible with function dog(...$args) defined in %s:17
-%s:34 PhanParamSignatureRealMismatchTooManyRequiredParameters Declaration of function dog(array $args) should be compatible with function dog(...$args) (the method override requires 1 parameters, but the overridden method requires only 0) defined in %s:17
+%s:34 PhanParamSignatureRealMismatchTooManyRequiredParameters Declaration of function dog(array $args) should be compatible with function dog(...$args) (the method override requires 1 parameter(s), but the overridden method requires only 0) defined in %s:17

--- a/tests/files/expected/0298_trait_match_abstract.php.expected
+++ b/tests/files/expected/0298_trait_match_abstract.php.expected
@@ -1,0 +1,8 @@
+%s:14 PhanParamSignatureMismatch Declaration of function foo1(string $arg) : void should be compatible with function foo1(int $arg) : void defined in %s:5
+%s:14 PhanParamSignatureRealMismatchParamType Declaration of function foo1(string $arg) : void should be compatible with function foo1(int $arg) : void (parameter #1 of type 'string' cannot replace original parameter of type 'int') defined in %s:5
+%s:18 PhanParamSignatureMismatch Declaration of function foo2() : bool should be compatible with function foo2() : void defined in %s:6
+%s:18 PhanParamSignatureRealMismatch Declaration of function foo2() : bool should be compatible with function foo2() : void (method returning 'bool' cannot override method returning 'void') defined in %s:6
+%s:23 PhanParamSignatureMismatch Declaration of function foo3($requiredArg) should be compatible with function foo3() defined in %s:7
+%s:23 PhanParamSignatureRealMismatchTooManyRequiredParameters Declaration of function foo3($requiredArg) should be compatible with function foo3() (the method override requires 1 parameter(s), but the overridden method requires only 0) defined in %s:7
+%s:33 PhanParamSignatureMismatch Declaration of function fooOverrideByAliasBad(int $arg) : bool should be compatible with function fooOverrideByAliasBad(int $arg) : void defined in %s:8
+%s:33 PhanParamSignatureRealMismatch Declaration of function fooOverrideByAliasBad(int $arg) : bool should be compatible with function fooOverrideByAliasBad(int $arg) : void (method returning 'bool' cannot override method returning 'void') defined in %s:8

--- a/tests/files/expected/0302_trait_abstract_signature.php.expected
+++ b/tests/files/expected/0302_trait_abstract_signature.php.expected
@@ -1,0 +1,1 @@
+%s:28 PhanTypeMismatchArgument Argument 1 (x) is string but \C::fn2() takes int defined at %s:17

--- a/tests/files/src/0125_trait_overrides.php
+++ b/tests/files/src/0125_trait_overrides.php
@@ -1,12 +1,19 @@
 <?php
+error_reporting(E_ALL);
 
 class C {}
 
 trait T {
-    public static function f(C $p) {}
+    public static function f(C $p) { }
+    public function gAbstract(C $p) {}
+    public static function gAbstractStatic(C $p) {}
 }
 
 class C1 {
     use T;
     public static function f($p) {}
+    public function gAbstract($p) : int {return 1;}  // This doesn't throw at runtime, so RealSignatureMismatch shouldn't be emitted. Maybe something else in the future.
+    public static function gAbstractStatic($p) : int {return 0;}  // This doesn't throw
 }
+$c125 = new C1();  // This does not throw
+C1::f(42);  // Neither does this.

--- a/tests/files/src/0298_trait_match_abstract.php
+++ b/tests/files/src/0298_trait_match_abstract.php
@@ -1,0 +1,53 @@
+<?php
+error_reporting(E_ALL);
+
+abstract class BaseClass {
+    abstract function foo1(int $arg) : void;
+    abstract function foo2() : void;
+    abstract function foo3();
+    abstract function fooOverrideByAliasBad(int $arg) : void;
+    abstract function fooOverrideByAliasGood(int $arg) : void;
+    abstract function fooMatching(int $arg) : bool ;
+}
+
+trait WorkTrait {
+    function foo1(string $arg) : void {
+        echo "Working\n";
+    }
+
+    function foo2() : bool {
+        echo "Working!\n";
+        return true;
+    }
+
+    function foo3($requiredArg) {
+        echo "Working!\n";
+        return true;
+    }
+
+    function fooMatching(int $arg) : bool {
+        echo "Working!\n";
+        return true;
+    }
+
+    function fooToAliasBad(int $arg) : bool {
+        return false;
+    }
+
+    function fooToAliasGood(int $arg) : void {
+    }
+}
+
+class DerivedClass extends BaseClass {
+    // TODO: Fix edge cases comparing visibility of these methods in later PRs.
+    use WorkTrait {
+        fooToAliasBad as fooOverrideByAliasBad;
+        fooToAliasGood as fooOverrideByAliasGood;
+    }
+}
+
+$obj = new DerivedClass;
+$obj->foo1('x');
+$obj->foo2();
+$obj->foo3('x');
+$obj->fooMatching(42);

--- a/tests/files/src/0302_trait_abstract_signature.php
+++ b/tests/files/src/0302_trait_abstract_signature.php
@@ -1,0 +1,32 @@
+<?php  // Test for #457
+trait A {
+    protected abstract function fn();
+
+    protected abstract function fn2(int $x);
+}
+
+class B {
+    function __construct() {
+        $this->fn(1);
+    }
+    protected function fn() {
+        $args = func_get_args();
+        return true;
+    }
+
+    protected function fn2(int $x) {
+        $args = func_get_args();
+        return $x;
+    }
+}
+
+class C extends B {
+    use A;
+
+    function __construct() {
+        $this->fn(1);
+        $this->fn2('incompatible', ['extra param']);
+    }
+}
+
+$c = new C;


### PR DESCRIPTION
Start analyzing traits to see if the methods they implement are
compatible (if overriding abstract base class's methods)

Fix grammar nit in error message (Should say {COUNT} parameter(s))
Add a unit test

Fix mismatch found for phpdoc trait in ElementFutureUnionType(debatable)