### PR TITLE
Fixes #142 : Automatically inherit types from compatible parent classes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,10 +1,11 @@
 Phan NEWS
-
-
 ?? ??? 2017, Phan 0.9.3 (dev)
 -----------------------
 
 New Features (Analysis)
++ Automatically inherit `@param` and `@return` types from parent methods.
+  This is controlled by the boolean config `enable_phpdoc_types`, which is true by default.
+  `analyze_signature_compatibility` must also be set to true (default is true) for this step to be performed.
 
 New Features (CLI, Configs)
 

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -120,6 +120,12 @@ class Config
         // can add quite a bit of time to the analysis.
         'analyze_signature_compatibility' => true,
 
+        // If enabled, inherit any missing phpdoc for types from
+        // the parent method if none is provided.
+        //
+        // NOTE: This step will only be performed if analyze_signature_compatibility is also enabled.
+        'inherit_phpdoc_types' => true,
+
         // The minimum severity level to report on. This can be
         // set to Issue::SEVERITY_LOW, Issue::SEVERITY_NORMAL or
         // Issue::SEVERITY_CRITICAL. Setting it to only

--- a/src/Phan/Language/Internal/FunctionSignatureMap.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMap.php
@@ -4435,7 +4435,7 @@ return [
 'IteratorIterator::next' => [''],
 'IteratorIterator::rewind' => [''],
 'IteratorIterator::valid' => ['bool'],
-'Iterator::key' => ['scalar'],
+'Iterator::key' => ['int|string'],
 'Iterator::next' => ['void'],
 'Iterator::rewind' => ['void'],
 'iterator_to_array' => ['array', 'it'=>'traversable', 'use_keys='=>'bool'],

--- a/src/Phan/Library/Map.php
+++ b/src/Phan/Library/Map.php
@@ -11,6 +11,9 @@ class Map extends \SplObjectStorage
     /**
      * We redefine the key to be the actual key rather than
      * the index of the key
+     *
+     * @return object
+     * @suppress PhanParamSignatureMismatchInternal - This is deliberately changing the phpdoc return type.
      */
     public function key()
     {

--- a/tests/files/expected/0307_inheritdoc_tests.php.expected
+++ b/tests/files/expected/0307_inheritdoc_tests.php.expected
@@ -1,0 +1,8 @@
+%s:18 PhanTypeMissingReturn Method \B307::offsetExists is declared to return bool but has no return value
+%s:22 PhanTypeMissingReturn Method \B307::offsetGet is declared to return mixed but has no return value
+%s:34 PhanTypeMismatchReturn Returning type int but serialize() is declared to return string
+%s:40 PhanTypeMismatchReturn Returning type bool but unserialize() is declared to return void
+%s:51 PhanTypeMismatchArgument Argument 1 (offset) is null but \B307::offsetExists() takes string defined at %s:18
+%s:52 PhanTypeMismatchArgument Argument 1 (offset) is null but \B307::offsetGet() takes string defined at %s:22
+%s:53 PhanTypeMismatchArgument Argument 1 (offset) is null but \B307::offsetSet() takes string defined at %s:26
+%s:54 PhanTypeMismatchArgument Argument 1 (offset) is null but \B307::offsetUnset() takes string defined at %s:30

--- a/tests/files/expected/0308_inheritdoc_incompatible.php.expected
+++ b/tests/files/expected/0308_inheritdoc_incompatible.php.expected
@@ -1,0 +1,1 @@
+%s:7 PhanParamSignatureMismatchInternal Declaration of function key() : object should be compatible with internal function key() : int

--- a/tests/files/expected/0309_inherit_interface_or_abstract.php.expected
+++ b/tests/files/expected/0309_inherit_interface_or_abstract.php.expected
@@ -1,0 +1,5 @@
+%s:34 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \stdClass but \intdiv() takes int
+%s:35 PhanTypeMismatchArgumentInternal Argument 1 (obj) is int but \spl_object_hash() takes object
+%s:51 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
+%s:52 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
+%s:53 PhanTypeMismatchReturn Returning type bool but foo() is declared to return void

--- a/tests/files/src/0307_inheritdoc_tests.php
+++ b/tests/files/src/0307_inheritdoc_tests.php
@@ -1,0 +1,57 @@
+<?php
+
+class A307 {
+
+    /**
+     * @param int $x
+     * @return int
+     */
+    public function userDefinedMethod($x) {
+        return $x * 2;
+    }
+}
+
+class B307 implements ArrayAccess, Serializable {
+    /**
+     * @param string $offset (Part of the phpdoc can be specified, but any remaining fields will be inferred
+     */
+	public function offsetExists($offset) { }  // Should warn about having no return value. It knows the expected return value from ArrayAccess
+    /**
+     * @param string $offset
+     */
+    public function offsetGet($offset) { }  // Warns about not returning `mixed`
+    /**
+     * @param string $offset
+     */
+    public function offsetSet($offset, $value) { }
+    /**
+     * @param string $offset
+     */
+    public function offsetUnset($offset) { }
+
+    // Should warn about returning int instead of string
+    public function serialize() {
+        return 42;
+    }
+
+    // Should warn.
+    public function unserialize($serialized) {
+        $x = intdiv($serialized, 2);  // Phan should warn, inferring that $serialized is an int.
+        return true; // should warn about returning a value
+    }
+
+    public function userDefinedMethod($x) {
+        $result = $x->property;  // should warn
+        return serialize($x);  // should also warn
+    }
+}
+
+function testB307() {
+    $b = new B307;
+    $b->offsetExists(null);  // should warn about invalid offset
+    $b->offsetGet(null);  // should warn
+    $b->offsetSet(null, 'value');  // should warn
+    $b->offsetUnset(null);  // should warn
+    // TODO: phan doesn't check short array syntax for array offsets yet
+}
+testB307();

--- a/tests/files/src/0308_inheritdoc_incompatible.php
+++ b/tests/files/src/0308_inheritdoc_incompatible.php
@@ -1,0 +1,19 @@
+<?php
+
+class MyMap308 extends SplObjectStorage {
+    /**
+     * @return object - This is deliberately incompatible
+     */
+    public function key() {
+        return self::current();
+    }
+
+    /**
+     * @return bool - This is deliberately incompatible
+     * @suppress PhanParamSignatureMismatchInternal (This suppression should work)
+     */
+    public function rewind() {
+        parent::rewind();
+        return true;
+    }
+}

--- a/tests/files/src/0309_inherit_interface_or_abstract.php
+++ b/tests/files/src/0309_inherit_interface_or_abstract.php
@@ -1,0 +1,55 @@
+<?php
+
+interface I309 {
+    /**
+     * @param stdClass $o (omit $y)
+     */
+    public function interfaceMethod($o, $y);
+}
+
+trait T309 {
+    /**
+     * @param object $o
+     * @return bool
+     */
+    public abstract function traitMethod($o);
+}
+
+abstract class A309 {
+    /**
+     * @param int $x (omit $y)
+     * @return void
+     */
+    public abstract function foo($x, $y);
+}
+
+class B309 extends A309 implements I309 {
+    use T309;
+
+    /**
+     * @param $y
+     * @param int $o (NOTE: This test reverses the parameter name order here to check that phan is analyzing by position)
+     */
+    public function interfaceMethod($y, $o) {
+        echo intdiv($y, 2);  // warn, $y is stdClass
+        echo spl_object_hash($o);  // warn, $o is an int
+    }
+
+    /**
+     * @param $arg1 (NOTE: This test reverses the parameter name order here to check that phan is analyzing by position)
+     * Should warn about failing to return a value.
+     */
+    public function traitMethod($arg1) {
+        echo intdiv($arg1, 2);  // warn, $y is stdClass
+    }
+
+    /**
+     * @param int $x
+     * @param string $y
+     */
+    public function foo($x, $y) {
+        echo intdiv($y, 3);  // warn, y is string
+        echo strlen($x);  // warn, x is int
+        return true;  // warn, this is void
+    }
+}

--- a/tests/rasmus_files/src/0043_array_access_object.php
+++ b/tests/rasmus_files/src/0043_array_access_object.php
@@ -4,10 +4,10 @@ $a = new A;
 if($a[1]) { }
 
 class B implements ArrayAccess {
-	function offsetExists($offset) { }
-    function offsetGet($offset) { }
-    function offsetSet($offset,$value) { }
-    function offsetUnset($offset) { }
+    function offsetExists($offset) { return false; }
+    function offsetGet($offset) { return null; }
+    function offsetSet($offset,$value) { return; }
+    function offsetUnset($offset) { return; }
 }
 
 $b = new B;


### PR DESCRIPTION
for the `@param` and `@return` annotations.
This also inherits types from interfaces,
or from traits with overridable/abstract methods, etc.

- This is enabled by the `inherit_phpdoc_types` setting, which is true
  by default (Also requires signature compatibility checking to be enabled)
- This may still have edge cases.

If there is already a real type or a phpdoc type on the overriding
method, then Phan won't do anything new. It will keep that type.

- This can be temporarily disabled if there are too many new issues.
- If `return` statements uncover new issues, then fix those,
  or add `@return` if it was a false positive
  (and suppress the phpdoc compatibility warning)
- If parameter types are guessed from parent, causing new issues,
  and those are false positives, adding `@param` on the overriding
  method will help if the guess is incorrect.

This is planned for a subsequent 0.9.3 release.

Fixes #198 as well