### PR TITLE
Fixes #841: Emit low severity warning PhanUndeclaredVarableDim

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,8 @@ New Features (Analysis)
 + Improve analysis of types in expressions within compound conditions (Issue #847)
   (E.g. `if (is_array($x) && fn_expecting_array($x)) {...}`)
 + Evaluate the third part of a for loop with the context after the inner body is evaluated (Issue #477)
++ Emit `PhanUndeclaredVariableDim` if adding an array field to an undeclared variable. (Issue #841)
+  Better analyze `list($var['field']) = values`
 
 New Features (CLI, Configs)
 

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -306,7 +306,7 @@ class ContextNode
      */
     public function getVariableName() : string
     {
-        if (!$this->node instanceof \ast\Node) {
+        if (!($this->node instanceof \ast\Node)) {
             return (string)$this->node;
         }
 
@@ -322,7 +322,7 @@ class ContextNode
             $node = array_values($node->children ?? [])[0];
         }
 
-        if (!$node instanceof \ast\Node) {
+        if (!($node instanceof \ast\Node)) {
             return (string)$node;
         }
 

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -38,6 +38,7 @@ class Issue
     const UndeclaredTypeParameter   = 'PhanUndeclaredTypeParameter';
     const UndeclaredTypeProperty    = 'PhanUndeclaredTypeProperty';
     const UndeclaredVariable        = 'PhanUndeclaredVariable';
+    const UndeclaredVariableDim     = 'PhanUndeclaredVariableDim';
 
     // Issue::CATEGORY_TYPE
     const NonClassMethodCall        = 'PhanNonClassMethodCall';
@@ -562,6 +563,14 @@ class Issue
                 "Trait alias {METHOD} has an ambiguous source method {METHOD} with more than one possible source trait. Possibilities: {TRAIT}",
                 self::REMEDIATION_B,
                 1026
+            ),
+            new Issue(
+                self::UndeclaredVariableDim,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_LOW,
+                "Variable \${VARIABLE} was undeclared, but array fields are being added to it.",
+                self::REMEDIATION_B,
+                1027
             ),
 
             // Issue::CATEGORY_ANALYSIS

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -846,6 +846,24 @@ class UnionType implements \Serializable
 
     /**
      * @return bool
+     * True if this union contains the ArrayAccess type.
+     * (Call asExpandedTypes() first to check for subclasses of ArrayAccess)
+     */
+    public function hasArrayAccess() : bool
+    {
+        if ($this->isEmpty()) {
+            return false;
+        }
+
+        return (false ===
+            $this->type_set->find(function (Type $type) : bool {
+                return !$type->isArrayAccess();
+            })
+        );
+    }
+
+    /**
+     * @return bool
      * True if this union type represents types that are
      * array-like, and nothing else (e.g. can't be null).
      * If any of the array-like types are nullable, this returns false.

--- a/src/Phan/Library/Hasher/Consistent.php
+++ b/src/Phan/Library/Hasher/Consistent.php
@@ -28,6 +28,7 @@ class Consistent implements Hasher {
             }
         }
         $hashRingIds = [];
+        $hashRingGroups = [];
         ksort($map);
         foreach ($map as $key => $group) {
             $hashRingIds[] = $key;

--- a/tests/files/expected/0135_array_assignment_type.php.expected
+++ b/tests/files/expected/0135_array_assignment_type.php.expected
@@ -1,0 +1,1 @@
+%s:5 PhanUndeclaredVariableDim Variable $arr135 was undeclared, but array fields are being added to it.

--- a/tests/files/expected/0313_undefined_array_push.php.expected
+++ b/tests/files/expected/0313_undefined_array_push.php.expected
@@ -1,0 +1,6 @@
+%s:8 PhanUndeclaredVariableDim Variable $myvar was undeclared, but array fields are being added to it.
+%s:9 PhanUndeclaredVariableDim Variable $myvAR was undeclared, but array fields are being added to it.
+%s:11 PhanUndeclaredProperty Reference to undeclared property \Foo313->prop
+%s:12 PhanUndeclaredStaticProperty Static property 'undef_static_prop' on \Foo313 is undeclared
+%s:13 PhanUndeclaredProperty Reference to undeclared property \Foo313->otherProp
+%s:13 PhanUndeclaredVariableDim Variable $myUndefListVar was undeclared, but array fields are being added to it.

--- a/tests/files/src/0135_array_assignment_type.php
+++ b/tests/files/src/0135_array_assignment_type.php
@@ -1,3 +1,6 @@
 <?php
-$arr['name'] = 'stuff';
-$arr['value'] = 2;
+$otherArr135 = [];
+$otherArr135['name'] = 'stuff';
+$otherArr135[] = 2;
+$arr135['name'] = 'stuff';
+$arr135['value'] = 2;

--- a/tests/files/src/0313_undefined_array_push.php
+++ b/tests/files/src/0313_undefined_array_push.php
@@ -1,0 +1,14 @@
+<?php
+
+class Foo313 {
+}
+
+function test313() {
+    $myVar = [];
+    $myvar[] = [];
+    $myvAR['x'] = [];
+    $f = new Foo313();
+    $f->prop[] = 'value';
+    Foo313::$undef_static_prop[] = 3;
+    list($myUndefListVar['x'], $f->otherProp) = [2];
+}


### PR DESCRIPTION
Emit a low severity warning if adding an array field to an undeclared
variable. (Currently, PHP will automatically create the array)

Better analyze `list($arr['field']) = someExpression()`

If Phan can't determine the variable name, don't add definition
for the empty string to the context. (Probably a bug)