### PR TITLE
Emit PhanDeprecatedFunctionInternal (uses ReflectionFunctionAbstract)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -53,6 +53,8 @@ New Features (CLI, Configs)
    Infers that $x is a string for constructs such as `if (!is_string($x)) {return;} function_using_x($x);`)
   This is slow, and disabled by default.
 + Add `--include-analysis-file-list` option to define files that will be included in static analysis, to the exclusion of others.
++ Start emitting `PhanDeprecatedFunctionInternal` if an internal (to PHP) function/method is deprecated.
+  (Phan emits `PhanUndeclaredFunction` if a function/method was removed; Functions deprecated in PHP 5.x were removed in 7.0)
 
 Maintenance
 + Update function signature map to analyze `iterable` and `is_iterable` from php 7.1

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -275,9 +275,9 @@ class CodeBase
     {
         foreach ($function_name_list as $i => $function_name) {
             foreach (FunctionFactory::functionListFromName($this, $function_name)
-                as $function_or_method
+                as $function
             ) {
-                $this->addFunction($function_or_method);
+                $this->addFunction($function);
             }
         }
     }

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -82,6 +82,7 @@ class Issue
     const DeprecatedInterface       = 'PhanDeprecatedInterface';
     const DeprecatedTrait           = 'PhanDeprecatedTrait';
     const DeprecatedFunction        = 'PhanDeprecatedFunction';
+    const DeprecatedFunctionInternal = 'PhanDeprecatedFunctionInternal';
     const DeprecatedProperty        = 'PhanDeprecatedProperty';
 
     // Issue::CATEGORY_PARAMETER
@@ -802,6 +803,14 @@ class Issue
                 "Call to deprecated function {FUNCTIONLIKE}() defined at {FILE}:{LINE}",
                 self::REMEDIATION_B,
                 5000
+            ),
+            new Issue(
+                self::DeprecatedFunctionInternal,
+                self::CATEGORY_DEPRECATED,
+                self::SEVERITY_NORMAL,
+                "Call to deprecated function {FUNCTIONLIKE}()",
+                self::REMEDIATION_B,
+                5005
             ),
             new Issue(
                 self::DeprecatedClass,

--- a/src/Phan/Language/Element/FunctionFactory.php
+++ b/src/Phan/Language/Element/FunctionFactory.php
@@ -13,7 +13,7 @@ class FunctionFactory {
 
     /**
      * @return Func[]
-     * One or more (alternate) methods begotten from
+     * One or more (alternate) functions/methods begotten from
      * reflection info and internal method data
      */
     public static function functionListFromName(
@@ -28,8 +28,8 @@ class FunctionFactory {
 
     /**
      * @return Func[]
-     * One or more (alternate) methods begotten from
-     * reflection info and internal method data
+     * One or more (alternate) functions begotten from
+     * reflection info and internal functions data
      */
     public static function functionListFromReflectionFunction(
         CodeBase $code_base,
@@ -39,11 +39,11 @@ class FunctionFactory {
         $context = new Context();
 
         $parts = explode('\\', $reflection_function->getName());
-        $method_name = array_pop($parts);
+        $function_name = array_pop($parts);
         $namespace = '\\' . implode('\\', $parts);
 
         $fqsen = FullyQualifiedFunctionName::make(
-            $namespace, $method_name
+            $namespace, $function_name
         );
 
         $function = new Func(
@@ -62,6 +62,7 @@ class FunctionFactory {
             $reflection_function->getNumberOfParameters()
             - $reflection_function->getNumberOfRequiredParameters()
         );
+        $function->setIsDeprecated($reflection_function->isDeprecated());
 
         return self::functionListFromFunction($function, $code_base);
     }
@@ -137,7 +138,7 @@ class FunctionFactory {
             $method->setNumberOfOptionalParameters(999);
             $method->setNumberOfRequiredParameters(0);
         }
-        // FIXME: make this from ReflectionMethod->getReturnType
+        $method->setIsDeprecated($reflection_method->isDeprecated());
         $method->setRealReturnType(UnionType::fromReflectionType($reflection_method->getReturnType()));
         $method->setRealParameterList(Parameter::listFromReflectionParameterList($reflection_method->getParameters()));
 


### PR DESCRIPTION
This will tell the user if a PHP function is deprecated
(in the PHP version used to run Phan, which isn't ideal, but can be suppressed)

For #829

Note: None of the core library functions were deprecated yet.
`each()` and `create_function()` will be deprecated in php 7.2
- e.g. remainder of mcrypt was deprecated in 7.1, but we won't have that on travis

(Issues for this were emitted successfully in the branch warn-deprecated-internal-functions-2, which was more ambitious, but still has issues)