### PR TITLE
Fixes #873: Warn about classes extending trait/interface/final classes.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -20,7 +20,8 @@ New Features (Analysis)
   Also `prefer_narrowed_phpdoc_param_type` (See "New Features (CLI, Configs))
 + Detect undeclared return types at point of declaration, and emit `PhanUndeclaredTypeReturnType` (Issue #835)
 + Create `PhanParamSignaturePHPDocMismatch*` issue types, for mismatches between `@method` and real signature/other `@method` tag.
-
++ Create `PhanAccessWrongInheritanceCategory*` issue types to warn about classes extending a trait/interface instead of class, etc. (#873)
++ Create `PhanExtendsFinalClass*` issue types to warn about classes extending from final classes.
 
 New Features (CLI, Configs)
 + Create `check_docblock_signature_param_type_match` (similar to `check_docblock_signature_return_type_match`) config setting

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -177,6 +177,10 @@ class Issue
     const AccessClassConstantInternal = 'PhanAccessClassConstantInternal';
     const AccessPropertyInternal    = 'PhanAccessPropertyInternal';
     const AccessMethodInternal      = 'PhanAccessMethodInternal';
+    const AccessWrongInheritanceCategory = 'PhanAccessWrongInheritanceCategory';
+    const AccessWrongInheritanceCategoryInternal = 'PhanAccessWrongInheritanceCategoryInternal';
+    const AccessExtendsFinalClass   = 'PhanAccessExtendsFinalClass';
+    const AccessExtendsFinalClassInternal = 'PhanAccessExtendsFinalClassInternal';
 
     // Issue::CATEGORY_COMPATIBLE
     const CompatibleExpressionPHP7  = 'PhanCompatibleExpressionPHP7';
@@ -251,6 +255,7 @@ class Issue
     // Keep sorted and in sync with Colorizing::default_color_for_template
     const uncolored_format_string_for_template = [
         'CLASS'         => '%s',
+        'CLASSLIKE'     => '%s',
         'COMMENT'       => '%s',
         'CONST'         => '%s',
         'COUNT'         => '%d',
@@ -1496,6 +1501,38 @@ class Issue
                 "Cannot access private method {METHOD} defined at {FILE}:{LINE} (if this call should be handled by __call, consider adding a @method tag to the class)",
                 self::REMEDIATION_B,
                 1012
+            ),
+            new Issue(
+                self::AccessWrongInheritanceCategory,
+                self::CATEGORY_ACCESS,
+                self::SEVERITY_CRITICAL,
+                "Attempting to inherit {CLASSLIKE} defined at {FILE}:{LINE} as if it were a {CLASSLIKE}",
+                self::REMEDIATION_B,
+                1013
+            ),
+            new Issue(
+                self::AccessWrongInheritanceCategoryInternal,
+                self::CATEGORY_ACCESS,
+                self::SEVERITY_CRITICAL,
+                "Attempting to inherit internal {CLASSLIKE} as if it were a {CLASSLIKE}",
+                self::REMEDIATION_B,
+                1014
+            ),
+            new Issue(
+                self::AccessExtendsFinalClass,
+                self::CATEGORY_ACCESS,
+                self::SEVERITY_CRITICAL,
+                "Attempting to extend from final class {CLASS} defined at {FILE}:{LINE}",
+                self::REMEDIATION_B,
+                1015
+            ),
+            new Issue(
+                self::AccessExtendsFinalClassInternal,
+                self::CATEGORY_ACCESS,
+                self::SEVERITY_CRITICAL,
+                "Attempting to extend from final internal class {CLASS}",
+                self::REMEDIATION_B,
+                1016
             ),
 
             // Issue::CATEGORY_COMPATIBLE

--- a/src/Phan/Output/Colorizing.php
+++ b/src/Phan/Output/Colorizing.php
@@ -60,6 +60,7 @@ class Colorizing {
     // In future PRs, it will be possible for users to add their own color schemes in .phan/config.php
     const default_color_for_template = [
         'CLASS'         => 'green',
+        'CLASSLIKE'     => 'green',
         'COMMENT'       => 'light_green',
         'CONST'         => 'light_red',
         'COUNT'         => 'light_magenta',

--- a/tests/files/expected/0316_incompatible_extend.php.expected
+++ b/tests/files/expected/0316_incompatible_extend.php.expected
@@ -1,0 +1,7 @@
+%s:9 PhanAccessWrongInheritanceCategory Attempting to inherit Trait \Trait316 defined at %s:7 as if it were a Class
+%s:9 PhanAccessWrongInheritanceCategory Attempting to inherit abstract Class \Abstract316 defined at %s:3 as if it were a Interface
+%s:11 PhanAccessWrongInheritanceCategoryInternal Attempting to inherit internal Class \Exception as if it were a Trait
+%s:11 PhanAccessWrongInheritanceCategoryInternal Attempting to inherit internal Class \SplObjectStorage as if it were a Interface
+%s:11 PhanAccessWrongInheritanceCategory Attempting to inherit Interface \Interface316 defined at %s:5 as if it were a Trait
+%s:16 PhanAccessWrongInheritanceCategoryInternal Attempting to inherit internal Class \Exception as if it were a Interface
+%s:20 PhanAccessWrongInheritanceCategoryInternal Attempting to inherit internal abstract Interface \ArrayAccess as if it were a Trait

--- a/tests/files/expected/0317_extend_final_class.php.expected
+++ b/tests/files/expected/0317_extend_final_class.php.expected
@@ -1,0 +1,2 @@
+%s:4 PhanAccessExtendsFinalClass Attempting to extend from final class \MyFinalClass317 defined at %s:2
+%s:6 PhanAccessExtendsFinalClassInternal Attempting to extend from final internal class \Closure

--- a/tests/files/src/0292_undefined_abstract_method.php
+++ b/tests/files/src/0292_undefined_abstract_method.php
@@ -25,7 +25,7 @@ class D292 extends C292 {
     public function f1(int $x) { }
 }
 
-class ETrait292 {
+trait ETrait292 {
     public function f1(int $x) { }
 }
 

--- a/tests/files/src/0316_incompatible_extend.php
+++ b/tests/files/src/0316_incompatible_extend.php
@@ -1,0 +1,22 @@
+<?php
+
+abstract class Abstract316 {}
+
+interface Interface316 {}
+
+trait Trait316 {}
+
+class BadInheritance316 extends Trait316 implements Interface316, Abstract316 {}
+
+class BadInheritanceInternal316 implements SplObjectStorage {
+    use Exception;
+    use Interface316;
+}
+
+interface MyBadExceptionInterface316 extends Exception { }
+
+interface MyGoodInterface extends ArrayAccess {}
+
+interface MyBadInternalInterfaceUsage316 {
+    use ArrayAccess;
+}

--- a/tests/files/src/0317_extend_final_class.php
+++ b/tests/files/src/0317_extend_final_class.php
@@ -1,0 +1,8 @@
+<?php
+final class MyFinalClass317 {}
+
+final class MyInvalidClass317 extends MyFinalClass317 {}
+
+class MyClosure317 extends Closure {}
+
+


### PR DESCRIPTION
Related to #581 (Only checks for final classes, doesn't check for final methods)