### PR TITLE
Make the analysis of traits much more similar to that of classes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -40,7 +40,9 @@ New Features (Analysis)
 + Start checking if unanalyzable variable accesses such as `$$x` are very likely to be invalid or typos (e.g. $x is an object or array or null)
   Emit `PhanTypeSuspiciousIndirectVariable` if those are seen. (PR #809)
 + Add partial support for inferring the union types of the results of expressions such as `$x ^= 5` (e.g. in `foo($x ^= 5)`) (PR #809)
-
++ Thoroughly analyze the methods declared within traits,
+  using only the information available within the trait. (Issue #800, PR #815)
+  If new emitted issues are seen, users can (1) add abstract methods to traits, (2) add `@method` annotations, or (3) add `@suppress` annotations.
 
 New Features (CLI, Configs)
 + (Linux/Unix only) Add Experimental Phan Daemon mode (PR #563 for Issue #22), which allows phan to run in the background, and accept TCP requests to analyze single files.

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -390,12 +390,6 @@ class UnionTypeVisitor extends AnalysisVisitor
                 }
             }
 
-            if ('self' === $node->children['name']
-                && $this->context->getClassInScope($this->code_base)->isTrait()
-            ) {
-                return new UnionType();
-            }
-
             return Type::fromStringInContext(
                 $node->children['name'],
                 $this->context,

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -72,8 +72,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor {
      *          ▼
      *
      * @param Node $node
-     * An AST node we'd like to determine the UnionType
-     * for
+     * An AST node we'd like to analyze the statements for
      *
      * @return Context
      * The updated context after visiting the node
@@ -168,8 +167,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor {
      *           ▼
      *
      * @param Node $node
-     * An AST node we'd like to determine the UnionType
-     * for
+     * An AST node we'd like to analyze the statements for
      *
      * @return Context
      * The updated context after visiting the node
@@ -244,8 +242,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor {
 
     /**
      * @param Node $node
-     * An AST node we'd like to determine the UnionType
-     * for
+     * An AST node we'd like to analyze the statements for
      *
      * @return Context
      * The updated context after visiting the node
@@ -309,8 +306,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor {
      *           ▼
      *
      * @param Node $node
-     * An AST node we'd like to determine the UnionType
-     * for
+     * An AST node we'd like to analyze the statements for
      *
      * @return Context
      * The updated context after visiting the node
@@ -368,8 +364,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor {
 
     /**
      * @param Node $node
-     * An AST node we'd like to determine the UnionType
-     * for
+     * An AST node we'd like to analyze the statements
      *
      * @return Context
      * The updated context after visiting the node
@@ -381,8 +376,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor {
 
     /**
      * @param Node $node
-     * An AST node we'd like to determine the UnionType
-     * for
+     * An AST node we'd like to analyze the statements for
      *
      * @return Context
      * The updated context after visiting the node
@@ -394,8 +388,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor {
 
     /**
      * @param Node $node
-     * An AST node we'd like to determine the UnionType
-     * for
+     * An AST node we'd like to analyze the statements for
      *
      * @return Context
      * The updated context after visiting the node
@@ -471,10 +464,10 @@ class BlockAnalysisVisitor extends AnalysisVisitor {
 
         return $context;
     }
+
     /**
      * @param Decl $node
-     * An AST node we'd like to determine the UnionType
-     * for
+     * An AST node we'd like to analyze the statements for
      *
      * @return Context
      * The updated context after visiting the node
@@ -486,8 +479,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor {
 
     /**
      * @param Decl $node
-     * An AST node we'd like to determine the UnionType
-     * for
+     * An AST node we'd like to analyze the statements for
      *
      * @return Context
      * The updated context after visiting the node
@@ -499,8 +491,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor {
 
     /**
      * @param Decl $node
-     * An AST node we'd like to determine the UnionType
-     * for
+     * An AST node we'd like to analyze the statements for
      *
      * @return Context
      * The updated context after visiting the node
@@ -512,8 +503,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor {
 
     /**
      * @param Decl $node
-     * An AST node we'd like to determine the UnionType
-     * for
+     * An AST node we'd like to analyze the statements for
      *
      * @return Context
      * The updated context after visiting the node
@@ -530,8 +520,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor {
      * @param Context $context - The context before pre-order analysis
      *
      * @param Node $node
-     * An AST node we'd like to determine the UnionType
-     * for
+     * An AST node we'd like to analyze the statements for
      *
      * @return Context
      * The updated context after pre-order analysis of the node
@@ -561,8 +550,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor {
      * @param Context $context - The context before post-order analysis
      *
      * @param Node $node
-     * An AST node we'd like to determine the UnionType
-     * for
+     * An AST node we'd like to analyze the statements for
      *
      * @return Context
      * The updated context after post-order analysis of the node

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -404,7 +404,7 @@ trait FunctionTrait {
      */
     public function getRealReturnType() : UnionType
     {
-        if (!$this->real_return_type && $this instanceof \Phan\Language\Element\Method) {
+        if (!$this->real_return_type) {
             // Incomplete patch for https://github.com/etsy/phan/issues/670
             return new UnionType();
             // throw new \Error(sprintf("Failed to get real return type in %s method %s", (string)$this->getClassFQSEN(), (string)$this));

--- a/src/Phan/Language/FQSEN/Alternatives.php
+++ b/src/Phan/Language/FQSEN/Alternatives.php
@@ -81,6 +81,7 @@ trait Alternatives
      * with this FQSEN
      *
      * @suppress PhanTypeMismatchDeclaredReturn
+     * @suppress PhanTypeMismatchReturn (Alternatives is a trait, cannot directly implement the FQSEN interface. Related to #800)
      */
     public function getCanonicalFQSEN() : FQSEN
     {

--- a/tests/files/expected/0195_trait_return_type_self.php.expected
+++ b/tests/files/expected/0195_trait_return_type_self.php.expected
@@ -1,1 +1,2 @@
-%s:26 PhanUndeclaredMethod Call to undeclared method \A::z
+%s:27 PhanUndeclaredMethod Call to undeclared method \B::z
+%s:28 PhanUndeclaredMethod Call to undeclared method \A::z

--- a/tests/files/expected/0801_trait_analyze_method_body.php.expected
+++ b/tests/files/expected/0801_trait_analyze_method_body.php.expected
@@ -1,0 +1,2 @@
+%s:4 PhanTypeMismatchReturn Returning type string but f2() is declared to return int
+%s:10 PhanTypeMismatchReturn Returning type array but f() is declared to return \U301

--- a/tests/files/src/0195_trait_return_type_self.php
+++ b/tests/files/src/0195_trait_return_type_self.php
@@ -1,6 +1,7 @@
 <?php
-
 trait B {
+    abstract function f();
+    /** @return static : TODO: Make phan recognize that @return static overrides real type of self */
     public function g(): self
     {
         return $this;
@@ -14,6 +15,7 @@ class A {
     {
     }
 
+    /** @return static */
     public function h() : self {
         return $this;
     }

--- a/tests/files/src/0801_trait_analyze_method_body.php
+++ b/tests/files/src/0801_trait_analyze_method_body.php
@@ -1,0 +1,16 @@
+<?php
+trait T301 {
+    private function f2() : int {
+        return "a";  // Should warn about this line
+    }
+}
+
+trait U301 {
+    private function f() : self {
+        return [];
+    }
+}
+
+class HasTrait301 {
+    use U301;
+}


### PR DESCRIPTION
There were a lot of unexpected workarounds.
Hopefully, with new features and bug fixes in Phan, and improved handling of traits, these workarounds can be removed without much user impact.

- Start analyzing `return` statements in the inner body of trait methods.
  (Compare against the real return type if it exists,
  instead of the phpdoc return type to maintain a low false positive rate.
  @morria - Thoughts? What were the original motivations for this behavior?)
- Get rid of workarounds to reduce false positive rate for traits
- Set the real return type for trait methods returning `self`
  Without it being set, incorrect `return` statements wouldn't be
  detected, method override compatibility checks would be wrong, and analysis of
  chained method calls wouldn't detect some issues (See test 0195)

  Abstract methods or the `@method` tag can be used to work around false
  positives (e.g. for PhanUndeclaredMethod) in traits with many users.

Fixes #800 

This will be merged on/after June 16th, if there are no new bugs identified/no comments from other maintainers.