### PR TITLE
Fixes #581: Check for methods overriding final methods.

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -73,6 +73,7 @@ return [
     // parent method to make sure its signature is
     // compatible with the parent's. This check
     // can add quite a bit of time to the analysis.
+    // This will also check if final methods are overridden, etc.
     'analyze_signature_compatibility' => true,
 
     // Set to true in order to attempt to detect dead

--- a/NEWS
+++ b/NEWS
@@ -22,6 +22,7 @@ New Features (Analysis)
 + Create `PhanParamSignaturePHPDocMismatch*` issue types, for mismatches between `@method` and real signature/other `@method` tag.
 + Create `PhanAccessWrongInheritanceCategory*` issue types to warn about classes extending a trait/interface instead of class, etc. (#873)
 + Create `PhanExtendsFinalClass*` issue types to warn about classes extending from final classes.
++ Create `PhanAccessOverridesFinalMethod*` issue types to warn about methods overriding final methods.
 
 New Features (CLI, Configs)
 + Create `check_docblock_signature_param_type_match` (similar to `check_docblock_signature_return_type_match`) config setting

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -3,6 +3,7 @@ namespace Phan\Analysis;
 
 use Phan\CodeBase;
 use Phan\Config;
+use Phan\Exception\CodeBaseException;
 use Phan\Issue;
 use Phan\Language\Element\Clazz;
 use Phan\Language\Element\FunctionInterface;
@@ -105,8 +106,42 @@ class ParameterTypesAnalyzer
             return;
         }
 
-        // Get the method that is being overridden
-        $o_method = $method->getOverriddenMethod($code_base);
+        // Get the method(s) that are being overridden
+        // E.g. if the subclass, the parent class, and an interface the subclass implements implement a method,
+        //      then this has to check two different overrides (Subclass overriding parent class, and subclass overriding abstract method in interface)
+        try {
+            $o_method_list = $method->getOverriddenMethods($code_base);
+        } catch(CodeBaseException $e) {
+            // TODO: Remove if no edge cases are seen.
+            Issue::maybeEmit(
+                $code_base,
+                $method->getContext(),
+                Issue::UnanalyzableInheritance,
+                $method->getFileRef()->getLineNumberStart(),
+                $method->getFQSEN()
+            );
+            return;
+        }
+        foreach ($o_method_list as $o_method) {
+            self::analyzeOverrideSignatureForOverriddenMethod($code_base, $method, $class, $o_method);
+        }
+    }
+
+    /**
+     * Make sure signatures line up between methods and a method it overrides.
+     *
+     * @see https://en.wikipedia.org/wiki/Liskov_substitution_principle
+     */
+    private static function analyzeOverrideSignatureForOverriddenMethod(
+        CodeBase $code_base,
+        Method $method,
+        Clazz $class,
+        Method $o_method
+    ) {
+        if ($o_method->isFinal()) {
+            // Even if it is a constructor, verify that a method doesn't override a final method.
+            self::warnOverridingFinalMethod($code_base, $method, $class, $o_method);
+        }
 
         // Unless it is an abstract constructor,
         // don't worry about signatures lining up on
@@ -696,6 +731,56 @@ class ParameterTypesAnalyzer
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * Warns if a method is overriding a final method
+     * @return void
+     */
+    private static function warnOverridingFinalMethod(CodeBase $code_base, Method $method, Clazz $class, Method $o_method)
+    {
+        if ($method->isFromPHPDoc()) {
+            // TODO: Track phpdoc methods separately from real methods
+            if ($method->hasSuppressIssue(Issue::AccessOverridesFinalMethodPHPDoc) || $class->hasSuppressIssue(Issue::AccessOverridesFinalMethodPHPDoc)) {
+                return;
+            }
+            Issue::maybeEmit(
+                $code_base,
+                $method->getContext(),
+                Issue::AccessOverridesFinalMethodPHPDoc,
+                $method->getFileRef()->getLineNumberStart(),
+                $method->getFQSEN(),
+                $o_method->getFQSEN(),
+                $o_method->getFileRef()->getFile(),
+                $o_method->getFileRef()->getLineNumberStart()
+            );
+        } else if ($o_method->isPHPInternal()) {
+            if ($method->hasSuppressIssue(Issue::AccessOverridesFinalMethodInternal)) {
+                return;
+            }
+            Issue::maybeEmit(
+                $code_base,
+                $method->getContext(),
+                Issue::AccessOverridesFinalMethodInternal,
+                $method->getFileRef()->getLineNumberStart(),
+                $method->getFQSEN(),
+                $o_method->getFQSEN()
+            );
+        } else {
+            if ($method->hasSuppressIssue(Issue::AccessOverridesFinalMethod)) {
+                return;
+            }
+            Issue::maybeEmit(
+                $code_base,
+                $method->getContext(),
+                Issue::AccessOverridesFinalMethod,
+                $method->getFileRef()->getLineNumberStart(),
+                $method->getFQSEN(),
+                $o_method->getFQSEN(),
+                $o_method->getFileRef()->getFile(),
+                $o_method->getFileRef()->getLineNumberStart()
+            );
         }
     }
 }

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -118,6 +118,7 @@ class Config
         // parent method to make sure its signature is
         // compatible with the parent's. This check
         // can add quite a bit of time to the analysis.
