### PR TITLE
Fix issues that would prevent the code from running in php 7.0

### DIFF
--- a/phan_client
+++ b/phan_client
@@ -280,6 +280,9 @@ EOB;
         exit($exit_code);
     }
 
+    /**
+     * @suppress PhanParamTooManyInternal - `getopt` added an optional third parameter in php 7.1
+     */
     public function __construct()  {
         global $argv;
 

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -393,7 +393,7 @@ class ConditionVisitor extends KindVisitorImplementation
         };
 
         /** @return void */
-        $object_callback = function(Variable $variable) : void
+        $object_callback = function(Variable $variable)
         {
             // Change the type to match the is_a relationship
             // If we already have the `object` type or generic object types, then keep those
@@ -409,7 +409,8 @@ class ConditionVisitor extends KindVisitorImplementation
             }
             $variable->setUnionType($newType);
         };
-        $scalar_callback = function(Variable $variable) : void
+        /** @return void */
+        $scalar_callback = function(Variable $variable)
         {
             // Change the type to match the is_a relationship
             // If we already have possible scalar types, then keep those


### PR DESCRIPTION
(or emit erroneous warnings)

0.8 is recommended for code both running under php 7.0 and targeting php 7.0.
Allow 0.9 to work under php 7.0 for now 