### PR TITLE
Fixes #861 Fix crash in trait use alias changing only the method's visibility

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -70,6 +70,7 @@ Bug Fixes
 - Fix a bug where the JSON output printer accidentally escaped some output ("<"), causing invalid JSON.
 - Fix a bug where a print/echo/method call erroneously marked methods/functions as having a return value. (Issue #811)
 - Improve analysis of SimpleXMLElement (Issues #542, #539)
+- Fix crash handling trait use aliases which change only the method's visibility (Issue #861)
 
 Backwards Incompatible Changes
 - Declarations of user-defined constants are now consistently

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -186,7 +186,7 @@ class ContextNode
         $trait_method_node = $adaptation_node->children['method'];
         $trait_original_class_name_node = $trait_method_node->children['class'];
         $trait_original_method_name = $trait_method_node->children['method'];
-        $trait_new_method_name = $adaptation_node->children['alias'];
+        $trait_new_method_name = $adaptation_node->children['alias'] ?? $trait_original_method_name;
         assert(is_string($trait_original_method_name));
         assert(is_string($trait_new_method_name));
         $trait_fqsen = (new ContextNode(
@@ -227,6 +227,11 @@ class ContextNode
         }
         // TODO: Could check for duplicate alias method occurences, but `php -l` would do that for you in some cases
         $adaptations_info->alias_methods[$trait_new_method_name] = new TraitAliasSource($trait_original_method_name, $adaptation_node->lineno ?? 0, $adaptation_node->flags ?? 0);
+        // Handle `use MyTrait { myMethod as private; }` by skipping the original method.
+        // TODO: Do this a cleaner way.
+        if (strcasecmp($trait_new_method_name, $trait_original_method_name) === 0) {
+            $adaptations_info->hidden_methods[strtolower($trait_original_method_name)] = true;
+        }
     }
 
     /**

--- a/tests/files/expected/0306_trait_change_only_visibility.php.expected
+++ b/tests/files/expected/0306_trait_change_only_visibility.php.expected
@@ -1,0 +1,6 @@
+%s:23 PhanUndeclaredAliasedMethodOfTrait Alias \Foo306::missingAsProtected was defined for a method \MyTrait306::missingAsProtected which does not exist in trait MyTrait306
+%s:29 PhanAccessMethodProtected Cannot access protected method \Foo306::publicAsProtected defined at %s:5
+%s:31 PhanAccessMethodPrivate Cannot access private method \Foo306::publicAsPrivate defined at %s:4
+%s:33 PhanAccessMethodProtected Cannot access protected method \Foo306::privateAsProtected defined at %s:9
+%s:34 PhanAccessMethodPrivate Cannot access private method \Foo306::privateAsPrivate defined at %s:8
+%s:36 PhanUndeclaredMethod Call to undeclared method \Foo306::missingAsProtected

--- a/tests/files/src/0306_trait_change_only_visibility.php
+++ b/tests/files/src/0306_trait_change_only_visibility.php
@@ -1,0 +1,38 @@
+<?php
+
+trait MyTrait306 {
+    public function publicAsPrivate() {}
+    public function publicAsProtected() {}
+    public function publicAsProtected2() {}
+    public function publicAsPublic() {}
+    private function privateAsPrivate() {}
+    private function privateAsProtected() {}
+    private function privateAsProtected2() {}
+    private function privateAsPublic() {}
+}
+class Foo306 {
+    use MyTrait306 {
+        publicAsPrivate as private;
+        publicAsProtected as protected;
+        // publicAsProtected2 as protected;  // FIXME : This should be an error if the alias and the original have the same name.
+        publicAsPublic as public;
+        privateAsPrivate as private;
+        privateAsProtected as protected;
+        // privateAsProtected2 as protected privateAsProtected2; // FIXME : This should be an error if the alias and the original have the same name.
+        privateAsPublic as public;
+        missingAsProtected as protected;
+    }
+}
+function test_foo306() {
+    $foo = new Foo306();
+    $foo->publicAsPublic();  // this is fine
+    $foo->publicAsProtected();  // should warn
+    // $foo->publicAsProtected2();  // should warn
+    $foo->publicAsPrivate();  // should warn
+    $foo->privateAsPublic();  // this is fine
+    $foo->privateAsProtected();  // should warn
+    $foo->privateAsPrivate();  // should warn
+    // $foo->privateAsProtected2();  // should warn
+    $foo->missingAsProtected();  // this is undeclared
+}
+test_foo306();


### PR DESCRIPTION
 Fix crash handling for a trait use alias which changes only the method's visibility.
This fixes an assertion error.

TODO: properly handle trait conflicts in subsequent PRs
TODO: If the new visibility is private, it should be callable without phan warning about visibility ( from the class using the trait)