### PR TITLE
Fix suppressing PhanTypeMismatchProperty on property defaults

### DIFF
--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -491,6 +491,7 @@ class ParseVisitor extends ScopeVisitor
             if ($variable = $comment->getVariableList()[$i] ?? null) {
                 if ((string)$union_type != 'null'
                     && !$union_type->canCastToUnionType($variable->getUnionType())
+                    && !$property->hasSuppressIssue(Issue::TypeMismatchProperty)
                 ) {
                     $this->emitIssue(
                         Issue::TypeMismatchProperty,

--- a/tests/files/expected/0307_suppress_on_property.php.expected
+++ b/tests/files/expected/0307_suppress_on_property.php.expected
@@ -1,0 +1,1 @@
+%s:7 PhanTypeMismatchProperty Assigning array to property but \Foo307::x is \ArrayAccess

--- a/tests/files/src/0307_suppress_on_property.php
+++ b/tests/files/src/0307_suppress_on_property.php
@@ -1,0 +1,14 @@
+<?php
+
+class Foo307 {
+    /**
+     * @var ArrayAccess
+     */
+    public $x = [];
+
+    /**
+     * @var ArrayAccess
+     * @suppress PhanTypeMismatchProperty
+     */
+    public $y = [];
+}


### PR DESCRIPTION
The context wasn't set to the property context (don't know if that
exists), so the suppression didn't work)

E.g. may want to declare something as an array