### PR TITLE
Don't pass the context for a hardcoded global type; add test

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -110,7 +110,8 @@ return [
     'consistent_hashing_file_order' => false,
 
     // Override to hardcode existence and types of (non-builtin) globals.
-    // Class names must be prefixed with '\\'.
+    // Class names should be prefixed with '\\'.
+    // (E.g. ['_FOO' => '\\FooClass', 'page' => '\\PageClass', 'userId' => 'int'])
     'globals_type_map' => [],
 
     // The minimum severity level to report on. This can be

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1033,7 +1033,7 @@ class UnionTypeVisitor extends AnalysisVisitor
 
         if (!$this->context->getScope()->hasVariableWithName($variable_name)) {
             if (Variable::isHardcodedVariableInScopeWithName($variable_name, $this->context->isInGlobalScope())) {
-                return Variable::getUnionTypeOfHardcodedGlobalVariableWithName($variable_name, $this->context);
+                return Variable::getUnionTypeOfHardcodedGlobalVariableWithName($variable_name);
             }
             if (!Config::get()->ignore_undeclared_variables_in_global_scope
                 || !$this->context->isInGlobalScope()

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -287,7 +287,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             false
         );
         $variable_name = $variable->getName();
-        $optional_global_variable_type = Variable::getUnionTypeOfHardcodedGlobalVariableWithName($variable_name, $this->context);
+        $optional_global_variable_type = Variable::getUnionTypeOfHardcodedGlobalVariableWithName($variable_name);
         if ($optional_global_variable_type) {
             $variable->setUnionType($optional_global_variable_type);
         } else {

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -365,7 +365,7 @@ class Config
         'runkit_superglobals' => [],
 
         // Override to hardcode existence and types of (non-builtin) globals in the global scope.
-        // Class names must be prefixed with '\\'.
+        // Class names should be prefixed with '\\'.
         // (E.g. ['_FOO' => '\\FooClass', 'page' => '\\PageClass', 'userId' => 'int'])
         'globals_type_map' => [],
 

--- a/src/Phan/Language/Element/Variable.php
+++ b/src/Phan/Language/Element/Variable.php
@@ -189,8 +189,7 @@ class Variable extends TypedElement
      * otherwise.
      */
     public static function getUnionTypeOfHardcodedGlobalVariableWithName(
-        string $name,
-        Context $context
+        string $name
     ) {
         if (array_key_exists($name, self::_BUILTIN_GLOBAL_TYPES)) {
             // More efficient than using context.
@@ -202,7 +201,7 @@ class Variable extends TypedElement
         ) {
             $type_string = $config->globals_type_map[$name] ?? '';
             // Want to allow 'resource' or 'mixed' as a type here,
-            return UnionType::fromStringInContext($type_string, $context, Type::FROM_PHPDOC);
+            return UnionType::fromStringInContext($type_string, new Context(), Type::FROM_PHPDOC);
         }
 
         return null;

--- a/tests/plugin_test/.phan/config.php
+++ b/tests/plugin_test/.phan/config.php
@@ -47,6 +47,8 @@ return [
     // Test dead code detection
     'dead_code_detection' => true,
 
+    'globals_type_map' => ['test_global_exception' => 'Exception', 'test_global_error' => '\\Error'],
+
     "quick_mode" => false,
 
     'generic_types_enabled' => true,

--- a/tests/plugin_test/expected/all_output.expected
+++ b/tests/plugin_test/expected/all_output.expected
@@ -10,3 +10,7 @@ src/000_plugins.php:47 PhanPluginNumericalComparison non numerical values compar
 src/000_plugins.php:49 PhanPluginNumericalComparison numerical values compared by the operators '===' or '!=='
 src/000_plugins.php:55 UnusedSuppression Element \testUnusedSuppressionPlugin suppresses issue PhanParamTooFew but does not use it
 src/000_plugins.php:61 PhanUnreferencedMethod Possibly zero references to method \testUnreferencedFunction
+src/001_globals_type_map.php:5 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \Exception|\Throwable but \intdiv() takes int
+src/001_globals_type_map.php:8 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \Error|\Throwable but \intdiv() takes int
+src/001_globals_type_map.php:12 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \Exception|\Throwable but \intdiv() takes int
+src/001_globals_type_map.php:15 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \Error|\Throwable but \intdiv() takes int

--- a/tests/plugin_test/src/001_globals_type_map.php
+++ b/tests/plugin_test/src/001_globals_type_map.php
@@ -1,0 +1,16 @@
+<?php
+
+// Should resolve 'globals_type_map' relative to root namespace, no matter where it's used
+namespace Foo {
+    echo intdiv($test_global_exception, 2);
+    echo $test_global_exception->getMessage();
+    echo $test_global_error->getMessage();
+    echo intdiv($test_global_error, 2);
+}
+
+namespace {
+    echo intdiv($test_global_exception, 2);
+    echo $test_global_exception->getMessage();
+    echo $test_global_error->getMessage();
+    echo intdiv($test_global_error, 2);
+}


### PR DESCRIPTION
It doesn't make sense to do that.
If the type wasn't namespaced, it would be relative to the context's
namespace (when missing '\\'), and the context namespace varies.