### PR TITLE
Use specialized getters for commonly used configs.

### DIFF
--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -497,7 +497,7 @@ class ContextNode
                     StringType::instance(false)
                 ])
                 && !(
-                    Config::get()->null_casts_as_any_type
+                    Config::get_null_casts_as_any_type()
                     && $union_type->hasType(NullType::instance(false))
                 )
             ) {
@@ -1255,7 +1255,7 @@ class ContextNode
      */
     public function analyzeBackwardCompatibility()
     {
-        if (!Config::get()->backward_compatibility_checks) {
+        if (!Config::get_backward_compatibility_checks()) {
             return;
         }
 

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -296,7 +296,7 @@ class Analysis
         // in mind that the results here are just a guess and
         // we can't tell with certainty that anything is
         // definitely unreferenced.
-        if (!Config::get()->dead_code_detection) {
+        if (!Config::get_dead_code_detection()) {
             return;
         }
 

--- a/src/Phan/Analysis/Analyzable.php
+++ b/src/Phan/Analysis/Analyzable.php
@@ -39,7 +39,7 @@ trait Analyzable
     public function setNode(Node $node)
     {
         // Don't waste the memory if we're in quick mode
-        if (Config::get()->quick_mode) {
+        if (Config::get_quick_mode()) {
             return;
         }
 
@@ -73,7 +73,7 @@ trait Analyzable
     {
         // Don't do anything if we care about being
         // fast
-        if (Config::get()->quick_mode) {
+        if (Config::get_quick_mode()) {
             return $context;
         }
 

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1071,8 +1071,8 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             // If we can't figure out the class for this method
             // call, cry YOLO and mark every method with that
             // name with a reference.
-            if (Config::get()->dead_code_detection
-                && Config::get()->dead_code_detection_prefer_false_negative
+            if (Config::get_dead_code_detection()
+                && Config::getValue('dead_code_detection_prefer_false_negative')
             ) {
                 foreach ($this->code_base->getMethodSetByName(
                     $method_name
@@ -1182,8 +1182,8 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             // If we can't figure out the class for this method
             // call, cry YOLO and mark every method with that
             // name with a reference.
-            if (Config::get()->dead_code_detection
-                && Config::get()->dead_code_detection_prefer_false_negative
+            if (Config::get_dead_code_detection()
+                && Config::getValue('dead_code_detection_prefer_false_negative')
             ) {
                 foreach ($this->code_base->getMethodSetByName(
                     $method_name
@@ -1358,8 +1358,8 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             // If we can't figure out the class for this method
             // call, cry YOLO and mark every method with that
             // name with a reference.
-            if (Config::get()->dead_code_detection
-                && Config::get()->dead_code_detection_prefer_false_negative
+            if (Config::get_dead_code_detection()
+                && Config::getValue('dead_code_detection_prefer_false_negative')
             ) {
                 foreach ($this->code_base->getMethodSetByName(
                     $method_name
@@ -1679,7 +1679,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 continue;
             }
 
-            if (Config::get()->dead_code_detection) {
+            if (Config::get_dead_code_detection()) {
                 (new ArgumentVisitor(
                     $this->code_base,
                     $this->context
@@ -1738,7 +1738,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
 
         // If we're in quick mode, don't retest methods based on
         // parameter types passed in
-        if (Config::get()->quick_mode) {
+        if (Config::get_quick_mode()) {
             return;
         }
 

--- a/src/Phan/Analysis/ReferenceCountsAnalyzer.php
+++ b/src/Phan/Analysis/ReferenceCountsAnalyzer.php
@@ -36,7 +36,7 @@ class ReferenceCountsAnalyzer
         // in mind that the results here are just a guess and
         // we can't tell with certainty that anything is
         // definitely unreferenced.
-        if (!Config::get()->dead_code_detection) {
+        if (!Config::get_dead_code_detection()) {
             return;
         }
 

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -109,7 +109,7 @@ class CLI
 
         // Determine the root directory of the project from which
         // we root all relative paths passed in as args
-        Config::get()->setProjectRootDirectory(
+        Config::setProjectRootDirectory(
             $opts['d'] ?? $opts['project-root-directory'] ?? getcwd()
         );
 
@@ -717,7 +717,7 @@ EOB;
             !empty($this->config_file)
             ? realpath($this->config_file)
             : implode(DIRECTORY_SEPARATOR, [
-                Config::get()->getProjectRootDirectory(),
+                Config::getProjectRootDirectory(),
                 '.phan',
                 'config.php'
             ]);
@@ -732,7 +732,7 @@ EOB;
 
         // Write each value to the config
         foreach ($config as $key => $value) {
-            Config::get()->__set($key, $value);
+            Config::setValue($key, $value);
         }
     }
 }

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -560,7 +560,7 @@ class CodeBase
         // If we're doing dead code detection and this is a
         // method, map the name to the FQSEN so we can do hail-
         // mary references.
-        if (Config::get()->dead_code_detection) {
+        if (Config::get_dead_code_detection()) {
             if (empty($this->name_method_map[$method->getFQSEN()->getNameWithAlternateId()])) {
                 $this->name_method_map[$method->getFQSEN()->getNameWithAlternateId()] = new Set;
             }
@@ -619,7 +619,7 @@ class CodeBase
      */
     public function getMethodSetByName(string $name) : Set
     {
-        \assert(Config::get()->dead_code_detection,
+        \assert(Config::get_dead_code_detection(),
             __METHOD__ . ' can only be called when dead code '
             . ' detection is enabled.'
         );

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -14,13 +14,28 @@ class Config
      * The root directory of the project. This is used to
      * store canonical path names and find project resources
      */
-    private $project_root_directory = null;
+    private static $project_root_directory = null;
 
     /**
      * Configuration options
      */
-    private $configuration = [
+    private static $configuration = self::DEFAULT_CONFIGURATION;
 
+    // The 4 most commonly accessed configs:
+    /** @var bool */
+    private static $null_casts_as_any_type = false;
+
+    /** @var bool */
+    private static $dead_code_detection = false;
+
+    /** @var bool */
+    private static $backward_compatibility_checks = false;
+
+    /** @var bool */
+    private static $quick_mode = false;
+    // End of the 4 most commonly accessed configs.
+
+    const DEFAULT_CONFIGURATION = [
         // A list of individual files to include in analysis
         // with a path relative to the root directory of the
         // project
@@ -510,9 +525,9 @@ class Config
      * Get the root directory of the project that we're
      * scanning
      */
-    public function getProjectRootDirectory() : string
+    public static function getProjectRootDirectory() : string
     {
-        return $this->project_root_directory ?? getcwd();
+        return self::$project_root_directory ?? getcwd();
     }
 
     /**
@@ -522,10 +537,10 @@ class Config
      *
      * @return void
      */
-    public function setProjectRootDirectory(
+    public static function setProjectRootDirectory(
         string $project_root_directory
     ) {
-        $this->project_root_directory = $project_root_directory;
+        self::$project_root_directory = $project_root_directory;
     }
 
     /**
@@ -541,7 +556,19 @@ class Config
         }
 
         $instance = new Config();
+        $instance->init();
         return $instance;
+    }
+
+    /**
+     * @return void
+     */
+    private function init()
+    {
+        // Trigger magic setters
+        foreach (self::$configuration as $name => $v) {
+            self::setValue($name, $v);
+        }
     }
 
     /**
@@ -550,18 +577,80 @@ class Config
      */
     public function toArray() : array
     {
-        return $this->configuration;
+        return self::$configuration;
     }
 
-    /** @return mixed */
+    public static function get_null_casts_as_any_type() : bool
+    {
+        return self::$null_casts_as_any_type;
+    }
+
+    public static function get_dead_code_detection() : bool
+    {
+        return self::$dead_code_detection;
+    }
+
+    public static function get_backward_compatibility_checks() : bool
+    {
+        return self::$backward_compatibility_checks;
+    }
+
+    public static function get_quick_mode() : bool
+    {
+        return self::$quick_mode;
+    }
+
+    /**
+     * @return mixed
+     * @deprecated
+     */
     public function __get(string $name)
     {
-        return $this->configuration[$name];
+        return self::getValue($name);
     }
 
+    /**
+     * @return mixed
+     */
+    public function getValue(string $name)
+    {
+        return self::$configuration[$name];
+    }
+
+    /**
+     * @param string $name
+     * @param mixed $value
+     * @return void
+     * @deprecated
+     */
     public function __set(string $name, $value)
     {
-        $this->configuration[$name] = $value;
+        self::setValue($name, $value);
+    }
+
+    /**
+     * @param string $name
+     * @param mixed $value
+     * @return void
+     */
+    public static function setValue(string $name, $value)
+    {
+        switch ($name) {
+        case 'null_casts_as_any_type':
+            self::$null_casts_as_any_type = $value;
+            break;
+        case 'dead_code_detection':
+            self::$dead_code_detection = $value;
+            break;
+        case 'backward_compatibility_checks':
+            self::$backward_compatibility_checks = $value;
+            break;
+        case 'quick_mode':
+            self::$quick_mode = $value;
+            break;
+        }
+
+        self::$configuration[$name] = $value;
     }
 
     /**
@@ -578,7 +667,7 @@ class Config
         }
 
         return \implode(DIRECTORY_SEPARATOR, [
-            Config::get()->getProjectRootDirectory(),
+            Config::getProjectRootDirectory(),
             $relative_path
         ]);
     }

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -357,7 +357,7 @@ trait FunctionTrait {
         if (count($parameter_list) === 0) {
             return 0;
         }
-        if (Config::get()->quick_mode) {
+        if (Config::get_quick_mode()) {
             return 0;
         }
         $param_repr = implode(',', array_map(function(Variable $param) {

--- a/src/Phan/Language/FileRef.php
+++ b/src/Phan/Language/FileRef.php
@@ -71,7 +71,7 @@ class FileRef implements \Serializable
     public static function getProjectRelativePathForPath($cwd_relative_path) {
         // Get a path relative to the project root
         $path = str_replace(
-            Config::get()->getProjectRootDirectory(),
+            Config::getProjectRootDirectory(),
             '',
             realpath($cwd_relative_path) ?: $cwd_relative_path
         );

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1281,7 +1281,7 @@ class Type
             // If this is nullable, but that isn't, and we've
             // configured nulls to cast as anything, ignore
             // the nullable part.
-            if (Config::get()->null_casts_as_any_type) {
+            if (Config::get_null_casts_as_any_type()) {
                 return $this->withIsNullable(false)->canCastToType($type);
             }
 

--- a/src/Phan/Language/Type/NullType.php
+++ b/src/Phan/Language/Type/NullType.php
@@ -55,7 +55,7 @@ class NullType extends ScalarType
             return true;
         }
 
-        if (Config::get()->null_casts_as_any_type) {
+        if (Config::get_null_casts_as_any_type()) {
             return true;
         }
 

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -818,7 +818,7 @@ class UnionType implements \Serializable
             return true;
         }
 
-        if (Config::get()->null_casts_as_any_type) {
+        if (Config::get_null_casts_as_any_type()) {
             // null <-> null
             if ($this->isType(NullType::instance(false))
                 || $target->isType(NullType::instance(false))
@@ -1236,7 +1236,7 @@ class UnionType implements \Serializable
         if ($this->hasType(ArrayType::instance(false))
             || $this->hasType(MixedType::instance(false))
             || (
-                Config::get()->null_casts_as_any_type
+                Config::get_null_casts_as_any_type()
                 && $this->hasType(ArrayType::instance(true))
             )
         ) {

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -750,7 +750,7 @@ class ParseVisitor extends ScopeVisitor
                 }
             }
         }
-        if (Config::get()->backward_compatibility_checks) {
+        if (Config::get_backward_compatibility_checks()) {
             $this->analyzeBackwardCompatibility($node);
 
             foreach ($node->children['args']->children ?? [] as $arg_node) {
@@ -800,7 +800,7 @@ class ParseVisitor extends ScopeVisitor
      */
     private function analyzeBackwardCompatibility(Node $node)
     {
-        if (Config::get()->backward_compatibility_checks) {
+        if (Config::get_backward_compatibility_checks()) {
             (new ContextNode(
                 $this->code_base,
                 $this->context,
@@ -897,7 +897,7 @@ class ParseVisitor extends ScopeVisitor
 
     public function visitAssign(Node $node) : Context
     {
-        if (!Config::get()->backward_compatibility_checks) {
+        if (!Config::get_backward_compatibility_checks()) {
             return $this->context;
         }
         // Analyze the assignment for compatibility with some
@@ -915,7 +915,7 @@ class ParseVisitor extends ScopeVisitor
 
     public function visitDim(Node $node) : Context
     {
-        if (!Config::get()->backward_compatibility_checks) {
+        if (!Config::get_backward_compatibility_checks()) {
             return $this->context;
         }
 

--- a/tests/Phan/AbstractPhanFileTest.php
+++ b/tests/Phan/AbstractPhanFileTest.php
@@ -48,7 +48,7 @@ abstract class AbstractPhanFileTest
 
         // Reinstate the original config
         foreach ($this->original_config as $key => $value) {
-            Config::get()->__set($key, $value);
+            Config::setValue($key, $value);
         }
     }
 
@@ -103,7 +103,7 @@ abstract class AbstractPhanFileTest
         // Overlay any test-specific config modifiers
         if ($config_file_path) {
             foreach (require($config_file_path) as $key => $value) {
-                Config::get()->__set($key, $value);
+                Config::setValue($key, $value);
             }
         }
 

--- a/tests/Phan/PhanTest.php
+++ b/tests/Phan/PhanTest.php
@@ -14,7 +14,7 @@ class PhanTest extends AbstractPhanFileTest {
         // overrides for the tests.
         $test_config_file_name = dirname(__FILE__) . '/../.phan/config.php';
         foreach (require($test_config_file_name) as $key => $value) {
-            Config::get()->__set($key, $value);
+            Config::setValue($key, $value);
         }
 
         return $this->scanSourceFilesDir(TEST_FILE_DIR, EXPECTED_DIR);


### PR DESCRIPTION
Those 4 are the most commonly fetched by __get() or getValue()
Overall runtime decreased 2%, from 26.4 seconds to 25.8 seconds
analyzing a third party project.