### PR TITLE
Release Phan 0.9.2

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,7 @@
 Phan NEWS
 
-?? ??? 2017, Phan 0.9.2 (dev)
------------------------
+0.9.2 Jun 13, 2017
+------------------
 
 New Features (Analysis)
 + Add `PhanParamSignatureRealMismatch*` (e.g. `ParamSignatureRealMismatchTooManyRequiredParameters`),

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -16,7 +16,7 @@ class CLI
     /**
      * This should be updated to x.y.z-dev after every release, and x.y.z before a release.
      */
-    const PHAN_VERSION = '0.9.2-dev';
+    const PHAN_VERSION = '0.9.2';
 
     /**
      * @var OutputInterface


### PR DESCRIPTION
This will be released on Tuesday, June 13th.
No changes are planned (by me) until then, except for bug fixes.
- E.g. if there are unexpected severe regressions from 0.9.1
  (such as assertion errors, TypeError, out of memory errors,
  failing to emit important categories of issues, etc.)

See https://github.com/etsy/phan/blob/master/NEWS for what has changed since Phan 0.9.1


@rlerdorf @morria - If you have time, test the latest release out, and if you see any blocking issues, let me know. I've tested most of the recent changes (internally, and quick sanity checks on open source projects)
