### PR TITLE
Fixes Issue #852 : Appropriate warning message for directly invoking parent::__construct

### DIFF
--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -414,6 +414,9 @@ class ContextNode
      * @param bool $is_static
      * Set to true if this is a static method call
      *
+     * @param bool $is_direct
+     * Set to true if this is directly invoking the method (guaranteed not to be special syntax)
+     *
      * @return Method
      * A method with the given name on the class referenced
      * from the given node
@@ -433,7 +436,8 @@ class ContextNode
      */
     public function getMethod(
         $method_name,
-        bool $is_static
+        bool $is_static,
+        bool $is_direct = false
     ) : Method {
 
         if ($method_name instanceof Node) {
@@ -514,7 +518,7 @@ class ContextNode
         // Hunt to see if any of them have the method we're
         // looking for
         foreach ($class_list as $i => $class) {
-            if ($class->hasMethodWithName($this->code_base, $method_name)) {
+            if ($class->hasMethodWithName($this->code_base, $method_name, $is_direct)) {
                 return $class->getMethodByNameInContext(
                     $this->code_base,
                     $method_name,

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -812,6 +812,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
 
             $method = $context_node->getMethod(
                 '__construct',
+                false,
                 false
             );
 
@@ -1149,7 +1150,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 $this->code_base,
                 $this->context,
                 $node
-            ))->getMethod($method_name, true);
+            ))->getMethod($method_name, true, true);
         } catch (IssueException $exception) {
             Issue::maybeEmitInstance(
                 $this->code_base,

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1076,11 +1076,8 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         string $static_class,
         string $method_name
     ) {
-        if ($static_class === 'parent') {
-            return;
-        }
         // TODO: what about unanalyzable?
-        if ($node->children['class']->kind != \ast\AST_NAME) {
+        if ($node->children['class']->kind !== \ast\AST_NAME) {
             return;
         }
         $class_context_node = (new ContextNode(
@@ -1099,8 +1096,21 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             if (!$possible_ancestor_type->isEmpty()) {
                 // but forbid 'self::__construct', 'static::__construct'
                 $type = $this->context->getClassFQSEN()->asUnionType();
-                if ($type->asExpandedTypes($this->code_base)->canCastToUnionType($possible_ancestor_type)
-                        && !$type->canCastToUnionType($possible_ancestor_type)) {
+                if ($possible_ancestor_type->hasStaticType()) {
+                    $this->emitIssue(
+                        Issue::AccessOwnConstructor,
+                        $node->lineno ?? 0,
+                        $static_class
+                    );
+                    $found_ancestor_constructor = true;
+                } else if ($type->asExpandedTypes($this->code_base)->canCastToUnionType($possible_ancestor_type)) {
+                    if ($type->canCastToUnionType($possible_ancestor_type)) {
+                        $this->emitIssue(
+                            Issue::AccessOwnConstructor,
+                            $node->lineno ?? 0,
+                            $static_class
+                        );
+                    }
                     $found_ancestor_constructor = true;
                 }
             }

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -155,6 +155,7 @@ class Issue
     const AccessClassConstantPrivate     = 'PhanAccessClassConstantPrivate';
     const AccessClassConstantProtected   = 'PhanAccessClassConstantProtected';
     const AccessPropertyStaticAsNonStatic = 'PhanAccessPropertyStaticAsNonStatic';
+    const AccessOwnConstructor = 'PhanAccessOwnConstructor';
 
     const AccessConstantInternal    = 'PhanAccessConstantInternal';
     const AccessClassInternal       = 'PhanAccessClassInternal';
@@ -1333,7 +1334,15 @@ class Issue
                 self::AccessPropertyStaticAsNonStatic,
                 self::CATEGORY_ACCESS,
                 self::SEVERITY_CRITICAL,
-                "Accessing static property %s as non static",
+                "Accessing static property {PROPERTY} as non static",
+                self::REMEDIATION_B,
+                1010
+            ),
+            new Issue(
+                self::AccessOwnConstructor,
+                self::CATEGORY_ACCESS,
+                self::SEVERITY_NORMAL,
+                "Accessing own constructor directly via {CLASS}::__construct",
                 self::REMEDIATION_B,
                 1010
             ),

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -1208,11 +1208,12 @@ class Clazz extends AddressableElement
      */
     public function hasMethodWithName(
         CodeBase $code_base,
-        string $name
+        string $name,
+        bool $is_direct_invocation = false
     ) : bool {
         // All classes have a constructor even if it hasn't
         // been declared yet
-        if ('__construct' === strtolower($name)) {
+        if (!$is_direct_invocation && '__construct' === strtolower($name)) {
             return true;
         }
 

--- a/tests/files/expected/0261_skip_constructor.php.expected
+++ b/tests/files/expected/0261_skip_constructor.php.expected
@@ -2,6 +2,6 @@
 %s:26 PhanUndeclaredClassMethod Call to method __construct from undeclared class \Missing261
 %s:26 PhanUndeclaredStaticMethod Static call to undeclared method Missing261::__construct()
 %s:37 PhanUndeclaredStaticMethod Static call to undeclared method Other261::__construct()
-%s:49 PhanUndeclaredStaticMethod Static call to undeclared method self::__construct()
-%s:55 PhanUndeclaredStaticMethod Static call to undeclared method static::__construct()
-%s:61 PhanUndeclaredStaticMethod Static call to undeclared method Self261C::__construct()
+%s:49 PhanAccessOwnConstructor Accessing own constructor directly via self::__construct
+%s:55 PhanAccessOwnConstructor Accessing own constructor directly via static::__construct
+%s:61 PhanAccessOwnConstructor Accessing own constructor directly via Self261C::__construct

--- a/tests/files/expected/0310_self_construct.php.expected
+++ b/tests/files/expected/0310_self_construct.php.expected
@@ -1,0 +1,6 @@
+%s:15 PhanAccessOwnConstructor Accessing own constructor directly via self::__construct
+%s:15 PhanTypeMismatchArgument Argument 1 (arg) is string but \Foo310::__construct() takes int defined at %s:10
+%s:16 PhanAccessOwnConstructor Accessing own constructor directly via static::__construct
+%s:16 PhanTypeMismatchArgument Argument 1 (arg) is string but \Foo310::__construct() takes int defined at %s:10
+%s:17 PhanParamTooMany Call with 1 arg(s) to \Bar310::__construct() which only takes 0 arg(s) defined at %s:4
+%s:21 PhanTypeMismatchArgument Argument 1 (arg) is string but \Foo310::__construct() takes int defined at %s:10

--- a/tests/files/expected/0310_self_construct.php.expected
+++ b/tests/files/expected/0310_self_construct.php.expected
@@ -1,6 +1,8 @@
-%s:15 PhanAccessOwnConstructor Accessing own constructor directly via self::__construct
-%s:15 PhanTypeMismatchArgument Argument 1 (arg) is string but \Foo310::__construct() takes int defined at %s:10
-%s:16 PhanAccessOwnConstructor Accessing own constructor directly via static::__construct
-%s:16 PhanTypeMismatchArgument Argument 1 (arg) is string but \Foo310::__construct() takes int defined at %s:10
-%s:17 PhanParamTooMany Call with 1 arg(s) to \Bar310::__construct() which only takes 0 arg(s) defined at %s:4
-%s:21 PhanTypeMismatchArgument Argument 1 (arg) is string but \Foo310::__construct() takes int defined at %s:10
+%s:8 PhanUndeclaredStaticMethod Static call to undeclared method \Baz310::__construct
+%s:19 PhanAccessOwnConstructor Accessing own constructor directly via self::__construct
+%s:19 PhanTypeMismatchArgument Argument 1 (arg) is string but \Foo310::__construct() takes int defined at %s:14
+%s:20 PhanAccessOwnConstructor Accessing own constructor directly via static::__construct
+%s:20 PhanTypeMismatchArgument Argument 1 (arg) is string but \Foo310::__construct() takes int defined at %s:14
+%s:21 PhanParamTooMany Call with 1 arg(s) to \Bar310::__construct() which only takes 0 arg(s) defined at %s:7
+%s:25 PhanTypeMismatchArgument Argument 1 (arg) is string but \Foo310::__construct() takes int defined at %s:14
+%s:27 PhanParamTooMany Call with 1 arg(s) to \Baz310::__construct() which only takes 0 arg(s) defined at %s:27


### PR DESCRIPTION
Catch the case where parent has no real constructor, but `parent::__construct()` is invoked.

Warn in some cases when directly invoking self::__construct and static::__construct within a class.
