### PR TITLE
Fix AccessMethodInternal from root namespace

### DIFF
--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -826,8 +826,10 @@ class ContextNode
                         $this->node->lineno ?? 0,
                         [
                             (string)$property->getFQSEN(),
+                            $property->getElementNamespace($this->code_base),
                             $property->getFileRef()->getFile(),
                             $property->getFileRef()->getLineNumberStart(),
+                            $this->context->getNamespace(),
                         ]
                     )
                 );
@@ -1073,8 +1075,10 @@ class ContextNode
                     $node->lineno ?? 0,
                     [
                         (string)$constant->getFQSEN(),
+                        $constant->getElementNamespace($this->code_base),
                         $constant->getFileRef()->getFile(),
                         $constant->getFileRef()->getLineNumberStart(),
+                        $this->context->getNamespace()
                     ]
                 )
             );

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -23,7 +23,7 @@ class ArgumentType
 
     /**
      * @param FunctionInterface $method
-     * The method we're analyzing arguments for
+     * The function/method we're analyzing arguments for
      *
      * @param Node $node
      * The node holding the method call we're looking at
@@ -96,8 +96,10 @@ class ArgumentType
                 Issue::AccessMethodInternal,
                 $context->getLineNumberStart(),
                 (string)$method->getFQSEN(),
+                $method->getElementNamespace($code_base) ?: '\\',
                 $method->getFileRef()->getFile(),
-                $method->getFileRef()->getLineNumberStart()
+                $method->getFileRef()->getLineNumberStart(),
+                ($context->getNamespace()) ?: '\\'
             );
         }
 

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -248,6 +248,7 @@ class Issue
         'ISSUETYPE_NORMAL' => '%s',  // for normal issues
         'LINE'          => '%d',
         'METHOD'        => '%s',
+        'NAMESPACE'     => '%s',
         'PARAMETER'     => '%s',
         'PROPERTY'      => '%s',
         'TYPE'          => '%s',
@@ -1418,7 +1419,7 @@ class Issue
                 self::AccessConstantInternal,
                 self::CATEGORY_INTERNAL,
                 self::SEVERITY_NORMAL,
-                "Cannot access internal constant {CONST} defined at {FILE}:{LINE}",
+                "Cannot access internal constant {CONST} of namepace {NAMESPACE} defined at {FILE}:{LINE} from namespace {NAMESPACE}",
                 self::REMEDIATION_B,
                 15000
             ),
@@ -1442,7 +1443,7 @@ class Issue
                 self::AccessPropertyInternal,
                 self::CATEGORY_INTERNAL,
                 self::SEVERITY_NORMAL,
-                "Cannot access internal property {PROPERTY} defined at {FILE}:{LINE}",
+                "Cannot access internal property {PROPERTY} of namespace {NAMESPACE} defined at {FILE}:{LINE} from namespace {NAMESPACE}",
                 self::REMEDIATION_B,
                 15003
             ),
@@ -1450,7 +1451,7 @@ class Issue
                 self::AccessMethodInternal,
                 self::CATEGORY_INTERNAL,
                 self::SEVERITY_NORMAL,
-                "Cannot access internal method {METHOD} defined at {FILE}:{LINE}",
+                "Cannot access internal method {METHOD} of namespace {NAMESPACE} defined at {FILE}:{LINE} from namespace {NAMESPACE}",
                 self::REMEDIATION_B,
                 15004
             ),

--- a/src/Phan/Language/Element/AddressableElement.php
+++ b/src/Phan/Language/Element/AddressableElement.php
@@ -158,11 +158,8 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
         CodeBase $code_base,
         Context $context
     ) : bool {
-        $element_fqsen = $this->getFQSEN();
-        assert($element_fqsen instanceof FullyQualifiedGlobalStructuralElement);
-
         // Figure out which namespace this element is within
-        $element_namespace = $element_fqsen->getNamespace();
+        $element_namespace = $this->getElementNamespace($code_base);
 
         // Get our current namespace from the context
         $context_namespace = $context->getNamespace();
@@ -230,5 +227,14 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
     protected function hydrateOnce(CodeBase $code_base)
     {
         // Do nothing unless overridden
+    }
+
+    public function getElementNamespace(CodeBase $code_base) : string
+    {
+        $element_fqsen = $this->getFQSEN();
+        assert($element_fqsen instanceof FullyQualifiedGlobalStructuralElement);
+
+        // Figure out which namespace this element is within
+        return $element_fqsen->getNamespace();
     }
 }

--- a/src/Phan/Language/Element/ClassElement.php
+++ b/src/Phan/Language/Element/ClassElement.php
@@ -176,29 +176,12 @@ abstract class ClassElement extends AddressableElement
         );
     }
 
-    /**
-     * @param CodeBase $code_base
-     * The code base in which this element exists.
-     *
-     * @return bool
-     * True if this element is intern
-     */
-    public function isNSInternalAccessFromContext(
-        CodeBase $code_base,
-        Context $context
-    ) : bool {
+    public function getElementNamespace(CodeBase $code_base) : string
+    {
         // Get the class that this element is defined on
         $class = $this->getClass($code_base);
 
         // Get the namespace that the class is within
-        $element_namespace = $class->getFQSEN()->getNamespace();
-
-        // Get our current namespace
-        $context_namespace = $context->getNamespace();
-
-        // Test to see if the context is within the same
-        // namespace as where the element is defined
-        return (0 === strcasecmp($context_namespace, $element_namespace));
+        return $class->getFQSEN()->getNamespace() ?: '\\';
     }
-
 }

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -184,4 +184,6 @@ interface FunctionInterface extends AddressableElementInterface {
      * This function's parameter list may or may not have been modified.
      */
     public function analyzeWithNewParams(Context $context, CodeBase $code_base) : Context;
+
+    public function getElementNamespace(CodeBase $code_base) : string;
 }

