### PR TITLE
Fixes #542 : SimpleXMLElement should support array operators

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -67,6 +67,7 @@ Bug Fixes
 - Phan can now detect the declaration of functions relative to a `use`d namespace (Issue #510)
 - Fix a bug where the JSON output printer accidentally escaped some output ("<"), causing invalid JSON.
 - Fix a bug where a print/echo/method call erroneously marked methods/functions as having a return value. (Issue #811)
+- Improve analysis of SimpleXMLElement (Issues #542, #539)
 
 Backwards Incompatible Changes
 - Declarations of user-defined constants are now consistently

--- a/tests/files/src/0300_simple_xml_element_array_dim.php
+++ b/tests/files/src/0300_simple_xml_element_array_dim.php
@@ -1,0 +1,9 @@
+<?php
+
+function xmltest() {
+    $x = new SimpleXMLElement('<a prop="c"></a>');
+    var_export($x['prop']);
+    $x['newprop'] = 'value';
+    var_export($x);
+}
+xmltest();


### PR DESCRIPTION
Array operators are used as a shorthand for tag attributes.

- But it doesn't implement ArrayAccess.