### PR TITLE
Fixes #119 : Always warn about slow PHP options (E.g. xdebug)

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -359,6 +359,10 @@ return [
         'vendor/'
     ],
 
+    // By default, Phan will log error messages to stdout if PHP is using options that slow the analysis.
+    // (e.g. PHP is compiled with --enable-debug or when using XDebug)
+    'skip_slow_php_options_warning' => false,
+
     // A list of plugin files to execute
     'plugins' => [
         '.phan/plugins/DemoPlugin.php',

--- a/NEWS
+++ b/NEWS
@@ -30,12 +30,15 @@ New Features (CLI, Configs)
 + Create `check_docblock_signature_param_type_match` (similar to `check_docblock_signature_return_type_match`) config setting
   to enable warning if phpdoc types are incompatible with the real types. False by default.
 
-  Create `prefer_narrowed_phpdoc_param_type` (requires `check_docblock_signature_return_type_match`)
-  to analyze phpdoc param types instead of provided signature types if the possible phpdoc types are narrower and compatible.
+  Create `prefer_narrowed_phpdoc_param_type` config setting (requires `check_docblock_signature_return_type_match`).
+  This is off by default, set it to true to analyze phpdoc param types instead of provided signature types if the possible phpdoc types are narrower and compatible.
   (E.g. indicate that subclasses are expected over base classes, indicate that non-nullable is expected instead of nullable)
   This affects analysis both inside and outside the method.
-+ Create `enable_class_alias_support` (disabled by default), which enables analyzing basic usage of class_alias. (Issue #586)
++ Create `enable_class_alias_support` config setting (disabled by default), which enables analyzing basic usage of class_alias. (Issue #586)
+  Set it to true to enable it.
   NOTE: this is still experimental.
++ Warn to stderr about running Phan analysis with XDebug (Issue #116)
+  The warning can be disabled by the Phan config setting `skip_slow_php_options_warning` to true.
 
 Maintenance
 

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -483,6 +483,10 @@ class Config
         // See https://github.com/etsy/phan/wiki/Different-Issue-Sets-On-Different-Numbers-of-CPUs
         'consistent_hashing_file_order' => false,
 
+        // By default, Phan will log error messages to stdout if PHP is using options that slow the analysis.
+        // (e.g. PHP is compiled with --enable-debug or when using XDebug)
+        'skip_slow_php_options_warning' => false,
+
         // Path to a unix socket for a daemon to listen to files to analyze. Use command line option instead.
         'daemonize_socket' => false,
 

--- a/src/Phan/Daemon.php
+++ b/src/Phan/Daemon.php
@@ -96,13 +96,6 @@ class Daemon {
         } else {
             throw new \InvalidArgumentException("Should not happen, no port/socket for daemon to listen on.");
         }
-        // Unless debugging Phan itself, these two configurations are unnecessarily adding slowness.
-        if (PHP_DEBUG) {
-            fwrite(STDERR, "Warning: This daemon is slower when php is compiled with --enable-debug\n");
-        }
-        if (extension_loaded('xdebug')) {
-            fwrite(STDERR, "Warning: This daemon is slower when xdebug is installed");
-        }
         echo "Listening for Phan analysis requests at $listen_url\n";
         $socket_server = stream_socket_server($listen_url, $errno, $errstr);
         if (!$socket_server) {

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -76,6 +76,7 @@ class Phan implements IgnoredFilesFilterInterface {
         CodeBase $code_base,
         \Closure $file_path_lister
     ) : bool {
+        self::checkForSlowPHPOptions();
         $is_daemon_request = Config::get()->daemonize_socket || Config::get()->daemonize_tcp_port;
         if ($is_daemon_request) {
             $code_base->enableUndoTracking();
@@ -462,5 +463,28 @@ class Phan implements IgnoredFilesFilterInterface {
      */
     public function isFilenameIgnored(string $filename):bool {
         return self::isExcludedAnalysisFile($filename);
+    }
+
+    /**
+     * Logs slow php options to stdout
+     * @return void
+     */
+    private static function checkForSlowPHPOptions() {
+        if (Config::get()->skip_slow_php_options_warning) {
+            return;
+        }
+        $warned = false;
+        // Unless debugging Phan itself, these two configurations are unnecessarily adding slowness.
+        if (PHP_DEBUG) {
+            fwrite(STDERR, "Warning: Phan is around twice as slow when php is compiled with --enable-debug (That option is only needed when debugging Phan itself).\n");
+            $warned = true;
+        }
+        if (extension_loaded('xdebug')) {
+            fwrite(STDERR, "Warning: Phan is around five times as slow when xdebug is enabled (xdebug only makes sense when debugging Phan itself)\n");
+            $warned = true;
+        }
+        if ($warned) {
+            fwrite(STDERR, "(The above warnings about slow PHP settings can be disabled by setting 'skip_slow_php_options_warning' to true in .phan/config.php)\n");
+        }
     }
 }


### PR DESCRIPTION
(not just in daemon mode)

Log the warnings to stderr. Add a config option to disable those options.

xdebug is already disabled by tests/setup.sh in travis