+        // This will also check if final methods are overridden, etc.
         'analyze_signature_compatibility' => true,
 
         // If enabled, inherit any missing phpdoc for types from

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -72,6 +72,7 @@ class Issue
 
     // Issue::CATEGORY_ANALYSIS
     const Unanalyzable              = 'PhanUnanalyzable';
+    const UnanalyzableInheritance   = 'PhanUnanalyzableInheritance';
 
     // Issue::CATEGORY_VARIABLE
     const VariableUseClause         = 'PhanVariableUseClause';
@@ -179,8 +180,11 @@ class Issue
     const AccessMethodInternal      = 'PhanAccessMethodInternal';
     const AccessWrongInheritanceCategory = 'PhanAccessWrongInheritanceCategory';
     const AccessWrongInheritanceCategoryInternal = 'PhanAccessWrongInheritanceCategoryInternal';
-    const AccessExtendsFinalClass   = 'PhanAccessExtendsFinalClass';
-    const AccessExtendsFinalClassInternal = 'PhanAccessExtendsFinalClassInternal';
+    const AccessExtendsFinalClass                = 'PhanAccessExtendsFinalClass';
+    const AccessExtendsFinalClassInternal        = 'PhanAccessExtendsFinalClassInternal';
+    const AccessOverridesFinalMethod             = 'PhanAccessOverridesFinalMethod';
+    const AccessOverridesFinalMethodInternal     = 'PhanAccessOverridesFinalMethodInternal';
+    const AccessOverridesFinalMethodPHPDoc     = 'PhanAccessOverridesFinalMethodPHPDoc';
 
     // Issue::CATEGORY_COMPATIBLE
     const CompatibleExpressionPHP7  = 'PhanCompatibleExpressionPHP7';
@@ -614,6 +618,14 @@ class Issue
                 self::CATEGORY_ANALYSIS,
                 self::SEVERITY_LOW,
                 "Expression is unanalyzable or feature is unimplemented. Please create an issue at https://github.com/etsy/phan/issues/new.",
+                self::REMEDIATION_B,
+                2000
+            ),
+            new Issue(
+                self::UnanalyzableInheritance,
+                self::CATEGORY_ANALYSIS,
+                self::SEVERITY_LOW,
+                "Unable to determine the method(s) which {METHOD} overrides, but Phan inferred that it did override something earlier. Please create an issue at https://github.com/etsy/phan/issues/new with a test case.",
                 self::REMEDIATION_B,
                 2000
             ),
@@ -1533,6 +1545,30 @@ class Issue
                 "Attempting to extend from final internal class {CLASS}",
                 self::REMEDIATION_B,
                 1016
