### PR TITLE
Catch uncaught issue exception (For complex indirect variable access?)

### DIFF
--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -544,11 +544,20 @@ class AssignmentVisitor extends AnalysisVisitor
      */
     public function visitVar(Node $node) : Context
     {
-        $variable_name = (new ContextNode(
-            $this->code_base,
-            $this->context,
-            $node
-        ))->getVariableName();
+        try {
+            $variable_name = (new ContextNode(
+                $this->code_base,
+                $this->context,
+                $node
+            ))->getVariableName();
+        } catch (IssueException $exception) {
+            Issue::maybeEmitInstance(
+                $this->code_base,
+                $this->context,
+                $exception->getIssueInstance()
+            );
+            return $this->context;
+        }
 
         // Check to see if the variable already exists
         if ($this->context->getScope()->hasVariableWithName(


### PR DESCRIPTION
`${(complex expression)}` may throw when attempting to get the variable name.

EDIT: may be related to `function foo() {$$someArrayTypo = [];}` 