### PR TITLE
Fix issue #811, and move backward compatibility checks(syntax) to parse phase

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -65,7 +65,8 @@ Bug Fixes
 - Existence of __get() no longer affects analyzing static properties. (Issue #610)
 - Phan can now detect the declaration of constants relative to a `use`d namespace (Issue #509)
 - Phan can now detect the declaration of functions relative to a `use`d namespace (Issue #510)
-- Fix bug where JSON output printer accidentally escaped some output ("<"), causing invalid JSON.
+- Fix a bug where the JSON output printer accidentally escaped some output ("<"), causing invalid JSON.
+- Fix a bug where a print/echo/method call erroneously marked methods/functions as having a return value. (Issue #811)
 
 Backwards Incompatible Changes
 - Declarations of user-defined constants are now consistently

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1216,7 +1216,9 @@ class ContextNode
     }
 
     /**
-     * Perform some backwards compatibility checks on a node
+     * Perform some backwards compatibility checks on a node.
+     * This ignores union types, and can be run in the parse phase.
+     * (It often should, because outside quick mode, it may be run multiple times per node)
      *
      * @return void
      */

--- a/tests/files/expected/0299_check_returns_bug.php.expected
+++ b/tests/files/expected/0299_check_returns_bug.php.expected
@@ -1,0 +1,2 @@
+%s:4 PhanTypeMissingReturn Method \Example is declared to return bool but has no return value
+%s:12 PhanTypeMissingReturn Method \X::Example is declared to return bool but has no return value

--- a/tests/files/src/0299_check_returns_bug.php
+++ b/tests/files/src/0299_check_returns_bug.php
@@ -1,0 +1,21 @@
+<?php
+
+//
+function Example( int $x ) : bool {
+    echo "x = $x\n";
+    print "Done printing\n";
+}
+
+class X{
+    function helper() : void {}
+
+    function Example( int $x ) : bool {
+        // Test for regression where method calls and echo/print statements would mark a function as having a return value.
+        self::helper();
+        intdiv($x, 2);
+        echo "x = ", $x, "\n";
+        print "done printing x\n";
+    }
+}
+
+Example( 1 );


### PR DESCRIPTION
Bug fix: don't re-use visitReturn to analyze echo, print, and method
call statements. Those mark a method as having a return value.

Design this for best performance when backward compatibility checks aren't run,
bail out as early as possible.
Consistently run it in the parse phase (Otherwise, code outside of
methods may not be analyzed, or something may be analyze multiple times)