### PR TITLE
Improve inferences on condition visitors(for/while/if)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,11 @@ New Features (Analysis)
   `analyze_signature_compatibility` must also be set to true (default is true) for this step to be performed.
 + Better analysis of calls to parent::__construct(). (Issue #852)
 + Warn with `PhanAccessOwnConstructor` if directly invoking self::__construct or static::__construct in some cases (partial).
++ Start analyzing the inside of for/while loops using the loop's condition (Issue #859)
+  (Inferences may leak to outside of those loops. `do{} while(cond)` is not specially analyzed yet)
++ Improve analysis of types in expressions within compound conditions (Issue #847)
+  (E.g. `if (is_array($x) && fn_expecting_array($x)) {...}`)
++ Evaluate the third part of a for loop with the context after the inner body is evaluated (Issue #477)
 
 New Features (CLI, Configs)
 

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -700,19 +700,10 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
      */
     public function visitIfElem(Node $node) : Context
     {
-        if (!isset($node->children['cond'])
-            || !($node->children['cond'] instanceof Node)
-        ) {
+        $cond = $node->children['cond'] ?? null;
+        if (!($cond instanceof Node)) {
             return $this->context;
         }
-
-        // Get the type just to make sure everything
-        // is defined.
-        $expression_type = UnionType::fromNode(
-            $this->context,
-            $this->code_base,
-            $node->children['cond']
-        );
 
         // Look to see if any proofs we do within the condition
         // can say anything about types within the statement
@@ -720,7 +711,55 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         return (new ConditionVisitor(
             $this->code_base,
             $this->context
-        ))($node->children['cond']);
+        ))($cond);
+    }
+
+    /**
+     * @param Node $node
+     * A node to parse
+     *
+     * @return Context
+     * A new or an unchanged context resulting from
+     * parsing the node
+     */
+    public function visitWhile(Node $node) : Context
+    {
+        $cond = $node->children['cond'];
+        if (!($cond instanceof Node)) {
+            return $this->context;
+        }
+
+        // Look to see if any proofs we do within the condition of the while
+        // can say anything about types within the statement
+        // list.
+        return (new ConditionVisitor(
+            $this->code_base,
+            $this->context
+        ))($cond);
+    }
+
+    /**
+     * @param Node $node
+     * A node to parse
+     *
+     * @return Context
+     * A new or an unchanged context resulting from
+     * parsing the node
+     */
+    public function visitFor(Node $node) : Context
+    {
+        $cond = $node->children['cond'];
+        if (!($cond instanceof Node)) {
+            return $this->context;
+        }
+
+        // Look to see if any proofs we do within the condition of the while
+        // can say anything about types within the statement
+        // list.
+        return (new ConditionVisitor(
+            $this->code_base,
+            $this->context
+        ))($cond);
     }
 
     /**

--- a/tests/files/expected/0311_condition_visitor_throw.php.expected
+++ b/tests/files/expected/0311_condition_visitor_throw.php.expected
@@ -1,0 +1,18 @@
+%s:17 PhanUndeclaredVariable Variable $x is undeclared
+%s:18 PhanUndeclaredVariable Variable $x2 is undeclared
+%s:19 PhanUndeclaredVariable Variable $z is undeclared
+%s:20 PhanUndeclaredVariable Variable $a is undeclared
+%s:21 PhanUndeclaredVariable Variable $b is undeclared
+%s:23 PhanUndeclaredVariable Variable $strTypo is undeclared
+%s:24 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
+%s:25 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
+%s:26 PhanUndeclaredVariable Variable $c is undeclared
+%s:27 PhanUndeclaredVariable Variable $unaryMissing1 is undeclared
+%s:28 PhanUndeclaredVariable Variable $unaryMissing2 is undeclared
+%s:30 PhanUndeclaredVariable Variable $unaryMissing3 is undeclared
+%s:31 PhanUndeclaredVariable Variable $c2 is undeclared
+%s:33 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
+%s:35 PhanUndeclaredVariable Variable $unaryMissing3 is undeclared
+%s:36 PhanUndeclaredVariable Variable $c2 is undeclared
+%s:38 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
+%s:39 PhanUndeclaredVariable Variable $x3 is undeclared

--- a/tests/files/expected/0312_for_loop_loop_after_statements.php.expected
+++ b/tests/files/expected/0312_for_loop_loop_after_statements.php.expected
@@ -1,0 +1,1 @@
+%s:16 PhanTypeMismatchArgumentInternal Argument 1 (string) is \Node312|int but \strlen() takes string

--- a/tests/files/src/0310_self_construct.php
+++ b/tests/files/src/0310_self_construct.php
@@ -1,0 +1,27 @@
+<?php
+
+class Baz310 {
+}
+
+class Bar310 extends Baz310 {
+    public function __construct() {
+        parent::__construct(23);  // The explicit constructor doesn't exist.
+    }
+}
+
+class Foo310 extends Bar310 {
+    public $arg;
+    public function __construct(int $arg) {
+        $this->arg = $arg;
+    }
+
+    public function myMethod() {
+        self::__construct('y');
+        static::__construct('z');
+        parent::__construct('z');  // this is incorrect.
+    }
+}
+// error happens with/without the below lines.
+$f310 = new Foo310('x');
+$f310->myMethod();
+$g310 = new Baz310('a');  // too many args for the implicit constructor

--- a/tests/files/src/0311_condition_visitor_throw.php
+++ b/tests/files/src/0311_condition_visitor_throw.php
@@ -1,0 +1,45 @@
+<?php
+// Verify that phan can handle weird assertions in ConditionVisitor without throwing.
+// TODO: Emit issues, update test to check for issues.
+/**
+ * @param int $str
+ */
+function testcondition311($y, $str) {
+    if (!0) { }
+    if (!STDERR) { }
+    if (!!0) { }
+    if (!1) { }
+    if (!null) { }
+    if (!!1) { }
+    if (!'') { }
+    if (!'aa') { }
+    if (!0.0) { }
+    if ($y && !$x) { }  // should emit undefined
+    if ($y && $x2) { }  // should emit undefined
+    if (!$z) { }  // should emit undefined
+    if (!is_null($a)) { }  // should emit undefined
+    if ($y && is_string($b)) { }  // should emit undefined
+    if (is_string($str) && strlen($str) > 0) { }  // should not warn
+    if (is_string($str) && strlen($strTypo) > 0) { }  // should not warn
+    if (is_string($str) && intdiv($str, 10)) { }  // should warn
+    if (($inCondVar = 3) && strlen($inCondVar) > 0) { }  // should warn
+    if ($c ?? false) { }  // should emit undefined
+    if (~$unaryMissing1) { }  // should emit undefined
+    if (-$unaryMissing2) { }  // should emit undefined
+
+    while (~$unaryMissing3) { }  // should emit undefined
+    while ($c2 ?? false) { }  // should emit undefined
+    while (is_string($str) && strlen($str) > 0) { }  // should not warn
+    while (is_string($str) && intdiv($str, 10) > 0) { }  // should warn
+
+    for ( ; ~$unaryMissing3; ) { }  // should emit undefined
+    for ( ; $c2 ?? false; ) { }  // should emit undefined
+    for ( ; is_string($str) && strlen($str) > 0; ) { }  // should not warn
+    for ( ; is_string($str) && intdiv($str, 10) > 0; ) { }  // should warn
+    for ( ;$y && $x3; ) { }  // should emit undefined
+
+    $last_error = error_get_last();
+    if (is_array($last_error) && $last_error['type'] === E_ERROR) {
+        // do something
+    }
+}

--- a/tests/files/src/0312_for_loop_loop_after_statements.php
+++ b/tests/files/src/0312_for_loop_loop_after_statements.php
@@ -1,0 +1,20 @@
+<?php
+
+class Node312 {
+    /** @var ?Node312 */
+    public $next;
+}
+
+function test312(Node312 $head) {
+  for ($node = $head; $node; $node = $next) {
+    $next = $node->next;
+    $node->next = null;
+  }
+}
+
+function test312Buggy(Node312 $head) {
+  for ($node = $head; $node; $node = strlen($next ?: 0)) {
+    $next = $node->next;
+    $node->next = null;
+  }
+}


### PR DESCRIPTION
Improve undefined variable detection a bit.
Start analyzing the inside of for/while loops using the loop's condition.
Better analysis of types withing compound if expressions

Fixes #747 (More complicated conditionals may still have issues)
Fixes #477 (Doesn't account for `continue` within a loop, but it's an improvement)
Fixes #859 (But the condition will start leaking out)