### PR TITLE
Use the trusty beta for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   - TEST_SUITE="__FakePluginTest"
 
 sudo: false
+dist: trusty
 
 cache:
   directories:


### PR DESCRIPTION
This is more likely to have the latest php minor release
This will also have newer build tools