+            ),
+            new Issue(
+                self::AccessOverridesFinalMethod,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_CRITICAL,
+                "Declaration of method {METHOD} overrides final method {METHOD} defined in {FILE}:{LINE}",
+                self::REMEDIATION_B,
+                1017
+            ),
+            new Issue(
+                self::AccessOverridesFinalMethodInternal,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_CRITICAL,
+                "Declaration of method {METHOD} overrides final internal method {METHOD}",
+                self::REMEDIATION_B,
+                1018
+            ),
+            new Issue(
+                self::AccessOverridesFinalMethodPHPDoc,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_LOW,
+                "Declaration of phpdoc method {METHOD} is an unnecessary override of final method {METHOD} defined in {FILE}:{LINE}",
+                self::REMEDIATION_B,
+                1019
             ),
 
             // Issue::CATEGORY_COMPATIBLE

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -1112,12 +1112,15 @@ class Clazz extends AddressableElement
         // Don't overwrite overridden methods with
         // parent methods
         if ($is_override) {
-
             // Note that we're overriding something
             // (but only do this if it's abstract)
             // TODO: Consider all permutations of abstract and real methods on classes, interfaces, and traits.
             $existing_method =
                 $code_base->getMethodByFQSEN($method_fqsen);
+            if ($method->getDefiningFQSEN() === $existing_method->getDefiningFQSEN()) {
+                return;
+            }
+
             if ($method->isAbstract() || !$existing_method->isAbstract() || $existing_method->getIsNewConstructor()) {
                 // TODO: What if both of these are abstract, and those get combined into an abstract class?
                 //       Should phan check compatibility of the abstract methods it inherits?
@@ -1132,6 +1135,9 @@ class Clazz extends AddressableElement
             $method = clone($method);
             $method->setDefiningFQSEN($method->getDefiningFQSEN());
             $method->setFQSEN($method_fqsen);
+            // When we inherit it from the ancestor class, it may be an override in the ancestor class,
+            // but that doesn't imply it's an override in *this* class.
+            $method->setIsOverride($is_override);
 
             // Clone the parameter list, so that modifying the parameters on the first call won't modify the others.
             // TODO: Make the parameter list immutable and have immutable types (e.g. getPhpdocParameterList(), setPhpdocParameterList()

--- a/tests/files/expected/0318_override_final_method.php.expected
+++ b/tests/files/expected/0318_override_final_method.php.expected
@@ -1,0 +1,8 @@
+%s:22 PhanAccessOverridesFinalMethod Declaration of method \B317::bar overrides final method \A317::bar defined in %s:4
+%s:26 PhanAccessOverridesFinalMethod Declaration of method \B317::bar2 overrides final method \A317::bar2 defined in %s:4
+%s:42 PhanAccessOverridesFinalMethod Declaration of method \PlainOverride317::baz overrides final method \PlainBase317::baz defined in %s:34
+%s:43 PhanAccessOverridesFinalMethod Declaration of method \PlainOverride317::FinalMETHOD overrides final method \PlainBase317::finalMethod defined in %s:35
+%s:45 PhanAccessOverridesFinalMethod Declaration of method \PlainOverride317::myStaticMethod overrides final method \PlainBase317::myStaticMethod defined in %s:37
+%s:51 PhanAccessOverridesFinalMethodPHPDoc Declaration of phpdoc method \PHPDocOverride317::baz is an unnecessary override of final method \PlainBase317::baz defined in %s:34
+%s:65 PhanAccessOverridesFinalMethod Declaration of method \SubclassOverridingFinalConstruct317::__construct overrides final method \BaseHasFinalConstruct317::__construct defined in %s:62
+%s:70 PhanAccessOverridesFinalMethodInternal Declaration of method \MyReflectionMethod::__clone overrides final internal method \ReflectionMethod::__clone

--- a/tests/files/expected/0319_override_parent_and_interface.php.expected
+++ b/tests/files/expected/0319_override_parent_and_interface.php.expected
@@ -1,0 +1,1 @@
+%s:20 PhanAccessOverridesFinalMethod Declaration of method \MySubclass::baz overrides final method \MyBase319::baz defined in %s:12

--- a/tests/files/src/0318_override_final_method.php
+++ b/tests/files/src/0318_override_final_method.php
@@ -1,0 +1,72 @@
+<?php
+
+trait Trait317 {
+    final function bar() { echo "Base\n"; }
+
+    function nonFinalFunction(int $x) : string { return "Can be overridden\n"; }
+
+    function plainFunction() : int{ return 42; }
+}
+
+// This shouldn't warn
+class A317 {
+    use Trait317 {
+        bar as bar2;
+        bar as bar3;
+    }
+
+    function plainFunction() : int { return 0; }
+}
+
+class B317 extends A317 {
+    public function bar() {
+    }
+
+    // This override is forbidden
+    public function bar2() {
+        echo "Override of alias\n";
+    }
+
+    public function nonFinalFunction(int $x) : string { return "A$x"; }
+}
+
+class PlainBase317 {
+    public final function baz($x) {}
+    public final function finalMethod() {}
+
+    protected static final function myStaticMethod() {}
+}
+
+class PlainOverride317 extends PlainBase317 {
+    // should warn
+    public final function baz($x) {}
+    public function FinalMETHOD() {}
+
+    protected static function myStaticMethod() {}
+}
+
+/**
+ * @method baz($x)
+ */
+class PHPDocOverride317 extends PlainBase317 {
+}
+
+/**
+ * @method baz($x)
+ * @suppress PhanAccessOverridesFinalMethodPHPDoc
+ */
+class PHPDocOverride317Suppressing extends PlainBase317 {
+}
+
+class BaseHasFinalConstruct317 {
+    public final function __construct() {}
+}
+class SubclassOverridingFinalConstruct317 extends BaseHasFinalConstruct317 {
+    public function __construct() {}
+}
+
+class MyReflectionMethod extends ReflectionMethod {
+    // should warn, the internal method is also final.
+    public function __clone() {
+    }
+}

--- a/tests/files/src/0319_override_parent_and_interface.php
+++ b/tests/files/src/0319_override_parent_and_interface.php
@@ -1,0 +1,23 @@
+<?php
+
+interface MyInterface319 {
+    public function foo(int $x) : int;
+    public function baz(string $x) : array;
+}
+
+class MyBase319 {
+    public final function foo(int $x) : int {
+        return $x * 2;
+    }
+    public final function baz(string $x) : array {
+        return [$x . 'suffix'];
+    }
+}
+
+// The fact that there's an interface with a non-final method shouldn't cause an error.
+// However, the fact that baz overrides the definition in the base class should.
+class MySubclass extends MyBase319 implements MyInterface319 {
+    public final function baz(string $x) : array {
+        return ["prefix$x"];
+    }
+}


### PR DESCRIPTION
Emit `PhanAccessOverridesFinalMethod` if a method with the `final`
keyword is overridden.

- Traits are edge cases, a class can override the definition.
  If they don't override the definition, a `final` method gets added to
  the class, which subclasses won't be able to override.

  That also applies to trait aliases.

Don't mark overriding methods inherited from parent classes as overrides
automatically, wait for them to override something else such as a
trait/interface.

0319 covers an edge case where a class overrides the same method
both in an interface and a parent class.
- Noticed uncaught CodeBaseException when fetching method override list.
  Catching it in case there are other edge cases I haven't thought of
  yet.