### PR TITLE
Fixes #835: Detect undeclared return type at point of declaration

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,7 @@ New Features (Analysis)
 + Improve accuracy of `PhanTypeMismatchDeclaredReturn` (Move the check to after params are parsed)
 + Create `PhanTypeMismatchDeclaredParam` (Move the check to after params are parsed)
   Also `prefer_narrowed_phpdoc_param_type` (See "New Features (CLI, Configs))
++ Detect undeclared return types at point of declaration, and emit `PhanUndeclaredTypeReturnType` (Issue #835)
 
 New Features (CLI, Configs)
 + Create `check_docblock_signature_param_type_match` (similar to `check_docblock_signature_return_type_match`) config setting

--- a/src/Phan/Analysis/ReturnTypesAnalyzer.php
+++ b/src/Phan/Analysis/ReturnTypesAnalyzer.php
@@ -27,8 +27,47 @@ class ReturnTypesAnalyzer
     ) {
         $real_return_type = $method->getRealReturnType();
         $phpdoc_return_type = $method->getUnionType();
-        $context = $method->getContext();
+        // Look at each parameter to make sure their types
+        // are valid
+
+        // Look at each type in the parameter's Union Type
+        foreach ($real_return_type->getTypeSet() as $type) {
+            // If its a native type or a reference to
+            // self, its OK
+            if ($type->isNativeType() || ($method instanceof Method && ($type->isSelfType() || $type->isStaticType()))) {
+                continue;
+            }
+
+            if ($type instanceof TemplateType) {
+                if ($method instanceof Method) {
+                    if ($method->isStatic()) {
+                        Issue::maybeEmit(
+                            $code_base,
+                            $method->getContext(),
+                            Issue::TemplateTypeStaticMethod,
+                            $method->getFileRef()->getLineNumberStart(),
+                            (string)$method->getFQSEN()
+                        );
+                    }
+                }
+            } else {
+                // Make sure the class exists
+                $type_fqsen = $type->asFQSEN();
+                assert($type_fqsen instanceof FullyQualifiedClassName, 'non-native types must be class names');
+                if (!$code_base->hasClassWithFQSEN($type_fqsen)) {
+                    Issue::maybeEmit(
+                        $code_base,
+                        $method->getContext(),
+                        Issue::UndeclaredTypeReturnType,
+                        $method->getFileRef()->getLineNumberStart(),
+                        $method->getName(),
+                        (string)$type_fqsen
+                    );
+                }
+            }
+        }
         if (Config::get()->check_docblock_signature_return_type_match && !$real_return_type->isEmpty() && !$phpdoc_return_type->isEmpty()) {
+            $context = $method->getContext();
             $resolved_real_return_type = $real_return_type->withStaticResolvedInContext($context);
             foreach ($phpdoc_return_type->getTypeSet() as $phpdoc_type) {
                 // Make sure that the commented type is a narrowed

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -36,6 +36,7 @@ class Issue
     const UndeclaredStaticProperty  = 'PhanUndeclaredStaticProperty';
     const UndeclaredTrait           = 'PhanUndeclaredTrait';
     const UndeclaredTypeParameter   = 'PhanUndeclaredTypeParameter';
+    const UndeclaredTypeReturnType  = 'PhanUndeclaredTypeReturnType';
     const UndeclaredTypeProperty    = 'PhanUndeclaredTypeProperty';
     const UndeclaredVariable        = 'PhanUndeclaredVariable';
     const UndeclaredVariableDim     = 'PhanUndeclaredVariableDim';
@@ -572,6 +573,14 @@ class Issue
                 "Variable \${VARIABLE} was undeclared, but array fields are being added to it.",
                 self::REMEDIATION_B,
                 1027
+            ),
+            new Issue(
+                self::UndeclaredTypeReturnType,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_NORMAL,
+                "Return type of {METHOD} is undeclared type {TYPE}",
+                self::REMEDIATION_B,
+                1028
             ),
 
             // Issue::CATEGORY_ANALYSIS

--- a/src/Phan/Language/Element/Func.php
+++ b/src/Phan/Language/Element/Func.php
@@ -251,6 +251,7 @@ class Func extends AddressableElement implements FunctionInterface
                 $code_base,
                 $node->children['returnType']
             );
+            $func->setRealReturnType($union_type);
 
             $func->getUnionType()->addUnionType($union_type);
         }

--- a/tests/files/expected/0098_undef.php.expected
+++ b/tests/files/expected/0098_undef.php.expected
@@ -12,3 +12,5 @@
 %s:37 PhanTraitParentReference Reference to parent from trait \T
 %s:40 PhanParentlessClass Reference to parent of class \G that does not extend anything
 %s:43 PhanUndeclaredExtendedClass Class extends undeclared class \Undef
+%s:46 PhanUndeclaredTypeReturnType Return type of j is undeclared type \Undef
+%s:49 PhanUndeclaredTypeReturnType Return type of k is undeclared type \self

--- a/tests/files/expected/0263_alias_outside_phpdoc.php.expected
+++ b/tests/files/expected/0263_alias_outside_phpdoc.php.expected
@@ -2,6 +2,7 @@
 %s:4 PhanUndeclaredTypeParameter Parameter of undeclared type \callback
 %s:4 PhanUndeclaredTypeParameter Parameter of undeclared type \double
 %s:4 PhanUndeclaredTypeParameter Parameter of undeclared type \integer
+%s:4 PhanUndeclaredTypeReturnType Return type of foo263 is undeclared type \boolean
 %s:5 PhanTypeMismatchReturn Returning type bool but foo263() is declared to return \boolean
 %s:7 PhanTypeMismatchArgument Argument 1 (a) is bool but \foo263() takes \boolean defined at %s:4
 %s:7 PhanTypeMismatchArgument Argument 2 (b) is int but \foo263() takes \integer defined at %s:4

--- a/tests/files/src/0098_undef.php
+++ b/tests/files/src/0098_undef.php
@@ -42,3 +42,8 @@ class G { function f() { parent::f(); } }
 // Issue::UndeclaredParentClass
 class H extends Undef {}
 
+// Issue::UndeclaredTypeReturnType
+function j() : Undef {throw new RuntimeException('not implemented');}
+
+// Issue::UndeclaredTypeReturnType
+function k() : self {throw new RuntimeException('not implemented');}


### PR DESCRIPTION
This is done the same way and in the same phase as PhanUndeclaredTypeParameter