--- a/src/Phan/Output/Colorizing.php
+++ b/src/Phan/Output/Colorizing.php
@@ -73,6 +73,7 @@ class Colorizing {
         'ISSUETYPE_NORMAL' => 'light_red',  // for normal issues
         'LINE'          => 'light_gray',
         'METHOD'        => 'light_yellow',
+        'NAMESPACE'     => 'green',
         'PARAMETER'     => 'cyan',
         'PROPERTY'      => 'cyan',
         'TYPE'          => 'light_gray',

--- a/tests/files/expected/0278_internal_elements.php.expected
+++ b/tests/files/expected/0278_internal_elements.php.expected
@@ -1,11 +1,11 @@
-%s:92 PhanAccessMethodInternal Cannot access internal method \NS278\A\f defined at %s:33
-%s:94 PhanAccessConstantInternal Cannot access internal constant \NS278\A\CONST_INTERNAL defined at %s:8
-%s:96 PhanAccessMethodInternal Cannot access internal method \NS278\A\C1::__construct defined at %s:39
-%s:97 PhanAccessPropertyInternal Cannot access internal property \NS278\A\C1::p defined at %s:13
-%s:98 PhanAccessMethodInternal Cannot access internal method \NS278\A\C1::f defined at %s:14
+%s:92 PhanAccessMethodInternal Cannot access internal method \NS278\A\f of namespace \NS278\A defined at %s:33 from namespace \NS278\B
+%s:94 PhanAccessConstantInternal Cannot access internal constant \NS278\A\CONST_INTERNAL of namepace \NS278\A defined at %s:8 from namespace \NS278\B
+%s:96 PhanAccessMethodInternal Cannot access internal method \NS278\A\C1::__construct of namespace \NS278\A defined at %s:39 from namespace \NS278\B
+%s:97 PhanAccessPropertyInternal Cannot access internal property \NS278\A\C1::p of namespace \NS278\A defined at %s:13 from namespace \NS278\B
+%s:98 PhanAccessMethodInternal Cannot access internal method \NS278\A\C1::f of namespace \NS278\A defined at %s:14 from namespace \NS278\B
 %s:99 PhanAccessClassConstantInternal Cannot access internal class constant \NS278\A\C1::CONST_INTERNAL defined at %s:12
-%s:102 PhanAccessPropertyInternal Cannot access internal property \NS278\A\C2::p defined at %s:24
-%s:103 PhanAccessMethodInternal Cannot access internal method \NS278\A\C2::f defined at %s:27
+%s:102 PhanAccessPropertyInternal Cannot access internal property \NS278\A\C2::p of namespace \NS278\A defined at %s:24 from namespace \NS278\B
+%s:103 PhanAccessMethodInternal Cannot access internal method \NS278\A\C2::f of namespace \NS278\A defined at %s:27 from namespace \NS278\B
 %s:106 PhanAccessClassConstantInternal Cannot access internal class constant \NS278\A\C2::CONST_INTERNAL defined at %s:21
 %s:108 PhanAccessClassInternal Cannot access internal Class \NS278\A\C1 defined at %s:11
 %s:108 PhanAccessClassInternal Cannot access internal Interface \NS278\A\I2 defined at %s:53


### PR DESCRIPTION
Context->getNamespace() will (sometimes?) return the empty string, not '\\',
if the current namespace is empty.