### PR TITLE
Fixes #913: Properly assert magic void methods don't return values

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -23,6 +23,8 @@ New Features (Analysis)
 + Create `PhanAccessWrongInheritanceCategory*` issue types to warn about classes extending a trait/interface instead of class, etc. (#873)
 + Create `PhanExtendsFinalClass*` issue types to warn about classes extending from final classes.
 + Create `PhanAccessOverridesFinalMethod*` issue types to warn about methods overriding final methods.
++ Create `PhanTypeMagicVoidWithReturn` to warn if `void` methods such as `__construct`, `__set`, etc return a value that would be ignored. (Issue #913)
++ Add check for `PhanTypeMissingReturn` within closures. Properly emit `PhanTypeMissingReturn` in functions/methods containing closures. (Issue #599)
 
 New Features (CLI, Configs)
 + Create `check_docblock_signature_param_type_match` (similar to `check_docblock_signature_return_type_match`) config setting

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -35,6 +35,7 @@ use Phan\Language\UnionType;
 use Phan\Library\None;
 use Phan\Library\Some;
 use ast\Node;
+use ast\Node\Decl;
 
 /**
  * Methods for an AST node in context
@@ -48,7 +49,7 @@ class ContextNode
     /** @var Context */
     private $context;
 
-    /** @var Node|string|null */
+    /** @var Decl|Node|string|null */
     private $node;
 
     /**
@@ -1231,7 +1232,8 @@ class ContextNode
     {
         $closure_fqsen =
             FullyQualifiedFunctionName::fromClosureInContext(
-                $this->context
+                $this->context,
+                $this->node
             );
 
         if (!$this->code_base->hasFunctionWithFQSEN($closure_fqsen)) {

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -985,7 +985,8 @@ class UnionTypeVisitor extends AnalysisVisitor
         // at its definition
         $closure_fqsen =
             FullyQualifiedFunctionName::fromClosureInContext(
-                $this->context
+                $this->context,
+                $node
             );
 
         $type = CallableType::instanceWithClosureFQSEN(

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -321,15 +321,10 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
     public function visitClosure(Decl $node) : Context
     {
         $closure_fqsen = FullyQualifiedFunctionName::fromClosureInContext(
-            $this->context->withLineNumberStart($node->lineno ?? 0)
+            $this->context->withLineNumberStart($node->lineno ?? 0),
+            $node
         );
-
-        $func = Func::fromNode(
-            $this->context,
-            $this->code_base,
-            $node,
-            $closure_fqsen
-        );
+        $func = $this->code_base->getFunctionByFQSEN($closure_fqsen);
 
         // usually the same as $this->context, unless this Closure uses @PhanClosureScope
         // Also need to override $this if bindTo is called?

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -55,6 +55,7 @@ class Issue
     const TypeInvalidClosureScope   = 'PhanTypeInvalidClosureScope';
     const TypeInvalidLeftOperand    = 'PhanTypeInvalidLeftOperand';
     const TypeInvalidRightOperand   = 'PhanTypeInvalidRightOperand';
+    const TypeMagicVoidWithReturn   = 'TypeMagicVoidWithReturn';
     const TypeMismatchArgument      = 'PhanTypeMismatchArgument';
     const TypeMismatchArgumentInternal = 'PhanTypeMismatchArgumentInternal';
     const TypeMismatchDefault       = 'PhanTypeMismatchDefault';
@@ -838,6 +839,14 @@ class Issue
                 'Indirect variable ${(expr)} has invalid inner expression type {TYPE}, expected string/integer',
                 self::REMEDIATION_B,
                 10023
+            ),
+            new Issue(
+                self::TypeMagicVoidWithReturn,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_LOW,
+                'Found a return statement with a value in the implementation of the magic method {METHOD}, expected void return type',
+                self::REMEDIATION_B,
+                10024
             ),
 
             // Issue::CATEGORY_VARIABLE

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -24,6 +24,18 @@ trait FunctionTrait {
      */
     abstract public function setPhanFlags(int $phan_flags);
 
+    /**
+     * @return string
+     * The (not fully-qualified) name of this element.
+     */
+    abstract public function getName() : string;
+
+    /**
+     * @return FQSEN
+     * The fully-qualified structural element name of this
+     * structural element
+     */
+    public abstract function getFQSEN();
 
     /**
      * @var int

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -53,7 +53,7 @@ class Method extends ClassElement implements FunctionInterface
     ) {
         parent::__construct(
             $context,
-            $name,
+            FullyQualifiedMethodName::canonicalName($name),
             $type,
             $flags,
             $fqsen
@@ -130,25 +130,19 @@ class Method extends ClassElement implements FunctionInterface
     /**
      * @return bool
      * True if this is a magic method
+     * (Names are all normalized in FullyQualifiedMethodName::make())
      */
     public function getIsMagic() : bool {
-        return in_array($this->getName(), [
-            '__call',
-            '__callStatic',
-            '__clone',
-            '__construct',
-            '__debugInfo',
-            '__destruct',
-            '__get',
-            '__invoke',
-            '__isset',
-            '__set',
-            '__set_state',
-            '__sleep',
-            '__toString',
-            '__unset',
-            '__wakeup',
-        ]);
+        return array_key_exists($this->getName(), FullyQualifiedMethodName::MAGIC_METHOD_NAME_SET);
+    }
+
+    /**
+     * @return bool
+     * True if this is a magic method which should have return type of void
+     * (Names are all normalized in FullyQualifiedMethodName::make())
+     */
+    public function getIsMagicAndVoid() : bool {
+        return array_key_exists($this->getName(), FullyQualifiedMethodName::MAGIC_VOID_METHOD_NAME_SET);
     }
 
     /**
@@ -157,7 +151,7 @@ class Method extends ClassElement implements FunctionInterface
      * (Does not return true for php4 constructors)
      */
     public function getIsNewConstructor() : bool {
-        return strcasecmp('__construct', $this->getName()) === 0;
+        return ($this->getName() === '__construct');
     }
 
     /**

--- a/src/Phan/Language/FQSEN/FullyQualifiedMethodName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedMethodName.php
@@ -7,6 +7,57 @@ namespace Phan\Language\FQSEN;
 class FullyQualifiedMethodName extends FullyQualifiedClassElement
     implements FullyQualifiedFunctionLikeName
 {
+    /**
+     * Maps lowercase versions of function names to their canonical names, for magic methods.
+     * This makes checks for magic method names more reliable.
+     */
+    const CANONICAL_NAMES = [
+        '__call'        => '__call',
+        '__callstatic'  => '__callStatic',
+        '__clone'       => '__clone',
+        '__construct'   => '__construct',
+        '__debuginfo'   => '__debugInfo',
+        '__destruct'    => '__destruct',
+        '__get'         => '__get',
+        '__invoke'      => '__invoke',
+        '__isset'       => '__isset',
+        '__set'         => '__set',
+        '__set_state'   => '__set_state',
+        '__sleep'       => '__sleep',
+        '__tostring'    => '__toString',
+        '__unset'       => '__unset',
+        '__wakeup'      => '__wakeup',
+    ];
+
+    const MAGIC_METHOD_NAME_SET = [
+        '__call'        => true,
+        '__callStatic'  => true,
+        '__clone'       => true,
+        '__construct'   => true,
+        '__debugInfo'   => true,
+        '__destruct'    => true,
+        '__get'         => true,
+        '__invoke'      => true,
+        '__isset'       => true,
+        '__set'         => true,
+        '__set_state'   => true,
+        '__sleep'       => true,
+        '__toString'    => true,
+        '__unset'       => true,
+        '__wakeup'      => true,
+    ];
+
+    /**
+     * A list of magic methods which should have a return type of void
+     */
+    const MAGIC_VOID_METHOD_NAME_SET = [
+        '__clone'       => true,
+        '__construct'   => true,
+        '__destruct'    => true,
+        '__set'         => true,
+        '__unset'       => true,
+        '__wakeup'      => true,
+    ];
 
     /**
      * @return string
@@ -15,7 +66,7 @@ class FullyQualifiedMethodName extends FullyQualifiedClassElement
      */
     public static function canonicalName(string $name) : string
     {
-        return $name;
+        return self::CANONICAL_NAMES[\strtolower($name)] ?? $name;
     }
 
     /**

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -669,6 +669,41 @@ class ParseVisitor extends ScopeVisitor
     }
 
     /**
+     * Visit a node with kind `\ast\AST_CLOSURE`
+     *
+     * @param Decl $node
+     * A node to parse
+     *
+     * @return Context
+     * A new or an unchanged context resulting from
+     * parsing the node
+     */
+    public function visitClosure(Decl $node) : Context
+    {
+        $closure_fqsen = FullyQualifiedFunctionName::fromClosureInContext(
+            $this->context->withLineNumberStart($node->lineno ?? 0),
+            $node
+        );
+
+        $func = Func::fromNode(
+            $this->context,
+            $this->code_base,
+            $node,
+            $closure_fqsen
+        );
+
+        $this->code_base->addFunction($func);
+
+        // Send the context into the function and reset the scope
+        // (E.g. to properly check for the presence of `return` statements.
+        $context = $this->context->withScope(
+            $func->getInternalScope()
+        );
+
+        return $context;
+    }
+
+    /**
      * Visit a node with kind `\ast\AST_CALL`
      *
      * @param Node $node

--- a/tests/files/expected/0264_closure_override_context.php.expected
+++ b/tests/files/expected/0264_closure_override_context.php.expected
@@ -1,3 +1,4 @@
+%s:17 PhanTypeMissingReturn Method \closure264\TestFramework::mockA is declared to return string but has no return value
 %s:44 PhanUndeclaredProperty Reference to undeclared property \closure264\BoundClass264->d
 %s:50 PhanTypeInvalidClosureScope Invalid PhanClosureScope: expected a class name, got string
 %s:51 PhanUndeclaredProperty Reference to undeclared property \closure264\TestFramework->b

--- a/tests/files/expected/0320_return_in_void_magic_method.php.expected
+++ b/tests/files/expected/0320_return_in_void_magic_method.php.expected
@@ -1,0 +1,6 @@
+%s:6 TypeMagicVoidWithReturn Found a return statement with a value in the implementation of the magic method \MyClass::__construct, expected void return type
+%s:16 TypeMagicVoidWithReturn Found a return statement with a value in the implementation of the magic method \MyClass::__clone, expected void return type
+%s:31 TypeMagicVoidWithReturn Found a return statement with a value in the implementation of the magic method \MyClass::__destruct, expected void return type
+%s:51 TypeMagicVoidWithReturn Found a return statement with a value in the implementation of the magic method \MyClass::__set, expected void return type
+%s:71 TypeMagicVoidWithReturn Found a return statement with a value in the implementation of the magic method \MyClass::__unset, expected void return type
+%s:77 TypeMagicVoidWithReturn Found a return statement with a value in the implementation of the magic method \MyClass::__wakeup, expected void return type

--- a/tests/files/src/0264_closure_override_context.php
+++ b/tests/files/src/0264_closure_override_context.php
@@ -14,7 +14,7 @@ class BoundClass264 {
 class TestFramework {
     /** @var string */
     protected $_frameworkProperty = 'value';
-    public function mockA() : string {
+    public function mockA() : string {  // mockA() is buggy, it didn't return anything.
         // BoundClass264::a_static_method(); // What? This should emit an issue.
 
         /**

--- a/tests/files/src/0276_assign_and_missing_static_property.php
+++ b/tests/files/src/0276_assign_and_missing_static_property.php
@@ -1,7 +1,7 @@
 <?php
 class ClassMissingStaticProps {
     public function __get($name) { return 42; }  // __get should have no impact on analyzing static properties
-    public function __set($name, $value) { return 42; }  // __set should have no impact on analyzing static properties.
+    public function __set($name, $value) { return; }  // __set should have no impact on analyzing static properties.
 }
 function checkMissingStaticProps() {
     ClassMissingStaticProps::$prop = 2;  // Causes Error to be thrown if executed.

--- a/tests/files/src/0320_return_in_void_magic_method.php
+++ b/tests/files/src/0320_return_in_void_magic_method.php
@@ -1,0 +1,80 @@
+<?php
+
+// These method names deliberately have the wrong case, to verify that the detection is case sensitive.
+class MyClass {
+    // Wrong, return value is ignored
+    public function __CONSTRUCT() {
+        return false;
+    }
+
+    // Fine
+    public function __Call($x, $args) {
+        return false;
+    }
+
+    // Wrong, return value is ignored
+    public function __CLONE() {
+        return false;
+    }
+
+    // Fine
+    public static function __callstatic($x, $args) {
+        return false;
+    }
+
+    // Fine
+    public function __debugINFO() {
+        return [];
+    }
+
+    // Wrong, return value is ignored
+    public function __Destruct() {
+        return false;
+    }
+
+    // Fine
+    public function __Get($key) {
+        return false;
+    }
+
+    // Fine
+    public function __INVOKE($args) {
+        return false;
+    }
+
+    // Fine
+    public function __ISSET($key) {
+        return false;
+    }
+
+    // Wrong, return value is ignored
+    public function __Set($key, $value) {
+        return false;
+    }
+
+    // Fine
+    public function __set_State($key) {
+        return new self();
+    }
+
+    // Fine
+    public function __sleep($key) {
+        return [];
+    }
+
+    // Fine
+    public function __tostring() {
+        return 'x';
+    }
+
+    // Fine
+    public function __UnSet($key) {
+        return false;
+    }
+
+    // Wrong, return value is ignored
+    // (Throw to indicate failure)
+    public function __Wakeup() {
+        return false;
+    }
+}


### PR DESCRIPTION
The return values just get ignored by PHP,
and return statements there are usually due to unfamiliarity
with the nature of magic methods.

Also, fix return value presence checking of Closures
- Fixes #599 : Start checking for PhanTypeMissingReturn in Closures
  (Also, previously, different Func instances were created instead of reusing
  the same one from ParseVisitor, so Phan lost track of the info for
  getHasReturn())
- Also, create a new Context in ParseVisitor for the closure, in order
  to properly check if functions/methods with closures really have
  return types.

Mitigate #767 a bit by making the doc comment, arg list, `use` list, and return type
part of what's used to generate the FQSEN for a closure.
(Add a way for users to help Phan distinguish between two closure on the same file+line)