### PR TITLE
Various improvements for handling phpdoc types when real type signatures exist

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -48,8 +48,26 @@ return [
     // Backwards Compatibility Checking
     'backward_compatibility_checks' => false,
 
-    // Backwards Compatibility Checking
+    // If true, check to make sure the return type declared
+    // in the doc-block (if any) matches the return type
+    // declared in the method signature. This process is
+    // slow.
     'check_docblock_signature_return_type_match' => true,
+
+    // If true, check to make sure the return type declared
+    // in the doc-block (if any) matches the return type
+    // declared in the method signature. This process is
+    // slow.
+    'check_docblock_signature_param_type_match' => true,
+
+    // (*Requires check_docblock_signature_param_type_match to be true*)
+    // If true, make narrowed types from phpdoc override
+    // the real types from the signature, when real types exist.
+    // Ignore incompatible or wider phpdoc union types.
+    // (E.g. allows specifying desired lists of subclasses,
+    //  or to indicate a preference for non-nullable types over nullable types)
+    // Affects analysis of the body of the method and the param types passed in by callers.
+    'prefer_narrowed_phpdoc_param_types' => true,
 
     // If enabled, check all methods that override a
     // parent method to make sure its signature is

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -48,6 +48,9 @@ return [
     // Backwards Compatibility Checking
     'backward_compatibility_checks' => false,
 
+    // Backwards Compatibility Checking
+    'check_docblock_signature_return_type_match' => true,
+
     // If enabled, check all methods that override a
     // parent method to make sure its signature is
     // compatible with the parent's. This check

--- a/NEWS
+++ b/NEWS
@@ -15,8 +15,18 @@ New Features (Analysis)
 + Evaluate the third part of a for loop with the context after the inner body is evaluated (Issue #477)
 + Emit `PhanUndeclaredVariableDim` if adding an array field to an undeclared variable. (Issue #841)
   Better analyze `list($var['field']) = values`
++ Improve accuracy of `PhanTypeMismatchDeclaredReturn` (Move the check to after params are parsed)
++ Create `PhanTypeMismatchDeclaredParam` (Move the check to after params are parsed)
+  Also `prefer_narrowed_phpdoc_param_type` (See "New Features (CLI, Configs))
 
 New Features (CLI, Configs)
++ Create `check_docblock_signature_param_type_match` (similar to `check_docblock_signature_return_type_match`) config setting
+  to enable warning if phpdoc types are incompatible with the real types. False by default.
+
+  Create `prefer_narrowed_phpdoc_param_type` (requires `check_docblock_signature_return_type_match`)
+  to analyze phpdoc param types instead of provided signature types if the possible phpdoc types are narrower and compatible.
+  (E.g. indicate that subclasses are expected over base classes, indicate that non-nullable is expected instead of nullable)
+  This affects analysis both inside and outside the method.
 
 Maintenance
 

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -4,6 +4,7 @@ namespace Phan;
 use Phan\AST\ASTSimplifier;
 use Phan\Analysis\DuplicateFunctionAnalyzer;
 use Phan\Analysis\ParameterTypesAnalyzer;
+use Phan\Analysis\ReturnTypesAnalyzer;
 use Phan\Analysis\ReferenceCountsAnalyzer;
 use Phan\Language\Context;
 use Phan\Language\Element\Clazz;
@@ -211,6 +212,7 @@ class Analysis
             if (is_array($file_filter) && !isset($file_filter[$function_or_method->getContext()->getFile()])) {
                 continue;
             }
+
             DuplicateFunctionAnalyzer::analyzeDuplicateFunction(
                 $code_base, $function_or_method
             );
@@ -218,6 +220,10 @@ class Analysis
             // This is the most time consuming step.
             // Can probably apply this to other functions, but this was the slowest.
             ParameterTypesAnalyzer::analyzeParameterTypes(
+                $code_base, $function_or_method
+            );
+
+            ReturnTypesAnalyzer::analyzeReturnTypes(
                 $code_base, $function_or_method
             );
             // Let any plugins analyze the methods or functions

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1830,7 +1830,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
      * The argument whose type we'd like to replace the
      * parameter type with.
      *
-     * @param Node|mixed $argument_type
+     * @param UnionType $argument_type
      * The type of $argument
      *
      * @param int $parameter_offset

--- a/src/Phan/Analysis/ReturnTypesAnalyzer.php
+++ b/src/Phan/Analysis/ReturnTypesAnalyzer.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+namespace Phan\Analysis;
+
+use Phan\CodeBase;
+use Phan\Config;
+use Phan\Issue;
+use Phan\Language\Element\Clazz;
+use Phan\Language\Element\FunctionInterface;
+use Phan\Language\Element\Method;
+use Phan\Language\Element\Parameter;
+use Phan\Language\FQSEN\FullyQualifiedClassName;
+use Phan\Language\Type\IterableType;
+use Phan\Language\Type\MixedType;
+use Phan\Language\Type\TemplateType;
+
+class ReturnTypesAnalyzer
+{
+
+    /**
+     * Check method return types (phpdoc and real) to make sure they're valid
+     *
+     * @return void
+     */
+    public static function analyzeReturnTypes(
+        CodeBase $code_base,
+        FunctionInterface $method
+    ) {
+        $real_return_type = $method->getRealReturnType();
+        $phpdoc_return_type = $method->getUnionType();
+        $context = $method->getContext();
+        if (Config::get()->check_docblock_signature_return_type_match && !$real_return_type->isEmpty() && !$phpdoc_return_type->isEmpty()) {
+            $resolved_real_return_type = $real_return_type->withStaticResolvedInContext($context);
+            foreach ($phpdoc_return_type->getTypeSet() as $phpdoc_type) {
+                // Make sure that the commented type is a narrowed
+                // or equivalent form of the syntax-level declared
+                // return type.
+                if (!$phpdoc_type->isExclusivelyNarrowedFormOrEquivalentTo(
+                        $resolved_real_return_type,
+                        $context,
+                        $code_base
+                    )
+                ) {
+                    if (!$method->hasSuppressIssue(Issue::TypeMismatchDeclaredReturn)) {
+                        Issue::maybeEmit(
+                            $code_base,
+                            $context,
+                            Issue::TypeMismatchDeclaredReturn,
+                            $context->getLineNumberStart(),
+                            $method->getName(),
+                            $phpdoc_type->__toString(),
+                            $real_return_type->__toString()
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -188,7 +188,7 @@ class CodeBase
     }
 
     /**
-     * @return string[] - The size of $this->getParsedFilePathList()
+     * @return int The size of $this->getParsedFilePathList()
      */
     public function getParsedFilePathCount() : int {
         if ($this->undo_tracker) {

--- a/src/Phan/CodeBase/UndoTracker.php
+++ b/src/Phan/CodeBase/UndoTracker.php
@@ -51,10 +51,9 @@ class UndoTracker {
     }
 
     /**
-     * @return string[] - The size of $this->getParsedFilePathList()
+     * @return int The size of $this->getParsedFilePathList()
      */
     public function getParsedFilePathCount() : int {
-
         return count($this->fileModificationState);
     }
 

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -158,8 +158,22 @@ class Config
         // If true, check to make sure the return type declared
         // in the doc-block (if any) matches the return type
         // declared in the method signature. This process is
-        // slow.
+        // probably still slow.
         'check_docblock_signature_return_type_match' => false,
+
+        // If true, check to make sure the param types declared
+        // in the doc-block (if any) matches the param types
+        // declared in the method signature. This process is
+        // probably still low.
+        'check_docblock_signature_param_type_match' => false,
+
+        // (*Requires check_docblock_signature_param_type_match to be true*)
+        // If true, make narrowed types from phpdoc override
+        // the real types from the signature, when real types exist.
+        // (E.g. allows specifying desired lists of subclasses,
+        //  or to indicate a preference for non-nullable types over nullable types)
+        // Affects analysis of the body of the method and the param types passed in by callers.
+        'prefer_narrowed_phpdoc_param_type' => false,
 
         // Set to true in order to attempt to detect dead
         // (unreferenced) code. Keep in mind that the

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -644,7 +644,7 @@ class Issue
                 self::TypeMismatchDeclaredReturn,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_NORMAL,
-                "Doc-block declares return type {TYPE} which is incompatible with the return type {TYPE} declared in the signature",
+                "Doc-block of {METHOD} declares return type {TYPE} which is incompatible with the return type {TYPE} declared in the signature",
                 self::REMEDIATION_B,
                 10020
             ),

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -62,6 +62,7 @@ class Issue
     const TypeMismatchProperty      = 'PhanTypeMismatchProperty';
     const TypeMismatchReturn        = 'PhanTypeMismatchReturn';
     const TypeMismatchDeclaredReturn = 'PhanTypeMismatchDeclaredReturn';
+    const TypeMismatchDeclaredParam = 'PhanTypeMismatchDeclaredParam';
     const TypeMissingReturn         = 'PhanTypeMissingReturn';
     const TypeNonVarPassByRef       = 'PhanTypeNonVarPassByRef';
     const TypeParentConstructorCalled = 'PhanTypeParentConstructorCalled';
@@ -644,9 +645,17 @@ class Issue
                 self::TypeMismatchDeclaredReturn,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_NORMAL,
-                "Doc-block of {METHOD} declares return type {TYPE} which is incompatible with the return type {TYPE} declared in the signature",
+                "Doc-block of {METHOD} contains declared return type {TYPE} which is incompatible with the return type {TYPE} declared in the signature",
                 self::REMEDIATION_B,
                 10020
+            ),
+            new Issue(
+                self::TypeMismatchDeclaredParam,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "Doc-block of \${VARIABLE} in {METHOD} contains phpdoc param type {TYPE} which is incompatible with the param type {TYPE} declared in the signature",
+                self::REMEDIATION_B,
+                10021
             ),
             new Issue(
                 self::TypeMissingReturn,

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -141,7 +141,7 @@ class Clazz extends AddressableElement
      * A reference to the entire code base in which this
      * context exists
      *
-     * @param ReflectionClass $class
+     * @param \ReflectionClass $class
      * A reflection class representing a builtin class.
      *
      * @return Clazz

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -369,8 +369,7 @@ class Clazz extends AddressableElement
 
         $this->parent_type = $parent_type;
 
-        // Add the parent to the union type of this
-        // class
+        // Add the parent to the union type of this class
         $this->getUnionType()->addUnionType(
             $parent_type->asUnionType()
         );

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -152,7 +152,7 @@ class Comment
      * @param string[] $template_type_list
      * A list of template types parameterizing a generic class
      *
-     * @param Option<Type> $inherited_type
+     * @param Option<Type>|None $inherited_type (Note: some issues with templates and narrowing signature types to phpdoc type, added None as a workaround)
      * An override on the type of the extended class
      *
      * @param UnionType $return_union_type
@@ -164,7 +164,7 @@ class Comment
      *
      * @param CommentMethod[] $magic_method_list
      *
-     * @param Option<Type> $closure_scope
+     * @param Option<Type>|None $closure_scope
      * For closures: Allows us to document the class of the object
      * to which a closure will be bound.
      */
@@ -227,6 +227,8 @@ class Comment
      * @return Comment
      * A comment built by parsing the given doc block
      * string.
+     *
+     * suppress PhanTypeMismatchArgument - Still need to work out issues with prefer_narrowed_phpdoc_param_type
      */
     public static function fromStringInContext(
         string $comment,

--- a/src/Phan/Language/Element/Func.php
+++ b/src/Phan/Language/Element/Func.php
@@ -141,7 +141,7 @@ class Func extends AddressableElement implements FunctionInterface
      *
      * @param CodeBase $code_base
      *
-     * @param Node $node
+     * @param Decl $node
      * An AST node representing a function
      *
      * @param FullyQualifiedFunctionName $fqsen

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -193,4 +193,22 @@ interface FunctionInterface extends AddressableElementInterface {
      * The type of this method in its given context.
      */
     public function getRealReturnType() : UnionType;
+
+    /**
+     * @return Parameter[]
+     * A list of parameters on the method, with types from the method signature.
+     */
+    public function getRealParameterList();
+
+    /**
+     * @param UnionType[] maps a subset of param names to the unmodified phpdoc parameter types.
+     * Will differ from real parameter types (ideally narrower)
+     * @return void
+     */
+    public function setPHPDocParameterTypeMap(array $parameter_map);
+
+    /**
+     * @return UnionType[] maps a subset of param names to the unmodified phpdoc parameter types.
+     */
+    public function getPHPDocParameterTypeMap();
 }

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -3,6 +3,7 @@ namespace Phan\Language\Element;
 
 use Phan\CodeBase;
 use Phan\Language\Context;
+use Phan\Language\UnionType;
 use Phan\Language\FQSEN\FullyQualifiedFunctionName;
 use Phan\Language\FQSEN\FullyQualifiedMethodName;
 use Phan\Language\Scope\ClosedScope;
@@ -186,4 +187,10 @@ interface FunctionInterface extends AddressableElementInterface {
     public function analyzeWithNewParams(Context $context, CodeBase $code_base) : Context;
 
     public function getElementNamespace(CodeBase $code_base) : string;
+
+    /**
+     * @return UnionType
+     * The type of this method in its given context.
+     */
+    public function getRealReturnType() : UnionType;
 }

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -380,27 +380,6 @@ class Method extends ClassElement implements FunctionInterface
                 }
             }
 
-            if (Config::get()->check_docblock_signature_return_type_match) {
-                // Make sure that the commented type is a narrowed
-                // or equivalent form of the syntax-level declared
-                // return type.
-                if (!$comment_return_union_type->isExclusivelyNarrowedFormOrEquivalentTo(
-                        $return_union_type,
-                        $context,
-                        $code_base
-                    )
-                ) {
-                    Issue::maybeEmit(
-                        $code_base,
-                        $context,
-                        Issue::TypeMismatchDeclaredReturn,
-                        $node->lineno ?? 0,
-                        $comment_return_union_type->__toString(),
-                        $return_union_type->__toString()
-                    );
-                }
-            }
-
             $method->getUnionType()->addUnionType($comment_return_union_type);
         }
 

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -32,7 +32,7 @@ class Parameter extends Variable
     private $default_value = null;
 
     /**
-     * @param \phan\Context $context
+     * @param Context $context
      * The context in which the structural element lives
      *
      * @param string $name

--- a/src/Phan/Language/FQSEN/Alternatives.php
+++ b/src/Phan/Language/FQSEN/Alternatives.php
@@ -68,7 +68,6 @@ trait Alternatives
     /**
      * @return static
      * A FQSEN with the given alternate_id set
-     *
      * @suppress PhanTypeMismatchDeclaredReturn
      */
     abstract public function withAlternateId(

--- a/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
@@ -243,7 +243,7 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
     }
 
     /**
-     * @param string|null $namespace
+     * @param string $namespace (can be empty)
      *
      * @return string
      * A cleaned version of the given namespace such that
@@ -253,7 +253,6 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
     protected static function cleanNamespace(string $namespace) : string
     {
         if (!$namespace
-            || empty($namespace)
             || $namespace === '\\'
         ) {
             return '\\';

--- a/src/Phan/Language/Type/MixedType.php
+++ b/src/Phan/Language/Type/MixedType.php
@@ -1,7 +1,10 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
+use Phan\CodeBase;
+use Phan\Language\Context;
 use Phan\Language\Type;
+use Phan\Language\UnionType;
 
 class MixedType extends NativeType
 {
@@ -17,5 +20,15 @@ class MixedType extends NativeType
     // For purposes of analysis, there's no difference between mixed and nullable mixed.
     protected function canCastToNonNullableType(Type $type) : bool {
         return true;
+    }
+
+    public function isExclusivelyNarrowedFormOrEquivalentTo(
+        UnionType $union_type,
+        Context $context,
+        CodeBase $code_base
+    ) : bool {
+        // Type casting rules allow mixed to cast to anything.
+        // But we don't want `@param mixed $x` to take precedence over `int $x` in the signature.
+        return $union_type->hasType($this);
     }
 }

--- a/src/Phan/Language/Type/ScalarType.php
+++ b/src/Phan/Language/Type/ScalarType.php
@@ -4,6 +4,8 @@ namespace Phan\Language\Type;
 use Phan\CodeBase;
 use Phan\Config;
 use Phan\Language\Type;
+use Phan\Language\UnionType;
+use Phan\Language\Context;
 
 abstract class ScalarType extends NativeType
 {
@@ -68,4 +70,14 @@ abstract class ScalarType extends NativeType
         return parent::canCastToNonNullableType($type);
     }
 
+    /**
+     * @override
+     */
+    public function isExclusivelyNarrowedFormOrEquivalentTo(
+        UnionType $union_type,
+        Context $context,
+        CodeBase $code_base
+    ) : bool {
+        return $union_type->hasType($this) || $this->asUnionType()->canCastToUnionType($union_type);
+    }
 }

--- a/src/Phan/Language/Type/StaticType.php
+++ b/src/Phan/Language/Type/StaticType.php
@@ -1,7 +1,10 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
+use Phan\CodeBase;
+use Phan\Language\Context;
 use Phan\Language\Type;
+use Phan\Language\UnionType;
 
 final class StaticType extends Type
 {
@@ -67,5 +70,36 @@ final class StaticType extends Type
         }
 
         return $string;
+    }
+
+    /**
+     * @return Type
+     * Either this or 'static' resolved in the given context.
+     */
+    public function withStaticResolvedInContext(
+        Context $context
+    ) : Type {
+        // If the context isn't in a class scope, there's nothing
+        // we can do
+        if (!$context->isInClassScope()) {
+            return $this;
+        }
+        $type = $context->getClassFQSEN()->asType();
+        if ($this->getIsNullable()) {
+            return $type->withIsNullable(true);
+        }
+        return $type;
+    }
+
+    public function isExclusivelyNarrowedFormOrEquivalentTo(
+        UnionType $union_type,
+        Context $context,
+        CodeBase $code_base
+    ) : bool {
+        $result = $this->withStaticResolvedInContext($context);
+        if ($result !== $this) {
+            return $result->isExclusivelyNarrowedFormOrEquivalentTo($union_type, $context, $code_base);
+        }
+        return false;
     }
 }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -631,6 +631,8 @@ class UnionType implements \Serializable
      * True if each type within this union type can cast
      * to the given union type.
      */
+    // Currently unused and buggy, commenting this out.
+    /**
     public function isExclusivelyNarrowedFormOrEquivalentTo(
         UnionType $union_type,
         Context $context,
@@ -678,6 +680,7 @@ class UnionType implements \Serializable
         }
         return true;
     }
+     */
 
     /**
      * @param Type[] $type_list
@@ -1178,7 +1181,7 @@ class UnionType implements \Serializable
     }
 
     /**
-     * @param Closure $closure
+     * @param \Closure $closure
      * A closure mapping `Type` to `Type`
      *
      * @return UnionType

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -16,6 +16,7 @@ use Phan\Language\Type\IntType;
 use Phan\Language\Type\MixedType;
 use Phan\Language\Type\NullType;
 use Phan\Language\Type\ObjectType;
+use Phan\Language\Type\StaticType;
 use Phan\Language\Type\TemplateType;
 use Phan\Library\Set;
 use ast\Node;
@@ -458,11 +459,14 @@ class UnionType implements \Serializable
      */
     public function hasStaticType() : bool
     {
-        return (false !==
-            $this->type_set->find(function (Type $type) : bool {
-                return $type->isStaticType();
-            })
-        );
+        static $static_type;
+        static $static_nullable_type;
+        if ($static_type === null) {
+            $static_type = StaticType::instance(false);
+            $static_nullable_type = StaticType::instance(true);
+        }
+        return $this->type_set->contains($static_type) ||
+            $this->type_set->contains($static_nullable_type);
     }
 
     /**
@@ -480,13 +484,18 @@ class UnionType implements \Serializable
             return $this;
         }
 
-        // Find the static type on the list
-        $static_type = $this->getTypeSet()->find(function (Type $type) : bool {
-            return $type->isStaticType();
-        });
+        static $static_type;
+        static $static_nullable_type;
+        if ($static_type === null) {
+            $static_type = StaticType::instance(false);
+            $static_nullable_type = StaticType::instance(true);
+        }
 
-        // If we don't actually have a static type, we're all set
-        if (!$static_type) {
+        $has_static_type = $this->type_set->contains($static_type);
+        $has_static_nullable_type = $this->type_set->contains($static_nullable_type);
+
+        // If this doesn't reference 'static', there's nothing to do.
+        if (!($has_static_type || $has_static_nullable_type)) {
             return $this;
         }
 
@@ -496,10 +505,17 @@ class UnionType implements \Serializable
         $union_type = clone($this);
 
         // Remove the static type
-        $union_type->removeType($static_type);
+        if ($has_static_type) {
+            $union_type->removeType($static_type);
 
-        // Add in the class in scope
-        $union_type->addType($context->getClassFQSEN()->asType());
+            // Add in the class in scope
+            $union_type->addType($context->getClassFQSEN()->asType());
+        } else {
+            $union_type->removeType($static_type);
+
+            // Add in the nullable class in scope
+            $union_type->addType($context->getClassFQSEN()->asType()->withIsNullable(true));
+        }
 
         return $union_type;
     }
@@ -622,7 +638,8 @@ class UnionType implements \Serializable
     ) : bool {
 
         // Special rule: anything can cast to nothing
-        if ($union_type->isEmpty()) {
+        // and nothing can cast to anything
+        if ($union_type->isEmpty() || $this->isEmpty()) {
             return true;
         }
 
@@ -630,30 +647,36 @@ class UnionType implements \Serializable
         if ($this->isEqualTo($union_type)) {
             return true;
         }
+        // TODO: Allow casting MyClass<TemplateType> to MyClass (Without the template?
 
         // Resolve 'static' for the given context to
         // determine whats actually being referred
         // to in concrete terms.
-        $union_type =
+        $other_resolved_type =
             $union_type->withStaticResolvedInContext($context);
+        $other_resolved_type_set = $other_resolved_type->type_set;
 
-        // Convert this type to an array of resolved
-        // types.
-        $type_set =
-            $this->withStaticResolvedInContext($context)
-            ->getTypeSet()->toArray();
+        // Convert this type to a set of resolved types to iterate over.
+        $this_resolved_type_set =
+            $this->withStaticResolvedInContext($context)->type_set;
+
+        // TODO: Need to resolve expanded union types (parents, interfaces) of classes *before* this is called.
 
         // Test to see if every single type in this union
         // type can cast to the given union type.
-        return array_reduce($type_set,
-            function (bool $can_cast, Type $type) use($union_type, $code_base) : bool {
-                return (
-                    $can_cast
-                    && $type->asUnionType()->asExpandedTypes($code_base)->canCastToUnionType(
-                        $union_type
-                    )
-                );
-            }, true);
+        foreach ($this_resolved_type_set as $type) {
+            // First check if this contains the type as an optimization.
+            if ($other_resolved_type_set->contains($type)) {
+                continue;
+            }
+            $expanded_types = $type->asExpandedTypes($code_base);
+            if ($other_resolved_type->canCastToUnionType(
+                $expanded_types
+            )) {
+                continue;
+            }
+        }
+        return true;
     }
 
     /**

--- a/src/Phan/Memoize.php
+++ b/src/Phan/Memoize.php
@@ -61,7 +61,7 @@ trait Memoize
      * The key to use for storing the result of the
      * computation.
      *
-     * @param Closure $fn
+     * @param \Closure $fn
      * A function to compute only once for the given
      * $key.
      *

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -63,7 +63,7 @@ class ParseVisitor extends ScopeVisitor
     /**
      * Visit a node with kind `\ast\AST_CLASS`
      *
-     * @param Node $node
+     * @param Decl $node
      * A node to parse
      *
      * @return Context
@@ -286,7 +286,7 @@ class ParseVisitor extends ScopeVisitor
     /**
      * Visit a node with kind `\ast\AST_METHOD`
      *
-     * @param Node $node
+     * @param Decl $node
      * A node to parse
      *
      * @return Context
@@ -622,7 +622,7 @@ class ParseVisitor extends ScopeVisitor
     /**
      * Visit a node with kind `\ast\AST_FUNC_DECL`
      *
-     * @param Node $node
+     * @param Decl $node
      * A node to parse
      *
      * @return Context

--- a/tests/.phan/config.php
+++ b/tests/.phan/config.php
@@ -32,6 +32,14 @@ return [
     // slow.
     'check_docblock_signature_return_type_match' => true,
 
+    // If true, check to make sure the return type declared
+    // in the doc-block (if any) matches the return type
+    // declared in the method signature. This process is
+    // slow.
+    'check_docblock_signature_param_type_match' => true,
+
+    'prefer_narrowed_phpdoc_param_type' => true,
+
     // A set of fully qualified class-names for which
     // a call to parent::__construct() is required.
     'parent_constructor_required' => ['Child283'],

--- a/tests/Phan/CodeBaseAwareTestInterface.php
+++ b/tests/Phan/CodeBaseAwareTestInterface.php
@@ -6,7 +6,7 @@ use Phan\CodeBase;
 
 interface CodeBaseAwareTestInterface {
 
-    /** @param CodeBase $codeBase */
+    /** @param ?CodeBase $codeBase */
     public function setCodeBase(CodeBase $codeBase = null);
 
 }

--- a/tests/files/expected/0253_return_type_match.php.expected
+++ b/tests/files/expected/0253_return_type_match.php.expected
@@ -1,2 +1,6 @@
-%s:4 PhanTypeMismatchDeclaredReturn Doc-block declares return type string which is incompatible with the return type int declared in the signature
-%s:26 PhanTypeMismatchDeclaredReturn Doc-block declares return type \C253_1 which is incompatible with the return type \C253_2 declared in the signature
+%s:4 PhanTypeMismatchDeclaredReturn Doc-block of f1 contains declared return type string which is incompatible with the return type int declared in the signature
+%s:21 PhanTypeMismatchDeclaredReturn Doc-block of a5 contains declared return type iterable which is incompatible with the return type array declared in the signature
+%s:33 PhanTypeMismatchDeclaredReturn Doc-block of a8 contains declared return type string which is incompatible with the return type iterable declared in the signature
+%s:42 PhanTypeMismatchDeclaredReturn Doc-block of a10 contains declared return type ?int which is incompatible with the return type int declared in the signature
+%s:57 PhanTypeMismatchDeclaredReturn Doc-block of f6 contains declared return type \C253_1 which is incompatible with the return type \C253_2 declared in the signature
+%s:61 PhanTypeMismatchDeclaredReturn Doc-block of f7 contains declared return type \C253_1 which is incompatible with the return type \C253_2 declared in the signature

--- a/tests/files/expected/0314_param_type_match.php.expected
+++ b/tests/files/expected/0314_param_type_match.php.expected
@@ -1,0 +1,11 @@
+%s:4 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in f1 contains phpdoc param type string which is incompatible with the param type int declared in the signature
+%s:15 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in f4 contains phpdoc param type iterable which is incompatible with the param type array declared in the signature
+%s:18 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in f5 contains phpdoc param type iterable which is incompatible with the param type array declared in the signature
+%s:24 PhanTypeMismatchDeclaredParam Doc-block of $arg2 in f6 contains phpdoc param type iterable which is incompatible with the param type array declared in the signature
+%s:24 PhanTypeMismatchDeclaredParam Doc-block of $arg2 in f6 contains phpdoc param type string which is incompatible with the param type array declared in the signature
+%s:33 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in f9 contains phpdoc param type string which is incompatible with the param type iterable declared in the signature
+%s:37 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in a10 contains phpdoc param type ?int which is incompatible with the param type int declared in the signature
+%s:58 PhanTypeMismatchReturn Returning type int[] but a13() is declared to return int
+%s:75 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in g2 contains phpdoc param type \C314_1 which is incompatible with the param type \C314_2 declared in the signature
+%s:79 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in g3 contains phpdoc param type \C314_1 which is incompatible with the param type \C314_2 declared in the signature
+%s:84 PhanTypeMismatchArgumentInternal Argument 1 (string) is int[] but \strlen() takes string

--- a/tests/files/src/0253_return_type_match.php
+++ b/tests/files/src/0253_return_type_match.php
@@ -16,14 +16,49 @@ class C253_1 {
     public static function f4() : C253_1 {
         return new static();
     }
+
+    /** @return iterable (Widening) */
+    public function a5() : array {
+        return array('a', 'b', 'c');
+    }
+    /** @return array (narrowing, allowed) */
+    public function a6() : iterable {
+        return array('a', 'b', 'c');
+    }
+    /** @return Traversable (narrowing, allowed) */
+    public function a7() : iterable {
+        return array('a', 'b', 'c');
+    }
+    /** @return string (incompatible, not allowed) */
+    public function a8() : iterable {
+        return array('a', 'b', 'c');
+    }
+    /** @return static (narrowing) */
+    public function a9() : self {
+        return new static();
+    }
+
+    /** @return ?int (widening, not allowed) */
+    public function a10() : int {
+        return 42;
+    }
+
+    /** @return int (narrowing) */
+    public function a11() : ?int {
+        return 42;
+    }
 }
 class C253_2 extends C253_1 {
-    /** @return C253_2 */
+    /** @return C253_2 (narrowing, allowed) */
     public function f5() : C253_1 {
         return new C253_2;
     }
-    /** @return C253_1 */
+    /** @return C253_1 (widening, not allowed) */
     public function f6() : C253_2 {
         return new C253_2;
+    }
+    /** @return C253_1 (widening, not allowed) */
+    public function f7() : self {
+        return new static();
     }
 }

--- a/tests/files/src/0314_param_type_match.php
+++ b/tests/files/src/0314_param_type_match.php
@@ -1,0 +1,86 @@
+<?php
+class C314_1 {
+    /** @param string $arg1 */
+    public function f1(int $arg1) {
+    }
+    /** @param string[] $arg1 */
+    public function f2(array $arg1) {
+        return array('a', 'b', 'c');
+    }
+    /** @param static $arg1 */
+    public function f3(self $arg1) {
+    }
+
+    /** @param iterable $arg1 (Widening, not allowed) */
+    public function f4(array $arg1) {
+    }
+    /** @param iterable|array $arg1 (Widening to include iterable, not allowed) */
+    public function f5(array $arg1) {
+    }
+    /**
+     * @param string $arg1
+     * @param string|iterable $arg2 (Widening, not allowed
+     */
+    public function f6(string $arg1, array $arg2) {
+    }
+    /** @param array $arg1 (narrowing, allowed) */
+    public function f7(iterable $arg1) {
+    }
+    /** @param Traversable $arg1 (narrowing, allowed) */
+    public function f8(iterable $arg1) {
+    }
+    /** @param string $arg1 (incompatible, not allowed) */
+    public function f9(iterable $arg1) {
+    }
+
+    /** @param ?int $arg1 (widening, not allowed) */
+    public function a10(int $arg1) {
+    }
+
+    /** @return int $arg1 (narrowing) */
+    public function a11(?int $arg1) {
+        return 42;
+    }
+
+    /**
+     * @param int... $vararg1
+     * @return int[]
+     */
+    public function a12(int ...$vararg1) {
+        return $vararg1;
+    }
+
+    /**
+     * @param int... $vararg1
+     * @return int (Should warn)
+     */
+    public function a13(int ...$vararg1) {
+        return $vararg1;
+    }
+
+    /**
+     * @param C314_2... $vararg1
+     * @return C314_1[]
+     */
+    public function a14(C314_1 ...$vararg1) {
+        return $vararg1;
+    }
+}
+class C314_2 extends C314_1 {
+    /** @param C314_2 $arg1 (narrowing, allowed) */
+    public function g1(C314_1 $arg1) {
+        return new C314_2;
+    }
+    /** @param C314_1 $arg1 (widening, not allowed) */
+    public function g2(C314_2 $arg1) {
+    }
+
+    /** @param C314_1 $arg1 (widening, not allowed) */
+    public function g3(self $arg1) {
+    }
+
+    /** @param int[] $x */
+    public function g4(array $x) {
+        return strlen($x);  // should warn, this is int.
+    }
+}


### PR DESCRIPTION
(These options are disabled by default, but Phan's self-analysis enables all of these.)

Enhance checks when phpdoc param types are narrower signature's types

Also, improve PhanTypeMismatchDeclaredReturn performance and accuracy

Emit PhanTypeMismatchDeclaredParam if any of the types in the phpdoc
union type are incompatible or wider (compared to the actual signature).

Also introduced in this PR: if phan is configured with
`prefer_narrowed_phpdoc_param_types`, then prefer phpdoc types if
they're compatible and narrower with real types.
(E.g. analyze methods as if they had the signature `Type[]` over `array`)

Fix issues this new config setting detected within Phan itself.

Related to #505 , but for params
