### PR TITLE
Add check if internal class has dynamic properties when assigning property

### DIFF
--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -392,13 +392,10 @@ class AssignmentVisitor extends AnalysisVisitor
             return $this->context;
         }
 
-        $std_class_fqsen =
-            FullyQualifiedClassName::getStdClassFQSEN();
+        // Check if it is a built in class with dynamic properties but (possibly) no __set, such as SimpleXMLElement or stdClass or V8Js
+        $is_class_with_arbitrary_types = isset($class_list[0]) ? $class_list[0]->getHasDynamicProperties($this->code_base) : false;
 
-        if (Config::get()->allow_missing_properties
-            || (!empty($class_list)
-                && $class_list[0]->getFQSEN() == $std_class_fqsen)
-        ) {
+        if ($is_class_with_arbitrary_types || Config::get()->allow_missing_properties) {
             try {
                 // Create the property
                 $property = (new ContextNode(

--- a/tests/files/src/0228_simplexmlelement.php
+++ b/tests/files/src/0228_simplexmlelement.php
@@ -7,3 +7,5 @@ f($x->foo);
 
 function g(bool $v) {}
 g($x->foo);
+
+$x->prop = 'some value';


### PR DESCRIPTION
Allow SimpleXMLElement to assign arbitrary properties to reduce false positives

- Doing this will create a sub-tag named 'foo' with the value as the
  contents, effectively a short form of addChild()
  (e.g. `$x = new SimpleXMLElement('<body><a>v1</a></body>'); $x->tagName = 'value';`)

see https://secure.php.net/manual/en/simplexmlelement.construct.php
Fixes #404 (Also affects v8js, etc)

Previously, Phan only checked for stdClass on the left hand side of
assignments.