### PR TITLE
Fixes #848: $argv and $argc are not superglobals

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1032,7 +1032,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             (string)$name_node;
 
         if (!$this->context->getScope()->hasVariableWithName($variable_name)) {
-            if (Variable::isSuperglobalVariableWithName($variable_name)) {
+            if (Variable::isHardcodedVariableInScopeWithName($variable_name, $this->context->isInGlobalScope())) {
                 return Variable::getUnionTypeOfHardcodedGlobalVariableWithName($variable_name, $this->context);
             }
             if (!Config::get()->ignore_undeclared_variables_in_global_scope

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -241,7 +241,7 @@ class AssignmentVisitor extends AnalysisVisitor
                 $node
             ))->getVariableName();
 
-            if (Variable::isSuperglobalVariableWithName($variable_name)) {
+            if (Variable::isHardcodedVariableInScopeWithName($variable_name, $this->context->isInGlobalScope())) {
                 return $this->analyzeSuperglobalDim($node, $variable_name);
             }
         }
@@ -274,7 +274,7 @@ class AssignmentVisitor extends AnalysisVisitor
             }
             // assert(is_string($dim), "dim is not a string");
 
-            if (Variable::isSuperglobalVariableWithName($dim)) {
+            if (Variable::isHardcodedVariableInScopeWithName($dim, $this->context->isInGlobalScope())) {
                 // Don't override types of superglobals such as $_POST, $argv through $_GLOBALS['_POST'] = expr either. TODO: Warn.
                 return $this->context;
             }

--- a/src/Phan/Language/Element/Variable.php
+++ b/src/Phan/Language/Element/Variable.php
@@ -16,8 +16,6 @@ class Variable extends TypedElement
      * @var string[] - Maps from a built in superglobal name to a UnionType spec string.
      */
     const _BUILTIN_SUPERGLOBAL_TYPES = [
-        'argv' => 'string[]',
-        'argc' => 'int',
         '_GET' => 'string[]|string[][]',
         '_POST' => 'string[]|string[][]',
         '_COOKIE' => 'string[]|string[][]',
@@ -27,7 +25,22 @@ class Variable extends TypedElement
         '_FILES' => 'int[][]|string[][]|int[][][]|string[][][]',  // Can have multiple files with the same name.
         '_SESSION' => 'array',
         'GLOBALS' => 'array',
-        'http_response_header' => 'string[]|null' // Revisit when we implement sub-block type refining
+        'http_response_header' => 'string[]|null', // Revisit when we implement sub-block type refining
+    ];
+
+    const _BUILTIN_GLOBAL_TYPES = [
+        '_GET' => 'string[]|string[][]',
+        '_POST' => 'string[]|string[][]',
+        '_COOKIE' => 'string[]|string[][]',
+        '_REQUEST' => 'string[]|string[][]',
+        '_SERVER' => 'array',
+        '_ENV' => 'string[]',
+        '_FILES' => 'int[][]|string[][]|int[][][]|string[][][]',  // Can have multiple files with the same name.
+        '_SESSION' => 'array',
+        'GLOBALS' => 'array',
+        'http_response_header' => 'string[]|null', // Revisit when we implement sub-block type refining
+        'argv' => 'string[]',
+        'argc' => 'int',
     ];
 
     /**
@@ -153,14 +166,24 @@ class Variable extends TypedElement
     public static function isHardcodedGlobalVariableWithName(
         string $name
     ) : bool {
-        return (
-            self::isSuperglobalVariableWithName($name)
-            || array_key_exists($name, Config::get()->globals_type_map)
-        );
+        return self::isSuperglobalVariableWithName($name) ||
+            array_key_exists($name, self::_BUILTIN_GLOBAL_TYPES) ||
+            array_key_exists($name, Config::get()->globals_type_map);
     }
 
     /**
-     * @return UnionType|null
+     * Returns true for all superglobals (if is_in_global_scope, also for variables in globals_type_map/built in globals)
+     */
+    public static function isHardcodedVariableInScopeWithName(
+        string $name,
+        bool $is_in_global_scope
+    ) : bool {
+        return $is_in_global_scope ? self::isHardcodedGlobalVariableWithName($name)
+                                   : self::isSuperglobalVariableWithName($name);
+    }
+
+    /**
+     * @return ?UnionType
      * Returns UnionType (Possible with empty set) if and only
      * if isHardcodedGlobalVariableWithName is true. Returns null
      * otherwise.
@@ -169,13 +192,10 @@ class Variable extends TypedElement
         string $name,
         Context $context
     ) {
-        if (array_key_exists($name, self::_BUILTIN_SUPERGLOBAL_TYPES)) {
+        if (array_key_exists($name, self::_BUILTIN_GLOBAL_TYPES)) {
             // More efficient than using context.
-            return UnionType::fromFullyQualifiedString(
-                self::_BUILTIN_SUPERGLOBAL_TYPES[$name]
-            );
+            return UnionType::fromFullyQualifiedString(self::_BUILTIN_GLOBAL_TYPES[$name]);
         }
-
         $config = Config::get();
         if (array_key_exists($name, $config->globals_type_map)
             || in_array($name, $config->runkit_superglobals)

--- a/tests/files/expected/0219_superglobal_type_check.php.expected
+++ b/tests/files/expected/0219_superglobal_type_check.php.expected
@@ -8,3 +8,5 @@
 %s:34 PhanTypeMismatchArgumentInternal Argument 1 (string) is int[]|int[][]|string[]|string[][] but \strlen() takes string
 %s:37 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is int[]|int[][]|string[]|string[][] but \intdiv() takes int
 %s:40 PhanTypeMismatchArgumentInternal Argument 1 (string) is null|string[] but \strlen() takes string
+%s:49 PhanUndeclaredVariable Variable $argc is undeclared
+%s:50 PhanUndeclaredVariable Variable $argv is undeclared

--- a/tests/files/src/0219_superglobal_type_check.php
+++ b/tests/files/src/0219_superglobal_type_check.php
@@ -1,7 +1,7 @@
 <?php
-
 // Sanity checking phan's checks on the types of built in superglobals.
 function superglobal_sanity_check(bool $exec = false) {
+    global $argc, $argv;
     var_dump(strlen($_POST));
     var_dump(count($_POST));
     var_dump(count($_GET));
@@ -44,3 +44,9 @@ function superglobal_sanity_check(bool $exec = false) {
     }
 }
 superglobal_sanity_check();
+
+function builtin_global_sanity_check() {
+    var_dump(intdiv($argc, 1));  // emits warning about undefined $argc
+    var_dump(count($argv));  // emits warning about undefined $argv
+}
+builtin_global_sanity_check();


### PR DESCRIPTION
Also, copy the types of globals from hardcoded types,
or from the global scope (hardcoded types have priority,
then `global_type_map`).

Also fixes #834