### PR TITLE
Fix error noticed when running Phan under php 7.2.0alpha1

### DIFF
--- a/src/Phan/Language/Element/TraitAdaptations.php
+++ b/src/Phan/Language/Element/TraitAdaptations.php
@@ -19,12 +19,12 @@ class TraitAdaptations
      * @var TraitAliasSource[] maps alias methods from this trait
      *                         to the info about the source method
      */
-    public $alias_methods;
+    public $alias_methods = [];
 
     /**
      * @var bool[] Has an entry mapping name to true if a method with a given name is hidden.
      */
-    public $hidden_methods;
+    public $hidden_methods = [];
 
     public function __construct(FQSEN $trait_fqsen)
     {


### PR DESCRIPTION
In php 7.2, `count()` can only be called on `array` or `Countable`.
It will emit a warning if it is called on other types, e.g. `null`,
`string`, etc.