### PR TITLE
Make setHasReturn treat `return;` consistently.

### DIFF
--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -665,7 +665,9 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         }
 
         // Mark the method as returning something (even if void)
-        $method->setHasReturn(true);
+        if (null !== $node->children['expr']) {
+            $method->setHasReturn(true);
+        }
 
         return $this->context;
     }

--- a/tests/files/expected/0279_void_return.php.expected
+++ b/tests/files/expected/0279_void_return.php.expected
@@ -1,2 +1,3 @@
 %s:9 PhanTypeMismatchReturn Returning type void but f() is declared to return \DateTime
+%s:14 PhanTypeMissingReturn Method \g is declared to return int but has no return value
 %s:15 PhanTypeMismatchReturn Returning type void but g() is declared to return int


### PR DESCRIPTION
This affects detecting implicit void functions(e.g. __set())
which return non-void values.