### PR TITLE
Fixes #771: improve analysis of booleans in union types: Allow param types, return types, etc. to include TrueType and FalseType

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1163,9 +1163,6 @@ class UnionTypeVisitor extends AnalysisVisitor
      */
     public function visitClassConst(Node $node) : UnionType
     {
-
-        $constant_name = $node->children['const'];
-
         try {
             $constant = (new ContextNode(
                 $this->code_base,

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -11,14 +11,22 @@ use Phan\Issue;
 use Phan\Language\Type;
 use Phan\Language\Context;
 use Phan\Language\Type\ArrayType;
+use Phan\Language\Type\CallableType;
+use Phan\Language\Type\FloatType;
 use Phan\Language\Type\IntType;
+use Phan\Language\Type\IterableType;
 use Phan\Language\Type\NullType;
 use Phan\Language\Type\ObjectType;
+use Phan\Language\Type\ResourceType;
+use Phan\Language\Type\ScalarType;
 use Phan\Language\Type\StringType;
 use Phan\Language\Element\Variable;
 use Phan\Language\UnionType;
 use ast\Node;
 
+
+// TODO: Make $x != null remove FalseType and NullType from $x
+// TODO: Make $x > 0, $x < 0, $x >= 50, etc.  remove FalseType and NullType from $x
 class ConditionVisitor extends KindVisitorImplementation
 {
 
@@ -109,6 +117,9 @@ class ConditionVisitor extends KindVisitorImplementation
         } else if ($flags === \ast\flags\BINARY_IS_IDENTICAL) {
             $this->checkVariablesDefined($node);
             return $this->analyzeIsIdentical($node->children['left'], $node->children['right']);
+        } else if ($flags === \ast\flags\BINARY_IS_NOT_IDENTICAL || $flags === \ast\flags\BINARY_IS_NOT_EQUAL) {
+            // TODO: Add a different function for IS_NOT_EQUAL, e.g. analysis of != null should be different from !== null (First would remove FalseType)
+            return $this->analyzeIsNotIdentical($node->children['left'], $node->children['right']);
         } else {
             $this->checkVariablesDefined($node);
         }
@@ -131,15 +142,31 @@ class ConditionVisitor extends KindVisitorImplementation
     }
 
     /**
+     * @param Node|int|float|string $left
+     * @param Node|int|float|string $right
+     * @return Context - Constant after inferring type from an expression such as `if ($x !== false)`
+     */
+    private function analyzeIsNotIdentical($left, $right) : Context
+    {
+        if (($left instanceof Node) && $left->kind === \ast\AST_VAR) {
+            return $this->analyzeVarIsNotIdentical($left, $right);
+        } else if (($right instanceof Node) && $right->kind === \ast\AST_VAR) {
+            return $this->analyzeVarIsNotIdentical($right, $left);
+        }
+        return $this->context;
+    }
+
+    /**
      * @param Node $var_node
      * @param Node|int|float|string $expr
      * @return Context - Constant after inferring type from an expression such as `if ($x === 'literal')`
      */
     private function analyzeVarIsIdentical(Node $var_node, $expr) : Context
     {
-        $name = $var_node->children['name'] ?? null;
+        $var_name = $var_node->children['name'] ?? null;
         $context = $this->context;
-        if (\is_string($name) && $name) {
+        // Don't analyze variables such as $$a
+        if (\is_string($var_name) && $var_name) {
             try {
                 $exprType = UnionTypeVisitor::unionTypeFromLiteralOrConstant($this->code_base, $this->context, $expr);
                 if ($exprType) {
@@ -163,11 +190,45 @@ class ConditionVisitor extends KindVisitorImplementation
                     return $context;
                 }
             } catch (\Exception $e) {
-                // ignore it.
+                // Swallow it (E.g. IssueException for undefined variable)
             }
         }
         return $context;
     }
+
+    /**
+     * @param Node $var_node
+     * @param Node|int|float|string $expr
+     * @return Context - Constant after inferring type from an expression such as `if ($x === 'literal')`
+     */
+    private function analyzeVarIsNotIdentical(Node $var_node, $expr) : Context
+    {
+        $var_name = $var_node->children['name'] ?? null;
+        $context = $this->context;
+        if (\is_string($var_name)) {
+            try {
+                if ($expr instanceof Node && $expr->kind === \ast\AST_CONST) {
+                    $exprNameNode = $expr->children['name'];
+                    if ($exprNameNode->kind === \ast\AST_NAME) {
+                        // Currently, only add this inference when we're absolutely sure this is a check rejecting null/false/true
+                        $exprName = $exprNameNode->children['name'];
+                        switch(\strtolower($exprName)) {
+                        case 'null':
+                            return $this->removeNullFromVariable($var_node, $context);
+                        case 'false':
+                            return $this->removeFalseFromVariable($var_node, $context);
+                        case 'true':
+                            return $this->removeTrueFromVariable($var_node, $context);
+                        }
+                    }
+                }
+            } catch (\Exception $e) {
+                // Swallow it (E.g. IssueException for undefined variable)
+            }
+        }
+        return $context;
+    }
+
 
     /**
      * @param Node $node
@@ -237,20 +298,109 @@ class ConditionVisitor extends KindVisitorImplementation
         // Negation
         // TODO: negate instanceof, other checks
         // TODO: negation would also go in the else statement
+        // TODO: if (!$x) {} should narrow the types down to false and null (and other falsey possibilities such as int(0), string(""/"0"), array([]))
         if (($negatedNode->kind ?? 0) === \ast\AST_CALL) {
-            $args = $negatedNode->children;
-            $this->checkVariablesDefinedInCallArgs($negatedNode);
-            if (self::isCallStringWithSingleVariableArgument($negatedNode)) {
-                // TODO: Make this generic to all type assertions? E.g. if (!\is_string($x)) removes 'string' from type, makes '?string' (nullable) into 'null'.
+            $args = $negatedNode->children['args']->children;
+            if (self::isArgumentListWithVarAsFirstArgument($args)) {
+                $function_name = strtolower(ltrim($negatedNode->children['expr']->children['name'], '\\'));
+                if (\count($args) !== 1) {
+                    if (\strcasecmp($function_name, 'is_a') === 0) {
+                        return $this->analyzeNegationOfVariableIsA($args, $context);
+                    }
+                    return $context;
+                }
+                static $map;
+                if ($map === null) {
+                    $map = self::createNegationCallbackMap();
+                }
+                // TODO: Make this generic to all type assertions? E.g. if (!is_string($x)) removes 'string' from type, makes '?string' (nullable) into 'null'.
                 // This may be redundant in some places if AST canonicalization is used, but still useful in some places
                 // TODO: Make this generic so that it can be used in the 'else' branches?
-                $function_name = $negatedNode->children['expr']->children['name'];
-                if (\in_array($function_name, ['empty', 'is_null', 'is_scalar'], true)) {
-                    return $this->removeNullFromVariable($negatedNode->children['args']->children[0], $context);
+                $callback = $map[$function_name] ?? null;
+                if ($callback === null) {
+                    return $context;
                 }
+                return $callback($this, $args[0], $context);
             }
         }
         return $context;
+    }
+
+    private function analyzeNegationOfVariableIsA(array $args, Context $context) : Context
+    {
+        // TODO: implement
+        return $context;
+    }
+
+    /**
+     * @return \Closure[] (ConditionVisitor $cv, Node $var_node, Context $context) -> Context
+     */
+    private static function createNegationCallbackMap() : array {
+        $remove_empty_cb = function(ConditionVisitor $cv, Node $var_node, Context $context) : Context {
+            return $cv->removeFalseyFromVariable($var_node, $context);
+        };
+        $remove_null_cb = function(ConditionVisitor $cv, Node $var_node, Context $context) : Context {
+            return $cv->removeNullFromVariable($var_node, $context);
+        };
+
+        // Remove any Types from UnionType that are subclasses of $base_class_name
+        $make_basic_negated_assertion_callback = function(string $base_class_name) : \Closure
+        {
+            return function(ConditionVisitor $cv, Node $var_node, Context $context) use($base_class_name) : Context {
+                return $cv->updateVariableWithConditionalFilter(
+                    $var_node,
+                    $context,
+                    function(UnionType $union_type) use($base_class_name) : bool {
+                        return $union_type->hasTypeMatchingCallback(function(Type $type) use($base_class_name) : bool {
+                            return $type instanceof $base_class_name;
+                        });
+                    },
+                    function(UnionType $union_type) use ($base_class_name) : UnionType {
+                        $new_type = new UnionType();
+                        $hasNull = false;
+                        $hasOtherNullableTypes = false;
+                        // Add types which are
+                        foreach ($union_type->getTypeSet() as $type) {
+                            if ($type instanceof $base_class_name) {
+                                $hasNull = $hasNull || $type->getIsNullable();
+                                continue;
+                            }
+                            assert($type instanceof Type);
+                            $hasOtherNullableTypes = $hasOtherNullableTypes || $type->getIsNullable();
+                            $new_type->addType($type);
+                        }
+                        // Add Null if some of the rejected types were were nullable, and none of the accepted types were nullable
+                        if ($hasNull && !$hasOtherNullableTypes) {
+                            $new_type->addType(NullType::instance(false));
+                        }
+                        return $new_type;
+                    }
+                );
+            };
+        };
+        $remove_float_callback = $make_basic_negated_assertion_callback(FloatType::class);
+        $remove_int_callback = $make_basic_negated_assertion_callback(IntType::class);
+
+        return [
+            'empty' => $remove_empty_cb,
+            'is_null' => $remove_null_cb,
+            'is_array' => $make_basic_negated_assertion_callback(ArrayType::class),
+            // 'is_bool' => $make_basic_assertion_callback(BoolType::class),
+            'is_callable' => $make_basic_negated_assertion_callback(CallableType::class),
+            'is_double' => $remove_float_callback,
+            'is_float' => $remove_float_callback,
+            'is_int' => $remove_int_callback,
+            'is_integer' => $remove_int_callback,
+            'is_iterable' => $make_basic_negated_assertion_callback(IterableType::class),  // TODO: Could keep basic array types and classes extending iterable
+            'is_long' => $remove_int_callback,
+            'is_null' => $remove_null_cb,
+            // 'is_numeric' => $make_basic_assertion_callback('string|int|float'),
+            // TODO 'is_object' => $remove_object_callback,
+            'is_real' => $remove_float_callback,
+            'is_resource' => $make_basic_negated_assertion_callback(ResourceType::class),
+            'is_scalar' => $make_basic_negated_assertion_callback(ScalarType::class),
+            'is_string' => $make_basic_negated_assertion_callback(StringType::class),
+        ];
     }
 
     /**
@@ -295,12 +445,100 @@ class ConditionVisitor extends KindVisitorImplementation
      */
     public function visitVar(Node $node) : Context
     {
-        $this->checkVariablesDefined($node);
-        return $this->removeNullFromVariable($node, $this->context);
+        return $this->removeFalseyFromVariable($node, $this->context);
+    }
+
+    // Remove any types which are definitely falsey from that variable (NullType, FalseType)
+    private function removeFalseyFromVariable(Node $var_node, Context $context) : Context
+    {
+        return $this->updateVariableWithConditionalFilter(
+            $var_node,
+            $context,
+            function(UnionType $type) : bool {
+                return $type->containsFalsey();
+            },
+            function(UnionType $type) : UnionType {
+                return $type->nonFalseyClone();
+            }
+        );
+    }
+
+    /**
+     * Remove any types which are definitely truthy from that variable (objects, TrueType, ResourceType, etc.)
+     * E.g. if (empty($x)) {} would result in this.
+     * Note that Phan can't know some scalars are not an int/string/float, since 0/""/"0"/0.0/[] are empty.
+     * (Remove arrays anyway)
+     */
+    private function removeTruthyFromVariable(Node $var_node, Context $context) : Context
+    {
+        return $this->updateVariableWithConditionalFilter(
+            $var_node,
+            $context,
+            function(UnionType $type) : bool {
+                return $type->containsTruthy();
+            },
+            function(UnionType $type) : UnionType {
+                return $type->nonTruthyClone();
+            }
+        );
     }
 
     private function removeNullFromVariable(Node $var_node, Context $context) : Context
     {
+        return $this->updateVariableWithConditionalFilter(
+            $var_node,
+            $context,
+            function(UnionType $type) : bool {
+                return $type->containsNullable();
+            },
+            function(UnionType $type) : UnionType {
+                return $type->nonNullableClone();
+            }
+        );
+    }
+
+    private function removeFalseFromVariable(Node $var_node, Context $context) : Context
+    {
+        return $this->updateVariableWithConditionalFilter(
+            $var_node,
+            $context,
+            function(UnionType $type) : bool {
+                return $type->containsFalse();
+            },
+            function(UnionType $type) : UnionType {
+                return $type->nonFalseClone();
+            }
+        );
+    }
+
+    private function removeTrueFromVariable(Node $var_node, Context $context) : Context
+    {
+        return $this->updateVariableWithConditionalFilter(
+            $var_node,
+            $context,
+            function(UnionType $type) : bool {
+                return $type->containsTrue();
+            },
+            function(UnionType $type) : UnionType {
+                return $type->nonTrueClone();
+            }
+        );
+    }
+
+    /**
+     * If the inferred UnionType makes $should_filter_cb return true
+     * (indicating there are Types to be removed from the UnionType or altered),
+     * then replace the UnionType with the modified UnionType which $filter_union_type_cb returns,
+     * and update the context.
+     *
+     * Note: It's expected that $should_filter_cb returns false on the new UnionType of that variable.
+     */
+    private function updateVariableWithConditionalFilter(
+        Node $var_node,
+        Context $context,
+        \Closure $should_filter_cb,
+        \Closure $filter_union_type_cb
+    ) : Context {
         try {
             // Get the variable we're operating on
             $variable = $this->getVariableFromScope($var_node);
@@ -309,7 +547,8 @@ class ConditionVisitor extends KindVisitorImplementation
             }
             \assert(!\is_null($variable));  // redundant annotation for phan.
 
-            if (!$variable->getUnionType()->containsNullable()) {
+            $union_type = $variable->getUnionType();
+            if (!$should_filter_cb($union_type)) {
                 return $context;
             }
 
@@ -317,7 +556,7 @@ class ConditionVisitor extends KindVisitorImplementation
             $variable = clone($variable);
 
             $variable->setUnionType(
-                $variable->getUnionType()->nonNullableClone()
+                $filter_union_type_cb($union_type)
             );
 
             // Overwrite the variable with its new type in this
@@ -444,22 +683,36 @@ class ConditionVisitor extends KindVisitorImplementation
         return $context;
     }
 
-    private static function isCallStringWithSingleVariableArgument(Node $node) : bool
+    private static function isArgumentListWithVarAsFirstArgument(array $args) : bool
     {
-        $args = $node->children['args']->children;
-        if (\count($args) === 1) {
+        if (\count($args) >= 1) {
             $arg = $args[0];
-            if (($arg instanceof Node) && ($arg->kind === \ast\AST_VAR)) {
-                $expr = $node->children['expr'];
-                if ($expr instanceof Node) {
-                    $name = $expr->children['name'] ?? null;
-                    if (\is_string($name) && $name) {
-                        return true;
-                    }
-                }
-            }
+            return ($arg instanceof Node) && ($arg->kind === \ast\AST_VAR);
         }
         return false;
+    }
+
+    /**
+     * @param Variable $variable (Node argument in a call to is_object)
+     * @return void
+     */
+    private static function analyzeIsObjectAssertion(Variable $variable)
+    {
+        // Change the type to match is_object relationship
+        // If we already have the `object` type or generic object types, then keep those
+        // (E.g. T|false becomes T, object|T[]|iterable|null becomes object)
+        // TODO: Convert `iterable` to `Traversable`?
+        // TODO: move to UnionType?
+        $newType = $variable->getUnionType()->objectTypes();
+        if ($newType->isEmpty()) {
+            $newType->addType(ObjectType::instance(false));
+        } else {
+            // Convert inferred ?MyClass to MyClass, ?object to object
+            if ($newType->containsNullable()) {
+                $newType = $newType->nonNullableClone();
+            }
+        }
+        $variable->setUnionType($newType);
     }
 
     /**
@@ -471,14 +724,14 @@ class ConditionVisitor extends KindVisitorImplementation
      */
     private static function initTypeModifyingClosuresForVisitCall() : array
     {
-        $make_basic_assertion_callback = function(string $union_type_string) : \Closure
+        $make_basic_assertion_callback = static function(string $union_type_string) : \Closure
         {
             $type = UnionType::fromFullyQualifiedString(
                 $union_type_string
             );
 
             /** @return void */
-            return function(Variable $variable) use($type)
+            return static function(Variable $variable, array $args) use($type)
             {
                 // Otherwise, overwrite the type for any simple
                 // primitive types.
@@ -487,7 +740,7 @@ class ConditionVisitor extends KindVisitorImplementation
         };
 
         /** @return void */
-        $array_callback = function(Variable $variable)
+        $array_callback = static function(Variable $variable, array $args)
         {
             // Change the type to match the is_a relationship
             // If we already have generic array types, then keep those
@@ -505,24 +758,12 @@ class ConditionVisitor extends KindVisitorImplementation
         };
 
         /** @return void */
-        $object_callback = function(Variable $variable)
+        $object_callback = static function(Variable $variable, array $args)
         {
-            // Change the type to match the is_a relationship
-            // If we already have the `object` type or generic object types, then keep those
-            // (E.g. T|false becomes T, object|T[]|iterable|null becomes object)
-            $newType = $variable->getUnionType()->objectTypes();
-            if ($newType->isEmpty()) {
-                $newType->addType(ObjectType::instance(false));
-            } else {
-                // Convert inferred ?MyClass to MyClass, ?object to object
-                if ($newType->containsNullable()) {
-                    $newType = $newType->nonNullableClone();
-                }
-            }
-            $variable->setUnionType($newType);
+            return self::analyzeIsObjectAssertion($variable);
         };
         /** @return void */
-        $scalar_callback = function(Variable $variable)
+        $scalar_callback = static function(Variable $variable, array $args)
         {
             // Change the type to match the is_a relationship
             // If we already have possible scalar types, then keep those
@@ -573,6 +814,58 @@ class ConditionVisitor extends KindVisitorImplementation
     }
 
     /**
+     * @return void
+     */
+    private function analyzeVariableIsA(Variable $variable, array $args)
+    {
+        $class_name = $args[1] ?? null;
+        if (!is_string($class_name)) {
+            if ($class_name instanceof Node && $class_name->kind === \ast\AST_CLASS_CONST) {
+                $constant_name = $class_name->children['const'];
+                if (strcasecmp($constant_name, 'class') === 0) {
+                    $class_name_node = $class_name->children['class'];
+                    if ($class_name_node instanceof Node && ($class_name_node->kind === \ast\AST_NAME)) {
+                        $class_union_type = UnionType::fromNode(
+                            $this->context,
+                            $this->code_base,
+                            $class_name_node
+                        );
+                        if (!$class_union_type->isEmpty()) {  // always true?
+                            $variable->setUnionType($class_union_type);
+                        }
+                    }
+                }
+            }
+            // Limit the types of $variable to an object if we can't infer the class name.
+            return self::analyzeIsObjectAssertion($variable);
+        }
+        $class_name = ltrim($class_name, '\\');
+        if (empty($class_name)) {
+            return;
+        }
+        // TODO: validate argument
+        $class_name = '\\' . $class_name;
+        $class_type = Type::fromStringInContext($class_name, new Context(), Type::FROM_NODE);
+        $variable->setUnionType($class_type->asUnionType());
+    }
+
+    /**
+     * Fetches the function name. Does not check for function uses or namespaces.
+     * @return ?string (null if function name could not be found)
+     */
+    private static function getFunctionName(Node $node) {
+        $expr = $node->children['expr'];
+        if (!($expr instanceof Node)) {
+            return null;
+        }
+        $raw_function_name = $expr->children['name'] ?? null;
+        if (!(is_string($raw_function_name) && $raw_function_name)) {
+            return null;
+        }
+        return $raw_function_name;
+    }
+
+    /**
      * Look at elements of the form `is_array($v)` and modify
      * the type of the variable.
      *
@@ -585,19 +878,60 @@ class ConditionVisitor extends KindVisitorImplementation
      */
     public function visitCall(Node $node) : Context
     {
+        $raw_function_name = self::getFunctionName($node);
+        if (!is_string($raw_function_name)) {
+            return $this->context;
+        }
+        assert(is_string($raw_function_name));
+        $args = $node->children['args']->children;
         // Only look at things of the form
         // `is_string($variable)`
-        if (!self::isCallStringWithSingleVariableArgument($node)) {
+        if (!self::isArgumentListWithVarAsFirstArgument($args)) {
             return $this->context;
         }
 
+        if (count($args) !== 1) {
+            if (strcasecmp($raw_function_name, 'is_a') === 0) {
+                // TODO: deduplicate
+                try {
+                    // Get the variable we're operating on
+                    $variable = (new ContextNode(
+                        $this->code_base,
+                        $this->context,
+                        $args[0]
+                    ))->getVariable();
+
+                    if ($variable->getUnionType()->isEmpty()) {
+                        $variable->getUnionType()->addType(
+                            NullType::instance(false)
+                        );
+                    }
+
+                    // Make a copy of the variable
+                    $variable = clone($variable);
+
+                    // Modify the types of that variable.
+                    $this->analyzeVariableIsA($variable, $args);
+
+                    // Overwrite the variable with its new type in this
+                    // scope without overwriting other scopes
+                    return $this->context->withScopeVariable(
+                        $variable
+                    );
+                } catch (\Exception $exception) {
+                    // Swallow it (E.g. IssueException for undefined variable)
+                }
+            }
+            return $this->context;
+        }
         // Translate the function name into the UnionType it asserts
         static $map = null;
-        if (empty($map)) {
+
+        if ($map === null) {
              $map = self::initTypeModifyingClosuresForVisitCall();
         }
 
-        $function_name = strtolower($node->children['expr']->children['name']);
+        $function_name = strtolower($raw_function_name);
         $type_modification_callback = $map[$function_name] ?? null;
         if ($type_modification_callback === null) {
             return $this->context;
@@ -607,7 +941,7 @@ class ConditionVisitor extends KindVisitorImplementation
 
         try {
             // Get the variable we're operating on
-            $variable = $this->getVariableFromScope($node->children['args']->children[0]);
+            $variable = $this->getVariableFromScope($args[0]);
 
             if (\is_null($variable)) {
                 return $context;
@@ -624,7 +958,7 @@ class ConditionVisitor extends KindVisitorImplementation
             $variable = clone($variable);
 
             // Modify the types of that variable.
-            $type_modification_callback($variable);
+            $type_modification_callback($variable, $args);
 
             // Overwrite the variable with its new type in this
             // scope without overwriting other scopes
@@ -634,7 +968,7 @@ class ConditionVisitor extends KindVisitorImplementation
         } catch (IssueException $exception) {
             Issue::maybeEmitInstance($this->code_base, $context, $exception->getIssueInstance());
         } catch (\Exception $exception) {
-            // Swallow it
+            // Swallow it (E.g. IssueException for undefined variable)
         }
 
         return $context;
@@ -651,7 +985,19 @@ class ConditionVisitor extends KindVisitorImplementation
     public function visitEmpty(Node $node) : Context
     {
         $this->checkVariablesDefined($node);
-        // TODO: implement rest of empty check
+        $var_node = $node->children['expr'];
+        if ($var_node->kind === \ast\AST_VAR) {
+            return $this->updateVariableWithConditionalFilter(
+                $var_node,
+                $this->context,
+                function(UnionType $type) : bool {
+                    return $type->containsTruthy();
+                },
+                function(UnionType $type) : UnionType {
+                    return $type->nonTruthyClone();
+                }
+            );
+        }
         return $this->context;
     }
 

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -7,6 +7,7 @@ use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\Type\ArrayType;
 use Phan\Language\Type\BoolType;
 use Phan\Language\Type\CallableType;
+use Phan\Language\Type\FalseType;
 use Phan\Language\Type\FloatType;
 use Phan\Language\Type\GenericArrayType;
 use Phan\Language\Type\IntType;
@@ -19,6 +20,7 @@ use Phan\Language\Type\ResourceType;
 use Phan\Language\Type\StaticType;
 use Phan\Language\Type\StringType;
 use Phan\Language\Type\TemplateType;
+use Phan\Language\Type\TrueType;
 use Phan\Language\Type\VoidType;
 use Phan\Language\UnionType;
 use Phan\Library\ArraySet;
@@ -85,6 +87,7 @@ class Type
         'array'     => true,
         'bool'      => true,
         'callable'  => true,
+        'false'     => true,
         'float'     => true,
         'int'       => true,
         'iterable'  => true,
@@ -94,6 +97,7 @@ class Type
         'resource'  => true,
         'static'    => true,
         'string'    => true,
+        'true'      => true,
         'void'      => true,
     ];
 
@@ -361,11 +365,13 @@ class Type
      * Uses the constants and types from https://secure.php.net/manual/en/reserved.constants.php
      */
     private static function createReservedConstantNameLookup() : array {
-        $int = IntType::instance(false);
-        $bool = BoolType::instance(false);
-        $null = NullType::instance(false);
-        $string = StringType::instance(false);
+        $false  = FalseType::instance(false);
         $float  = FloatType::instance(false);
+        $int    = IntType::instance(false);
+        $null   = NullType::instance(false);
+        $string = StringType::instance(false);
+        $true   = TrueType::instance(false);
+
         return [
             'PHP_VERSION'           => $string,
             'PHP_MAJOR_VERSION'     => $int,
@@ -419,8 +425,8 @@ class Type
             'E_ALL'                 => $int,
             'E_STRICT'              => $int,
             '__COMPILER_HALT_OFFSET__' => $int,
-            'TRUE'                  => $bool,
-            'FALSE'                 => $bool,
+            'TRUE'                  => $true,
+            'FALSE'                 => $false,
             'NULL'                  => $null,
         ];
     }
@@ -474,6 +480,7 @@ class Type
         $type_name =
             self::canonicalNameFromName($type_name);
 
+        // TODO: Is this worth optimizing into a lookup table?
         switch (\strtolower($type_name)) {
             case 'array':
                 return ArrayType::instance($is_nullable);
@@ -481,6 +488,8 @@ class Type
                 return BoolType::instance($is_nullable);
             case 'callable':
                 return CallableType::instance($is_nullable);
+            case 'false':
+                return FalseType::instance($is_nullable);
             case 'float':
                 return FloatType::instance($is_nullable);
             case 'int':
@@ -495,6 +504,8 @@ class Type
                 return ResourceType::instance($is_nullable);
             case 'string':
                 return StringType::instance($is_nullable);
+            case 'true':
+                return TrueType::instance($is_nullable);
             case 'void':
                 // TODO: This can't be nullable, right?
                 return VoidType::instance($is_nullable);
@@ -849,6 +860,51 @@ class Type
         return $this->is_nullable;
     }
 
+    public function getIsPossiblyFalsey() : bool
+    {
+        return $this->is_nullable;
+    }
+
+    public function getIsAlwaysFalsey() : bool
+    {
+        return false;  // overridden in FalseType and NullType
+    }
+
+    public function getIsPossiblyTruthy() : bool
+    {
+        return true;  // overridden in various types. This base class (Type) is implicitly the type of an object, which is always truthy.
+    }
+
+    public function getIsAlwaysTruthy() : bool
+    {
+        return true;  // overridden in various types. This base class (Type) is implicitly the type of an object, which is always truthy.
+    }
+
+    public function getIsPossiblyFalse() : bool
+    {
+        return false;
+    }
+
+    public function getIsAlwaysFalse() : bool
+    {
+        return false;  // overridden in FalseType
+    }
+
+    public function getIsPossiblyTrue() : bool
+    {
+        return false;
+    }
+
+    public function getIsAlwaysTrue() : bool
+    {
+        return false;  // overridden in TrueType
+    }
+
+    public function getIsInBoolFamily() : bool
+    {
+        return false;  // overridden in FalseType, TrueType, BoolType
+    }
+
     /**
      * @param bool $is_nullable
      * Set to true if the type should be nullable, else pass
@@ -870,6 +926,30 @@ class Type
             $is_nullable,
             Type::FROM_TYPE
         );
+    }
+
+    public function asNonFalseyType() : Type
+    {
+        // Overridden by BoolType subclass to return TrueType
+        return $this->withIsNullable(false);
+    }
+
+    public function asNonTruthyType() : Type
+    {
+        // Overridden by ScalarType, BoolType, etc.
+        return NullType::instance(false);
+    }
+
+    public function asNonFalseType() : Type
+    {
+        // Overridden by BoolType, etc.
+        return $this;
+    }
+
+    public function asNonTrueType() : Type
+    {
+        // Overridden by BoolType, etc.
+        return $this;
     }
 
     /**
@@ -1473,15 +1553,13 @@ class Type
      * @return string
      * A canonical name for the given type name
      */
-    private static function canonicalNameFromName(
+    public static function canonicalNameFromName(
         string $name
     ) : string {
         static $map = [
             'boolean'  => 'bool',
             'callback' => 'callable',
             'double'   => 'float',
-            'false'    => 'bool',
-            'true'     => 'bool',
             'integer'  => 'int',
         ];
 

--- a/src/Phan/Language/Type/ArrayType.php
+++ b/src/Phan/Language/Type/ArrayType.php
@@ -1,7 +1,19 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
+use Phan\Language\Type;
+
 class ArrayType extends IterableType
 {
     const NAME = 'array';
+    public function getIsAlwaysTruthy() : bool
+    {
+        return false;
+    }
+
+    public function asNonTruthyType() : Type
+    {
+        // There's no EmptyArrayType, so return $this
+        return $this;
+    }
 }

--- a/src/Phan/Language/Type/BoolType.php
+++ b/src/Phan/Language/Type/BoolType.php
@@ -1,7 +1,76 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
+use Phan\Language\UnionType;
+use Phan\Language\Type;
+
+// Temporary hack to load FalseType and TrueType before BoolType::instance() is called
+// (Due to bugs in php static variables)
+assert(class_exists(FalseType::class));
+assert(class_exists(TrueType::class));
+
 class BoolType extends ScalarType
 {
     const NAME = 'bool';
+    public static function unionTypeInstance(bool $is_nullable) : UnionType
+    {
+        // Optimized equivalent of `return new UnionType([FalseType::instance($is_nullable), TrueType::instance($is_nullable)]);`
+        if ($is_nullable) {
+            static $nullable_instance = null;
+            if ($nullable_instance === null) {
+                $nullable_instance = new UnionType([FalseType::instance(true), TrueType::instance(true)]);
+            }
+            return clone($nullable_instance);
+        }
+        static $instance = null;
+        if ($instance === null) {
+            $instance = new UnionType([FalseType::instance(false), TrueType::instance(false)]);
+        }
+        return clone($instance);
+    }
+
+    public function getIsPossiblyFalsey() : bool
+    {
+        return true;  // it's always falsey, since this is conceptually a collection of FalseType and TrueType
+    }
+
+    public function asNonFalseyType() : Type
+    {
+        return TrueType::instance(false);
+    }
+
+    public function asNonTruthyType() : Type
+    {
+        return FalseType::instance($this->is_nullable);
+    }
+
+    public function getIsPossiblyFalse() : bool
+    {
+        return true;  // it's possibly false, since this is conceptually a collection of FalseType and TrueType
+    }
+
+    public function asNonFalseType() : Type
+    {
+        return TrueType::instance($this->is_nullable);
+    }
+
+    public function getIsPossiblyTrue() : bool
+    {
+        return true;  // it's possibly true, since this is conceptually a collection of FalseType and TrueType
+    }
+
+    public function asNonTrueType() : Type
+    {
+        return FalseType::instance($this->is_nullable);
+    }
+
+    public function getIsInBoolFamily() : bool
+    {
+        return true;
+    }
+
+    public function getIsAlwaysTruthy() : bool
+    {
+        return false;  // overridden in various types. This base class (Type) is implicitly the type of an object, which is always truthy.
+    }
 }

--- a/src/Phan/Language/Type/FalseType.php
+++ b/src/Phan/Language/Type/FalseType.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+namespace Phan\Language\Type;
+
+use Phan\Language\Type;
+
+class FalseType extends ScalarType
+{
+    const NAME = 'false';
+
+    public function getIsPossiblyFalsey() : bool
+    {
+        return true;  // it's always falsey, whether or not it's nullable.
+    }
+
+    public function getIsAlwaysFalsey() : bool
+    {
+        return true;  // FalseType is always falsey, whether or not it's nullable.
+    }
+
+    public function getIsAlwaysFalse() : bool
+    {
+        return !$this->is_nullable;  // If it can be null, it's not **always** identical to false
+    }
+
+    public function getIsPossiblyTruthy() : bool
+    {
+        return false;
+    }
+
+    public function getIsAlwaysTruthy() : bool
+    {
+        return false;
+    }
+
+    public function getIsPossiblyFalse() : bool
+    {
+        return true;
+    }
+
+    public function asNonFalseType() : Type
+    {
+        assert($this->is_nullable, 'should only call on ?false');
+        return NullType::instance(false);
+    }
+
+    public function getIsInBoolFamily() : bool
+    {
+        return true;
+    }
+}

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -87,182 +87,60 @@ abstract class NativeType extends Type
         if ($this->getIsNullable() && !$type->getIsNullable()) {
             return false;
         }
-
-        // A matrix of allowable type conversions between
-        // the various native types.
-        static $matrix = [
-            ArrayType::NAME => [
-                ArrayType::NAME => true,
-                IterableType::NAME => true,
-                BoolType::NAME => false,
-                CallableType::NAME => true,
-                FloatType::NAME => false,
-                IntType::NAME => false,
-                MixedType::NAME => true,
-                NullType::NAME => false,
-                ObjectType::NAME => false,
-                ResourceType::NAME => false,
-                StringType::NAME => false,
-                VoidType::NAME => false,
-            ],
-            IterableType::NAME => [
-                ArrayType::NAME => false,
-                IterableType::NAME => true,
-                BoolType::NAME => false,
-                CallableType::NAME => false,
-                FloatType::NAME => false,
-                IntType::NAME => false,
-                MixedType::NAME => true,
-                NullType::NAME => false,
-                ObjectType::NAME => false,
-                ResourceType::NAME => false,
-                StringType::NAME => false,
-                VoidType::NAME => false,
-            ],
-            BoolType::NAME => [
-                ArrayType::NAME => false,
-                IterableType::NAME => false,
-                BoolType::NAME => true,
-                CallableType::NAME => false,
-                FloatType::NAME => false,
-                IntType::NAME => false,
-                MixedType::NAME => true,
-                NullType::NAME => false,
-                ObjectType::NAME => false,
-                ResourceType::NAME => false,
-                StringType::NAME => false,
-                VoidType::NAME => false,
-            ],
-            CallableType::NAME => [
-                ArrayType::NAME => false,
-                IterableType::NAME => false,
-                BoolType::NAME => false,
-                CallableType::NAME => true,
-                FloatType::NAME => false,
-                IntType::NAME => false,
-                MixedType::NAME => true,
-                NullType::NAME => false,
-                ObjectType::NAME => false,
-                ResourceType::NAME => false,
-                StringType::NAME => false,
-                VoidType::NAME => false,
-            ],
-            FloatType::NAME => [
-                ArrayType::NAME => false,
-                IterableType::NAME => false,
-                BoolType::NAME => false,
-                CallableType::NAME => false,
-                FloatType::NAME => true,
-                IntType::NAME => false,
-                MixedType::NAME => true,
-                NullType::NAME => false,
-                ObjectType::NAME => false,
-                ResourceType::NAME => false,
-                StringType::NAME => false,
-                VoidType::NAME => false,
-            ],
-            IntType::NAME => [
-                ArrayType::NAME => false,
-                IterableType::NAME => false,
-                BoolType::NAME => false,
-                CallableType::NAME => false,
-                FloatType::NAME => true,
-                IntType::NAME => true,
-                MixedType::NAME => true,
-                NullType::NAME => false,
-                ObjectType::NAME => false,
-                ResourceType::NAME => false,
-                StringType::NAME => false,
-                VoidType::NAME => false,
-            ],
-            MixedType::NAME => [
-                ArrayType::NAME => false,
-                IterableType::NAME => false,
-                BoolType::NAME => false,
-                CallableType::NAME => false,
-                FloatType::NAME => false,
-                IntType::NAME => false,
-                MixedType::NAME => true,
-                NullType::NAME => false,
-                ObjectType::NAME => false,
-                ResourceType::NAME => false,
-                StringType::NAME => false,
-                VoidType::NAME => false,
-            ],
-            NullType::NAME => [
-                ArrayType::NAME => false,
-                IterableType::NAME => false,
-                BoolType::NAME => false,
-                CallableType::NAME => false,
-                FloatType::NAME => false,
-                IntType::NAME => false,
-                MixedType::NAME => true,
-                NullType::NAME => true,
-                ObjectType::NAME => false,
-                ResourceType::NAME => false,
-                StringType::NAME => false,
-                VoidType::NAME => false,
-            ],
-            ObjectType::NAME => [
-                ArrayType::NAME => false,
-                IterableType::NAME => false,
-                BoolType::NAME => false,
-                CallableType::NAME => false,
-                FloatType::NAME => false,
-                IntType::NAME => false,
-                MixedType::NAME => true,
-                NullType::NAME => false,
-                ObjectType::NAME => true,
-                ResourceType::NAME => false,
-                StringType::NAME => false,
-                VoidType::NAME => false,
-            ],
-            ResourceType::NAME => [
-                ArrayType::NAME => false,
-                IterableType::NAME => false,
-                BoolType::NAME => false,
-                CallableType::NAME => false,
-                FloatType::NAME => false,
-                IntType::NAME => false,
-                MixedType::NAME => true,
-                NullType::NAME => false,
-                ObjectType::NAME => false,
-                ResourceType::NAME => true,
-                StringType::NAME => false,
-                VoidType::NAME => false,
-            ],
-            StringType::NAME => [
-                ArrayType::NAME => false,
-                IterableType::NAME => false,
-                BoolType::NAME => false,
-                CallableType::NAME => true,
-                FloatType::NAME => false,
-                IntType::NAME => false,
-                MixedType::NAME => true,
-                NullType::NAME => false,
-                ObjectType::NAME => false,
-                ResourceType::NAME => false,
-                StringType::NAME => true,
-                VoidType::NAME => false,
-            ],
-            VoidType::NAME => [
-                ArrayType::NAME => false,
-                IterableType::NAME => false,
-                BoolType::NAME => false,
-                CallableType::NAME => false,
-                FloatType::NAME => false,
-                IntType::NAME => false,
-                MixedType::NAME => false,
-                NullType::NAME => false,
-                ObjectType::NAME => false,
-                ResourceType::NAME => false,
-                StringType::NAME => false,
-                VoidType::NAME => true,
-            ],
-        ];
+        static $matrix;
+        if ($matrix === null) {
+            $matrix = self::initializeTypeCastingMatrix();
+        }
 
         return $matrix[$this->getName()][$type->getName()]
             ?? parent::canCastToNonNullableType($type);
+    }
+
+    /**
+     * @return bool[][]
+     */
+    private static function initializeTypeCastingMatrix() : array
+    {
+        $generateRow = function(string ...$permittedCastTypeNames) {
+            return [
+                ArrayType::NAME    => in_array(ArrayType::NAME, $permittedCastTypeNames, true),
+                IterableType::NAME => in_array(IterableType::NAME, $permittedCastTypeNames, true),
+                BoolType::NAME     => in_array(BoolType::NAME, $permittedCastTypeNames, true),
+                CallableType::NAME => in_array(CallableType::NAME, $permittedCastTypeNames, true),
+                FalseType::NAME    => in_array(FalseType::NAME, $permittedCastTypeNames, true),
+                FloatType::NAME    => in_array(FloatType::NAME, $permittedCastTypeNames, true),
+                IntType::NAME      => in_array(IntType::NAME, $permittedCastTypeNames, true),
+                MixedType::NAME    => true,
+                NullType::NAME     => in_array(NullType::NAME, $permittedCastTypeNames, true),
+                ObjectType::NAME   => in_array(ObjectType::NAME, $permittedCastTypeNames, true),
+                ResourceType::NAME => in_array(ResourceType::NAME, $permittedCastTypeNames, true),
+                StringType::NAME   => in_array(StringType::NAME, $permittedCastTypeNames, true),
+                TrueType::NAME     => in_array(TrueType::NAME, $permittedCastTypeNames, true),
+                VoidType::NAME     => in_array(VoidType::NAME, $permittedCastTypeNames, true),
+            ];
+        };
+
+        // A matrix of allowable type conversions between
+        // the various native types.
+        // (Represented in a readable format, with only the true entries (omitting Mixed, which is always true))
+
+        return [
+            ArrayType::NAME    => $generateRow(ArrayType::NAME, IterableType::NAME, CallableType::NAME),
+            BoolType::NAME     => $generateRow(BoolType::NAME, FalseType::NAME, TrueType::NAME),
+            CallableType::NAME => $generateRow(CallableType::NAME),
+            FalseType::NAME    => $generateRow(FalseType::NAME, BoolType::NAME),
+            FloatType::NAME    => $generateRow(FloatType::NAME),
+            IntType::NAME      => $generateRow(IntType::NAME, FloatType::NAME),
+            IterableType::NAME => $generateRow(IterableType::NAME),
+            MixedType::NAME    => $generateRow(MixedType::NAME),  // MixedType overrides the methods which would use this
+            NullType::NAME     => $generateRow(NullType::NAME),
+            ObjectType::NAME   => $generateRow(ObjectType::NAME),
+            ResourceType::NAME => $generateRow(ResourceType::NAME),
+            StringType::NAME   => $generateRow(StringType::NAME, CallableType::NAME),
+            TrueType::NAME     => $generateRow(TrueType::NAME, BoolType::NAME),
+            VoidType::NAME     => $generateRow(VoidType::NAME),
+        ];
+
     }
 
     public function __toString() : string

--- a/src/Phan/Language/Type/NullType.php
+++ b/src/Phan/Language/Type/NullType.php
@@ -101,4 +101,13 @@ class NullType extends ScalarType
         return $this->name;
     }
 
+    public function getIsPossiblyFalsey() : bool
+    {
+        return true;  // Null is always falsey.
+    }
+
+    public function getIsAlwaysFalsey() : bool
+    {
+        return true;  // Null is always falsey.
+    }
 }

--- a/src/Phan/Language/Type/ScalarType.php
+++ b/src/Phan/Language/Type/ScalarType.php
@@ -95,4 +95,17 @@ abstract class ScalarType extends NativeType
     {
         return $this->name;
     }
+
+    public function getIsAlwaysTruthy() : bool
+    {
+        // Most scalars (Except ResourceType) have a false value, e.g. 0/""/"0"/0.0/false.
+        // (But ResourceType isn't a subclass of ScalarType in Phan's implementation)
+        return false;
+    }
+
+    public function asNonTruthyType() : Type
+    {
+        // Subclasses of ScalarType all have false values within their types.
+        return $this;
+    }
 }

--- a/src/Phan/Language/Type/TrueType.php
+++ b/src/Phan/Language/Type/TrueType.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+namespace Phan\Language\Type;
+
+use Phan\Language\Type;
+
+// Not sure if it made sense to extend BoolType, so not doing that.
+class TrueType extends ScalarType
+{
+    const NAME = 'true';
+
+    public function getIsPossiblyTruthy() : bool
+    {
+        return true;
+    }
+
+    public function getIsAlwaysTruthy() : bool
+    {
+        return true;
+    }
+
+    public function getIsPossiblyTrue() : bool
+    {
+        return true;
+    }
+
+    public function getIsAlwaysTrue() : bool
+    {
+        return !$this->is_nullable;  // If it can be null, it's not **always** identical to true
+    }
+
+    public function asNonTrueType() : Type
+    {
+        assert($this->is_nullable, 'should only call on ?true');
+        return NullType::instance(false);
+    }
+
+    public function getIsInBoolFamily() : bool
+    {
+        return true;
+    }
+}

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -1307,8 +1307,10 @@ class UnionType implements \Serializable
     }
 
     /**
-     * Takes "MyClass|int|?bool|array|?object" and returns "int|?bool"
-     * Takes "?MyClass" and returns "null"
+     * Returns the types for which is_scalar($x) would be true.
+     * This means null/nullable is removed.
+     * Takes "MyClass|int|?bool|array|?object" and returns "int|bool"
+     * Takes "?MyClass" and returns an empty union type.
      *
      * @return UnionType
      * A UnionType with known object types kept, other types filtered out.
@@ -1320,14 +1322,8 @@ class UnionType implements \Serializable
     {
         // TODO: is_scalar(null) is false, account for that in analysis.
         $types = \array_filter($this->type_set, function (Type $type) : bool {
-            return $type->isScalar();
+            return $type->isScalar() && !($type instanceof NullType);
         });
-        $null_type = NullType::instance(false);
-        $null_type_id = \runkit_object_id($null_type);
-        if (!\array_key_exists($null_type_id, $types) && $this->containsNullable()) {
-            // E.g. if this has `?stdClass`, add `null` to the resulting set of scalar types.
-            $types[\runkit_object_id($null_type)] = $null_type;
-        }
         return new UnionType($types, true);
     }
 

--- a/tests/files/expected/0005_compat.php.expected
+++ b/tests/files/expected/0005_compat.php.expected
@@ -1,3 +1,3 @@
-%s:16 PhanTypeMismatchDefault Default value for int $b can't be bool
+%s:16 PhanTypeMismatchDefault Default value for int $b can't be false
 %s:16 PhanTypeMismatchDefault Default value for string $c can't be int
 

--- a/tests/files/expected/0099_type_error.php.expected
+++ b/tests/files/expected/0099_type_error.php.expected
@@ -1,5 +1,5 @@
-%s:4 PhanTypeMismatchDefault Default value for int $p can't be bool
-%s:7 PhanTypeArraySuspicious Suspicious array access to bool
+%s:4 PhanTypeMismatchDefault Default value for int $p can't be false
+%s:7 PhanTypeArraySuspicious Suspicious array access to false
 %s:10 PhanTypeMismatchProperty Assigning string to property but \C::p is int
 %s:13 PhanTypeInstantiateAbstract Instantiation of abstract class \D
 %s:16 PhanTypeInstantiateInterface Instantiation of interface \E

--- a/tests/files/expected/0101_one_of_each.php.expected
+++ b/tests/files/expected/0101_one_of_each.php.expected
@@ -19,7 +19,7 @@
 %s:90 PhanRedefineFunctionInternal Function strlen defined at %s:90 was previously defined internally
 %s:94 PhanStaticCallToNonStatic Static call to non-static method \C19::f() defined at %s:93
 %s:98 PhanNonClassMethodCall Call to method f on non-class type null
-%s:104 PhanTypeArraySuspicious Suspicious array access to bool
+%s:104 PhanTypeArraySuspicious Suspicious array access to false
 %s:107 PhanTypeComparisonFromArray array to string comparison
 %s:110 PhanTypeComparisonToArray int to array comparison
 %s:116 PhanTypeInstantiateAbstract Instantiation of abstract class \C6
@@ -27,7 +27,7 @@
 %s:129 PhanTypeMismatchArgument Argument 1 (i) is string but \f8() takes int defined at %s:128
 %s:132 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
 %s:138 PhanTypeMismatchForeach null passed to foreach instead of array
-%s:141 PhanTypeMismatchDefault Default value for int $p can't be bool
+%s:141 PhanTypeMismatchDefault Default value for int $p can't be false
 %s:144 PhanTypeMismatchReturn Returning type string but f() is declared to return int
 %s:147 PhanTypeMissingReturn Method \C9::f is declared to return int but has no return value
 %s:150 PhanUndeclaredClassMethod Call to method f from undeclared class \F

--- a/tests/files/expected/0116_try_merge.php.expected
+++ b/tests/files/expected/0116_try_merge.php.expected
@@ -1,4 +1,4 @@
 %s:16 PhanTypeMismatchArgument Argument 1 (p) is int but \f() takes string defined at %s:15
-%s:17 PhanTypeMismatchArgument Argument 1 (p) is bool|int but \f() takes string defined at %s:15
+%s:17 PhanTypeMismatchArgument Argument 1 (p) is int|true but \f() takes string defined at %s:15
 %s:18 PhanTypeMismatchArgument Argument 1 (p) is int|null but \f() takes string defined at %s:15
 

--- a/tests/files/expected/0118_conditional_union_type.php.expected
+++ b/tests/files/expected/0118_conditional_union_type.php.expected
@@ -1,2 +1,2 @@
-%s:13 PhanTypeMismatchArgument Argument 1 (p) is bool|string but \f() takes int defined at %s:12
+%s:13 PhanTypeMismatchArgument Argument 1 (p) is false|string but \f() takes int defined at %s:12
 

--- a/tests/files/expected/0166_is_a.php.expected
+++ b/tests/files/expected/0166_is_a.php.expected
@@ -12,6 +12,6 @@
 %s:31 PhanTypeMismatchArgument Argument 1 (var) is object but \emitType() takes resource defined at %s:3
 %s:33 PhanTypeMismatchArgument Argument 1 (var) is float but \emitType() takes resource defined at %s:3
 %s:35 PhanTypeMismatchArgument Argument 1 (var) is resource but \emitResourceType() takes string defined at %s:5
-%s:37 PhanTypeMismatchArgument Argument 1 (var) is bool|float|int|null|string but \emitType() takes resource defined at %s:3
+%s:37 PhanTypeMismatchArgument Argument 1 (var) is bool|float|int|string but \emitType() takes resource defined at %s:3
 %s:39 PhanTypeMismatchArgument Argument 1 (var) is string but \emitType() takes resource defined at %s:3
 %s:41 PhanTypeMismatchArgument Argument 1 (var) is iterable but \emitType() takes resource defined at %s:3

--- a/tests/files/expected/0166_is_a.php.expected
+++ b/tests/files/expected/0166_is_a.php.expected
@@ -15,3 +15,7 @@
 %s:37 PhanTypeMismatchArgument Argument 1 (var) is bool|float|int|null|string but \emitType() takes resource defined at %s:3
 %s:39 PhanTypeMismatchArgument Argument 1 (var) is string but \emitType() takes resource defined at %s:3
 %s:41 PhanTypeMismatchArgument Argument 1 (var) is iterable but \emitType() takes resource defined at %s:3
+%s:44 PhanTypeMismatchArgument Argument 1 (var) is \stdClass but \emitType() takes resource defined at %s:3
+%s:46 PhanTypeMismatchArgument Argument 1 (var) is \SimpleXMLElement|\Traversable but \emitType() takes resource defined at %s:3
+%s:48 PhanTypeMismatchArgument Argument 1 (var) is \DateTime|\DateTimeInterface but \emitType() takes resource defined at %s:3
+%s:50 PhanTypeMismatchArgument Argument 1 (var) is \DateTimeImmutable|\DateTimeInterface but \emitType() takes resource defined at %s:3

--- a/tests/files/expected/0166_is_a.php.expected
+++ b/tests/files/expected/0166_is_a.php.expected
@@ -15,7 +15,3 @@
 %s:37 PhanTypeMismatchArgument Argument 1 (var) is bool|float|int|null|string but \emitType() takes resource defined at %s:3
 %s:39 PhanTypeMismatchArgument Argument 1 (var) is string but \emitType() takes resource defined at %s:3
 %s:41 PhanTypeMismatchArgument Argument 1 (var) is iterable but \emitType() takes resource defined at %s:3
-%s:44 PhanTypeMismatchArgument Argument 1 (var) is \stdClass but \emitType() takes resource defined at %s:3
-%s:46 PhanTypeMismatchArgument Argument 1 (var) is \SimpleXMLElement|\Traversable but \emitType() takes resource defined at %s:3
-%s:48 PhanTypeMismatchArgument Argument 1 (var) is \DateTime|\DateTimeInterface but \emitType() takes resource defined at %s:3
-%s:50 PhanTypeMismatchArgument Argument 1 (var) is \DateTimeImmutable|\DateTimeInterface but \emitType() takes resource defined at %s:3

--- a/tests/files/expected/0263_alias_outside_phpdoc.php.expected
+++ b/tests/files/expected/0263_alias_outside_phpdoc.php.expected
@@ -3,8 +3,8 @@
 %s:4 PhanUndeclaredTypeParameter Parameter of undeclared type \double
 %s:4 PhanUndeclaredTypeParameter Parameter of undeclared type \integer
 %s:4 PhanUndeclaredTypeReturnType Return type of foo263 is undeclared type \boolean
-%s:5 PhanTypeMismatchReturn Returning type bool but foo263() is declared to return \boolean
-%s:7 PhanTypeMismatchArgument Argument 1 (a) is bool but \foo263() takes \boolean defined at %s:4
+%s:5 PhanTypeMismatchReturn Returning type false but foo263() is declared to return \boolean
+%s:7 PhanTypeMismatchArgument Argument 1 (a) is false but \foo263() takes \boolean defined at %s:4
 %s:7 PhanTypeMismatchArgument Argument 2 (b) is int but \foo263() takes \integer defined at %s:4
 %s:7 PhanTypeMismatchArgument Argument 3 (c) is callable but \foo263() takes \callback defined at %s:4
 %s:7 PhanTypeMismatchArgument Argument 4 (d) is float but \foo263() takes \double defined at %s:4

--- a/tests/files/expected/0264_emptiness_check.php.expected
+++ b/tests/files/expected/0264_emptiness_check.php.expected
@@ -5,10 +5,10 @@
 %s:44 PhanTypeMismatchArgument Argument 1 (x) is null|object but \A263::expect_array() takes array defined at %s:7
 %s:46 PhanTypeMismatchArgument Argument 1 (x) is object but \A263::expect_array() takes array defined at %s:7
 %s:54 PhanTypeMismatchArgument Argument 1 (x) is bool|null but \A263::expect_array() takes array defined at %s:7
-%s:56 PhanTypeMismatchArgument Argument 1 (x) is bool but \A263::expect_array() takes array defined at %s:7
-%s:59 PhanTypeMismatchArgument Argument 1 (x) is bool|null but \A263::expect_array() takes array defined at %s:7
-%s:61 PhanTypeMismatchArgument Argument 1 (x) is bool but \A263::expect_array() takes array defined at %s:7
-%s:63 PhanTypeMismatchArgument Argument 1 (x) is bool|null but \A263::expect_array() takes array defined at %s:7
-%s:65 PhanTypeMismatchArgument Argument 1 (x) is bool but \A263::expect_array() takes array defined at %s:7
+%s:56 PhanTypeMismatchArgument Argument 1 (x) is true but \A263::expect_array() takes array defined at %s:7
+%s:59 PhanTypeMismatchArgument Argument 1 (x) is bool|null|true but \A263::expect_array() takes array defined at %s:7
+%s:61 PhanTypeMismatchArgument Argument 1 (x) is bool|true but \A263::expect_array() takes array defined at %s:7
+%s:63 PhanTypeMismatchArgument Argument 1 (x) is bool|null|true but \A263::expect_array() takes array defined at %s:7
+%s:65 PhanTypeMismatchArgument Argument 1 (x) is bool|true but \A263::expect_array() takes array defined at %s:7
 %s:73 PhanTypeMismatchArgument Argument 1 (x) is ?bool but \A263::expect_array() takes array defined at %s:7
-%s:75 PhanTypeMismatchArgument Argument 1 (x) is bool but \A263::expect_array() takes array defined at %s:7
+%s:75 PhanTypeMismatchArgument Argument 1 (x) is true but \A263::expect_array() takes array defined at %s:7

--- a/tests/files/expected/0277_literal_conditional.php.expected
+++ b/tests/files/expected/0277_literal_conditional.php.expected
@@ -1,8 +1,8 @@
 %s:10 PhanTypeArraySuspicious Suspicious array access to int
 %s:11 PhanTypeArraySuspicious Suspicious array access to int
-%s:12 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is bool but \intdiv() takes int
-%s:13 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is bool but \intdiv() takes int
-%s:17 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is bool but \intdiv() takes int
+%s:12 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is true but \intdiv() takes int
+%s:13 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is true but \intdiv() takes int
+%s:17 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is true but \intdiv() takes int
 %s:18 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
 %s:19 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
 %s:22 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is float but \intdiv() takes int

--- a/tests/files/expected/0289_check_incorrect_soft_types.php.expected
+++ b/tests/files/expected/0289_check_incorrect_soft_types.php.expected
@@ -1,5 +1,5 @@
 %s:3 PhanUndeclaredTypeParameter Parameter of undeclared type \resource
 %s:4 PhanTypeMismatchArgumentInternal Argument 1 (fp) is \resource but \fread() takes resource
-%s:10 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is bool|resource but \intdiv() takes int
+%s:10 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is false|resource but \intdiv() takes int
 %s:14 PhanUndeclaredTypeParameter Parameter of undeclared type \object
 %s:18 PhanUndeclaredTypeParameter Parameter of undeclared type \mixed

--- a/tests/files/expected/0290_internal_types_are_phpdoc_types.php.expected
+++ b/tests/files/expected/0290_internal_types_are_phpdoc_types.php.expected
@@ -1,1 +1,1 @@
-%s:4 PhanNonClassMethodCall Call to method doSomething on non-class type bool|int
+%s:4 PhanNonClassMethodCall Call to method doSomething on non-class type false|int

--- a/tests/files/expected/0291_is_array_preserve_types.php.expected
+++ b/tests/files/expected/0291_is_array_preserve_types.php.expected
@@ -2,4 +2,4 @@
 %s:10 PhanNonClassMethodCall Call to method badMethodCall on non-class type int
 %s:21 PhanUndeclaredMethod Call to undeclared method \ArrayAccess::offsetExisssssssts
 %s:22 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \ArrayAccess but \intdiv() takes int
-%s:31 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is bool but \intdiv() takes int
+%s:31 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is false but \intdiv() takes int

--- a/tests/files/expected/0292_strict_equality.php.expected
+++ b/tests/files/expected/0292_strict_equality.php.expected
@@ -2,5 +2,5 @@
 %s:13 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string[] but \intdiv() takes int
 %s:16 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is float but \intdiv() takes int
 %s:22 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is null but \intdiv() takes int
-%s:25 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is bool but \intdiv() takes int
-%s:28 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is bool but \intdiv() takes int
+%s:25 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is false but \intdiv() takes int
+%s:28 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is true but \intdiv() takes int

--- a/tests/files/expected/0298_weird_variable_name.php.expected
+++ b/tests/files/expected/0298_weird_variable_name.php.expected
@@ -1,4 +1,5 @@
 %s:7 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string[] but \intdiv() takes int
-%s:10 PhanTypeSuspiciousIndirectVariable Indirect variable ${(expr)} has invalid inner expression type bool, expected string/integer
-%s:11 PhanTypeSuspiciousIndirectVariable Indirect variable ${(expr)} has invalid inner expression type int[], expected string/integer
+%s:10 PhanTypeSuspiciousIndirectVariable Indirect variable ${(expr)} has invalid inner expression type true, expected string/integer
+%s:11 PhanTypeSuspiciousIndirectVariable Indirect variable ${(expr)} has invalid inner expression type bool, expected string/integer
 %s:12 PhanTypeSuspiciousIndirectVariable Indirect variable ${(expr)} has invalid inner expression type int[], expected string/integer
+%s:13 PhanTypeSuspiciousIndirectVariable Indirect variable ${(expr)} has invalid inner expression type int[], expected string/integer

--- a/tests/files/expected/0305_is_a_tests.php.expected
+++ b/tests/files/expected/0305_is_a_tests.php.expected
@@ -1,0 +1,4 @@
+%s:5 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \stdClass but \intdiv() takes int
+%s:8 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \stdClass but \intdiv() takes int
+%s:14 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is object but \intdiv() takes int
+%s:17 PhanParamTooFew Call with 3 arg(s) to \test305() which requires 4 arg(s) defined at %s:3

--- a/tests/files/expected/0307_inheritdoc_tests.php.expected
+++ b/tests/files/expected/0307_inheritdoc_tests.php.expected
@@ -1,7 +1,7 @@
 %s:18 PhanTypeMissingReturn Method \B307::offsetExists is declared to return bool but has no return value
 %s:22 PhanTypeMissingReturn Method \B307::offsetGet is declared to return mixed but has no return value
 %s:34 PhanTypeMismatchReturn Returning type int but serialize() is declared to return string
-%s:40 PhanTypeMismatchReturn Returning type bool but unserialize() is declared to return void
+%s:40 PhanTypeMismatchReturn Returning type true but unserialize() is declared to return void
 %s:51 PhanTypeMismatchArgument Argument 1 (offset) is null but \B307::offsetExists() takes string defined at %s:18
 %s:52 PhanTypeMismatchArgument Argument 1 (offset) is null but \B307::offsetGet() takes string defined at %s:22
 %s:53 PhanTypeMismatchArgument Argument 1 (offset) is null but \B307::offsetSet() takes string defined at %s:26

--- a/tests/files/expected/0309_inherit_interface_or_abstract.php.expected
+++ b/tests/files/expected/0309_inherit_interface_or_abstract.php.expected
@@ -2,4 +2,4 @@
 %s:35 PhanTypeMismatchArgumentInternal Argument 1 (obj) is int but \spl_object_hash() takes object
 %s:51 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
 %s:52 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
-%s:53 PhanTypeMismatchReturn Returning type bool but foo() is declared to return void
+%s:53 PhanTypeMismatchReturn Returning type true but foo() is declared to return void

--- a/tests/files/src/0166_is_a.php
+++ b/tests/files/src/0166_is_a.php
@@ -40,15 +40,7 @@ function check($var) {
 	} elseif (is_iterable($var)) {
 		emitType($var);
 		foreach ($var as $v) { }  // sanity check that iteration works
-    } elseif (is_a($var, 'stdClass')) {
-        emitType($var);
-    } elseif (is_a($var, '\\SimpleXMLElement')) {
-        emitType($var);
-    } elseif (is_a($var, \DateTime::class)) {
-        emitType($var);
-    } elseif (is_a($var, DateTimeImmutable::class)) {
-        emitType($var);
-    }
+	}
 }
 
 check(null);

--- a/tests/files/src/0166_is_a.php
+++ b/tests/files/src/0166_is_a.php
@@ -40,7 +40,15 @@ function check($var) {
 	} elseif (is_iterable($var)) {
 		emitType($var);
 		foreach ($var as $v) { }  // sanity check that iteration works
-	}
+    } elseif (is_a($var, 'stdClass')) {
+        emitType($var);
+    } elseif (is_a($var, '\\SimpleXMLElement')) {
+        emitType($var);
+    } elseif (is_a($var, \DateTime::class)) {
+        emitType($var);
+    } elseif (is_a($var, DateTimeImmutable::class)) {
+        emitType($var);
+    }
 }
 
 check(null);

--- a/tests/files/src/0298_weird_variable_name.php
+++ b/tests/files/src/0298_weird_variable_name.php
@@ -7,7 +7,8 @@ function testIrregularVar128() {
     echo intdiv(${42}, 3);  // intdiv takes int but this is string[]
     } catch(Throwable $e) {}
     echo "Next\n";
-    ${rand() % 2 === 0} = ['value'];
+    ${true} = ['value'];
+    ${rand() % 2 == 0} = ['value'];
     ${[2]} = ['value'];  // Seriously, this is an alias for $Array?
     echo intdiv(${[3]}, 4);
     echo "Done\n";

--- a/tests/files/src/0305_is_a_tests.php
+++ b/tests/files/src/0305_is_a_tests.php
@@ -1,0 +1,17 @@
+<?php
+
+function test305($x, $y, $z, $className) {
+    if (is_a($x, 'stdClass')) {
+        echo intdiv($x, 2);  // wrong
+    }
+    if (is_a($y, '\\stdClass')) {
+        echo intdiv($y, 2);  // wrong
+    }
+    if (is_a($y, '')) {}  // TODO: warn
+    if (is_a($y, '\\')) {}  // TODO: warn
+
+    if (is_a($z, $className)) {
+        echo intdiv($z, 2);  // infer ObjectType if we don't know?
+    }
+}
+test305(0, 1, 'ignored');

--- a/tests/rasmus_files/expected/0027_void.php.expected
+++ b/tests/rasmus_files/expected/0027_void.php.expected
@@ -1,2 +1,1 @@
-%s:6 PhanTypeMismatchReturn Returning type bool but test() is declared to return void
-
+%s:6 PhanTypeMismatchReturn Returning type true but test() is declared to return void

--- a/tests/rasmus_files/expected/0042_array_access.php.expected
+++ b/tests/rasmus_files/expected/0042_array_access.php.expected
@@ -1,2 +1,1 @@
-%s:4 PhanTypeArraySuspicious Suspicious array access to bool
-
+%s:4 PhanTypeArraySuspicious Suspicious array access to false


### PR DESCRIPTION
A large number of internal and user-defined functions will have `T|false` as a return value, where `false` signifies failure.

By recognizing `false` as an actual type in Phan's type system, this allows us to know that the following uses are probably bugs:

- `return true;` inside a function declared as `/** @return T|false */` for an actual class T
- `$x = functionReturningT_or_false(); if ($x) {some_function_expecting_bool($x); }`


Additional changes:

- Treat the `true`/`false` literals as TrueType and FalseType, respectively (both in code and phpdoc)
- For ConditionVisitor, also add code to remove falsey types and convert possibly falsey types (e.g. nullable) to consistently falsey (e.g. non-nullable) (e.g. BoolType to TrueType)
  (This is how `if($x)` updates the inferred types for `$x`)

---

Pending changes (not created yet):

Change the way UnionType::__toString() works - If a UnionType contains a mix of 2 or more different classes among FalseType, BoolType, or TrueType, then display the human-readable version as `bool` or `?bool` (may do this in another PR)
(Or could change the way UnionType::add() works, but changing the way it's displayed in issues seems faster)
Fix false positive PhanTypeMismatchProperty (Assign false in one place, assign true in another place. Maybe make that a special case to ignore this specific error type for 'true' <=> 'false' **(done)**
Fix bug in parameter defaults (`/** @param bool $arg */ function foo($arg = false){}` seems like it is incorrectly inferred to have type `false` in some conditions) **(This happens when a method calls itself)**

- May want to add `toReadableString()`

Support analysis of `if(!$x)`

Decide how PhanSignatureMismatch should work with the `false` and `true` types in the type system

---

EDIT: **fixed is_scalar in this PR**
https://secure.php.net/manual/en/function.is-scalar.php

>  is_scalar() does not consider resource type values to be scalar as resources are abstract datatypes which are currently based on integers. This implementation detail should not be relied upon, as it may change. 
>  is_scalar() does not consider NULL to be scalar. 