### PR TITLE
Rewrite remaining config fetches to use Config::getValue('config_name')

### DIFF
--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -848,7 +848,7 @@ class ContextNode
         // properties
         if (!$is_static) {
             foreach ($class_list as $i => $class) {
-                if (Config::get()->allow_missing_properties
+                if (Config::getValue('allow_missing_properties')
                     || $class->getHasDynamicProperties($this->code_base)
                 ) {
                     return $class->getPropertyByNameInContext(
@@ -868,7 +868,7 @@ class ContextNode
         // If missing properties are cool, create it on
         // the first class we found
         if (!$is_static && ($class_fqsen && ($class_fqsen === $std_class_fqsen))
-            || Config::get()->allow_missing_properties
+            || Config::getValue('allow_missing_properties')
         ) {
             if (count($class_list) > 0) {
                 $class = $class_list[0];

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1048,7 +1048,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             if (Variable::isHardcodedVariableInScopeWithName($variable_name, $this->context->isInGlobalScope())) {
                 return Variable::getUnionTypeOfHardcodedGlobalVariableWithName($variable_name);
             }
-            if (!Config::get()->ignore_undeclared_variables_in_global_scope
+            if (!Config::getValue('ignore_undeclared_variables_in_global_scope')
                 || !$this->context->isInGlobalScope()
             ) {
                 throw new IssueException(

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -52,12 +52,12 @@ class Analysis
             if (\is_string($override_contents)) {
                 $node = \ast\parse_code(
                     $override_contents,
-                    Config::get()->ast_version
+                    Config::getValue('ast_version')
                 );
             } else {
                 $node = \ast\parse_file(
                     Config::projectPath($file_path),
-                    Config::get()->ast_version
+                    Config::getValue('ast_version')
                 );
             }
         } catch (\ParseError $parse_error) {
@@ -75,7 +75,7 @@ class Analysis
             return $context;
         }
 
-        if (Config::get()->dump_ast) {
+        if (Config::getValue('dump_ast')) {
             echo $file_path . "\n"
                 . str_repeat("\u{00AF}", strlen($file_path))
                 . "\n";
@@ -330,12 +330,12 @@ class Analysis
             if (\is_string($file_contents_override)) {
                 $node = \ast\parse_code(
                     $file_contents_override,
-                    Config::get()->ast_version
+                    Config::getValue('ast_version')
                 );
             } else {
                 $node = \ast\parse_file(
                     Config::projectPath($file_path),
-                    Config::get()->ast_version
+                    Config::getValue('ast_version')
                 );
             }
         } catch (\ParseError $parse_error) {
@@ -361,7 +361,7 @@ class Analysis
             return $context;
         }
 
-        if (Config::get()->simplify_ast) {
+        if (Config::getValue('simplify_ast')) {
             try {
                 $newNode = ASTSimplifier::applyStatic($node);  // Transform the original AST, leaving the original unmodified.
                 $node = $newNode;  // Analyze the new AST instead.

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -433,7 +433,7 @@ class AssignmentVisitor extends AnalysisVisitor
         // Check if it is a built in class with dynamic properties but (possibly) no __set, such as SimpleXMLElement or stdClass or V8Js
         $is_class_with_arbitrary_types = isset($class_list[0]) ? $class_list[0]->getHasDynamicProperties($this->code_base) : false;
 
-        if ($is_class_with_arbitrary_types || Config::get()->allow_missing_properties) {
+        if ($is_class_with_arbitrary_types || Config::getValue('allow_missing_properties')) {
             try {
                 // Create the property
                 $property = (new ContextNode(

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -371,7 +371,7 @@ class ConditionVisitor extends KindVisitorImplementation
             if (Variable::isHardcodedVariableInScopeWithName($var_name, $this->context->isInGlobalScope())) {
                 return null;
             }
-            if (!Config::get()->ignore_undeclared_variables_in_global_scope
+            if (!Config::getValue('ignore_undeclared_variables_in_global_scope')
                 || !$this->context->isInGlobalScope()
             ) {
                 throw new IssueException(

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -26,7 +26,7 @@ class ParameterTypesAnalyzer
         CodeBase $code_base,
         FunctionInterface $method
     ) {
-        if (Config::get()->check_docblock_signature_param_type_match) {
+        if (Config::getValue('check_docblock_signature_param_type_match')) {
             self::analyzeParameterTypesDocblockSignaturesMatch($code_base, $method);
         }
 
@@ -88,7 +88,7 @@ class ParameterTypesAnalyzer
         CodeBase $code_base,
         Method $method
     ) {
-        if (!Config::get()->analyze_signature_compatibility) {
+        if (!Config::getValue('analyze_signature_compatibility')) {
             return;
         }
 
@@ -571,7 +571,7 @@ class ParameterTypesAnalyzer
             }
         }
         if ($is_possibly_compatible) {
-            if (Config::get()->inherit_phpdoc_types) {
+            if (Config::getValue('inherit_phpdoc_types')) {
                 self::inheritPHPDoc($method, $o_method);
             }
         }
@@ -724,7 +724,7 @@ class ParameterTypesAnalyzer
                     }
                 }
                 // TODO: test edge cases of variadic signatures
-                if ($is_exclusively_narrowed && Config::get()->prefer_narrowed_phpdoc_param_type) {
+                if ($is_exclusively_narrowed && Config::getValue('prefer_narrowed_phpdoc_param_type')) {
                     $param_to_modify = $method->getParameterList()[$i] ?? null;
                     if ($param_to_modify) {
                         $param_to_modify->setUnionType($phpdoc_param_union_type);

--- a/src/Phan/Analysis/ParentConstructorCalledAnalyzer.php
+++ b/src/Phan/Analysis/ParentConstructorCalledAnalyzer.php
@@ -20,9 +20,9 @@ class ParentConstructorCalledAnalyzer
     ) {
         // Only look at classes configured to require a call
         // to its parent constructor
-        if (!in_array(
+        if (!\in_array(
             $clazz->getName(),
-            Config::get()->parent_constructor_required
+            Config::getValue('parent_constructor_required')
         )
         ) {
             return;

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -235,7 +235,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
 
                 // Don't worry about non-existent undeclared variables
                 // in the global scope if configured to do so
-                if(Config::get()->ignore_undeclared_variables_in_global_scope
+                if (Config::getValue('ignore_undeclared_variables_in_global_scope')
                     && $this->context->isInGlobalScope()
                 ) {
                     continue;

--- a/src/Phan/Analysis/ReturnTypesAnalyzer.php
+++ b/src/Phan/Analysis/ReturnTypesAnalyzer.php
@@ -66,7 +66,7 @@ class ReturnTypesAnalyzer
                 }
             }
         }
-        if (Config::get()->check_docblock_signature_return_type_match && !$real_return_type->isEmpty() && !$phpdoc_return_type->isEmpty()) {
+        if (Config::getValue('check_docblock_signature_return_type_match') && !$real_return_type->isEmpty() && !$phpdoc_return_type->isEmpty()) {
             $context = $method->getContext();
             $resolved_real_return_type = $real_return_type->withStaticResolvedInContext($context);
             foreach ($phpdoc_return_type->getTypeSet() as $phpdoc_type) {

--- a/src/Phan/Daemon.php
+++ b/src/Phan/Daemon.php
@@ -89,10 +89,10 @@ class Daemon {
      */
     private static function createDaemonStreamSocketServer() {
         $listen_url = null;
-        if (Config::get()->daemonize_socket) {
-            $listen_url = 'unix://' . Config::get()->daemonize_socket;
-        } else if (Config::get()->daemonize_tcp_port) {
-            $listen_url = sprintf('tcp://127.0.0.1:%d', Config::get()->daemonize_tcp_port);
+        if (Config::getValue('daemonize_socket')) {
+            $listen_url = 'unix://' . Config::getValue('daemonize_socket');
+        } else if (Config::getValue('daemonize_tcp_port')) {
+            $listen_url = sprintf('tcp://127.0.0.1:%d', Config::getValue('daemonize_tcp_port'));
         } else {
             throw new \InvalidArgumentException("Should not happen, no port/socket for daemon to listen on.");
         }

--- a/src/Phan/Daemon/Request.php
+++ b/src/Phan/Daemon/Request.php
@@ -356,7 +356,7 @@ class Request {
 
         $file_list = $file_path_lister();
 
-        if (Config::get()->consistent_hashing_file_order) {
+        if (Config::getValue('consistent_hashing_file_order')) {
             // Parse the files in lexicographic order.
             // If there are duplicate class/function definitions,
             // this ensures they are added to the maps in the same order.

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -1951,17 +1951,16 @@ class Issue
         // If this issue type has been suppressed in
         // the config, ignore it
 
-        $config = Config::get();
-        if (!$config->disable_suppression) {
+        if (!Config::getValue('disable_suppression')) {
             if (in_array($issue_instance->getIssue()->getType(),
-                    $config->suppress_issue_types ?? [])
+                    Config::getValue('suppress_issue_types') ?? [])
             ) {
                 return;
             }
 
             // If a white-list of allowed issue types is defined,
             // only emit issues on the white-list
-            $whitelist_issue_types = $config->whitelist_issue_types ?? [];
+            $whitelist_issue_types = Config::getValue('whitelist_issue_types') ?? [];
             if (count($whitelist_issue_types) > 0
                 && !in_array($issue_instance->getIssue()->getType(),
                         $whitelist_issue_types)
@@ -2041,23 +2040,23 @@ class Issue
     ) {
         // If this issue type has been suppressed in
         // the config, ignore it
-        if (!Config::get()->disable_suppression
+        if (!Config::getValue('disable_suppression')
             && in_array($issue_type,
-            Config::get()->suppress_issue_types ?? [])
+            Config::getValue('suppress_issue_types') ?? [])
         ) {
             return;
         }
         // If a white-list of allowed issue types is defined,
         // only emit issues on the white-list
-        if (!Config::get()->disable_suppression
-            && count(Config::get()->whitelist_issue_types) > 0
+        if (!Config::getValue('disable_suppression')
+            && count(Config::getValue('whitelist_issue_types')) > 0
             && !in_array($issue_type,
-                Config::get()->whitelist_issue_types ?? [])
+                Config::getValue('whitelist_issue_types') ?? [])
         ) {
             return;
         }
 
-        if (!Config::get()->disable_suppression
+        if (!Config::getValue('disable_suppression')
             && $context->hasSuppressIssue($code_base, $issue_type)
         ) {
             return;

--- a/src/Phan/IssueInstance.php
+++ b/src/Phan/IssueInstance.php
@@ -34,7 +34,7 @@ class IssueInstance
         $this->line = $line;
 
         // color_issue_message will interfere with some formatters, such as xml.
-        if (Config::get()->color_issue_messages) {
+        if (Config::getValue('color_issue_messages')) {
             $this->message = self::generateColorizedMessage($issue, $template_parameters);
         } else {
             $this->message = self::generatePlainMessage($issue, $template_parameters);
@@ -49,7 +49,7 @@ class IssueInstance
 
         // markdown_issue_messages doesn't make sense with color, unless you add <span style="color:red">msg</span>
         // Not sure if codeclimate supports that.
-        if (Config::get()->markdown_issue_messages) {
+        if (Config::getValue('markdown_issue_messages')) {
             $template = preg_replace(
                 '/([^ ]*%s[^ ]*)/', '`\1`',
                 $template

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -894,7 +894,7 @@ class Clazz extends AddressableElement
         // Check to see if missing properties are allowed
         // or we're working with a class with dynamic
         // properties such as stdclass.
-        if (!$is_static && (Config::get()->allow_missing_properties
+        if (!$is_static && (Config::getValue('allow_missing_properties')
             || $this->getHasDynamicProperties($code_base))
         ) {
             $property = new Property(

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -238,7 +238,7 @@ class Comment
         int $comment_type
     ) : Comment {
 
-        if (!Config::get()->read_type_annotations) {
+        if (!Config::getValue('read_type_annotations')) {
             return new Comment(
                 0, [], [], [], new None, new UnionType(), [], [], [], new None
             );
@@ -288,7 +288,7 @@ class Comment
             } elseif (\stripos($line, '@template') !== false) {
 
                 // Make sure support for generic types is enabled
-                if (Config::get()->generic_types_enabled) {
+                if (Config::getValue('generic_types_enabled')) {
                     $check_compatible('@template', [Comment::ON_CLASS]);
                     if (($template_type =
                         self::templateTypeFromCommentLine($context, $line))
@@ -299,7 +299,7 @@ class Comment
             } elseif (\stripos($line, '@inherits') !== false) {
                 $check_compatible('@inherits', [Comment::ON_CLASS]);
                 // Make sure support for generic types is enabled
-                if (Config::get()->generic_types_enabled) {
+                if (Config::getValue('generic_types_enabled')) {
                     $inherited_type =
                         self::inheritsFromCommentLine($context, $line);
                 }
@@ -324,7 +324,7 @@ class Comment
             } elseif (\strpos($line, '@property') !== false) {
                 $check_compatible('@property', [Comment::ON_CLASS]);
                 // Make sure support for magic properties is enabled.
-                if (Config::get()->read_magic_property_annotations) {
+                if (Config::getValue('read_magic_property_annotations')) {
                     $magic_property = self::magicPropertyFromCommentLine($code_base, $context, $line, $lineno);
                     if ($magic_property !== null) {
                         $magic_property_list[] = $magic_property;
@@ -332,7 +332,7 @@ class Comment
                 }
             } elseif (\strpos($line, '@method') !== false) {
                 // Make sure support for magic methods is enabled.
-                if (Config::get()->read_magic_method_annotations) {
+                if (Config::getValue('read_magic_method_annotations')) {
                     $check_compatible('@method', [Comment::ON_CLASS]);
                     $magic_method = self::magicMethodFromCommentLine($code_base, $context, $line, $lineno);
                     if ($magic_method !== null) {

--- a/src/Phan/Language/Element/Variable.php
+++ b/src/Phan/Language/Element/Variable.php
@@ -157,7 +157,7 @@ class Variable extends TypedElement
         if (\array_key_exists($name, self::_BUILTIN_SUPERGLOBAL_TYPES)) {
             return true;
         }
-        return \in_array($name, Config::get()->runkit_superglobals);
+        return \in_array($name, Config::getValue('runkit_superglobals'));
     }
 
     /**
@@ -168,7 +168,7 @@ class Variable extends TypedElement
     ) : bool {
         return self::isSuperglobalVariableWithName($name) ||
             \array_key_exists($name, self::_BUILTIN_GLOBAL_TYPES) ||
-            \array_key_exists($name, Config::get()->globals_type_map);
+            \array_key_exists($name, Config::getValue('globals_type_map'));
     }
 
     /**
@@ -195,11 +195,10 @@ class Variable extends TypedElement
             // More efficient than using context.
             return UnionType::fromFullyQualifiedString(self::_BUILTIN_GLOBAL_TYPES[$name]);
         }
-        $config = Config::get();
-        if (\array_key_exists($name, $config->globals_type_map)
-            || \in_array($name, $config->runkit_superglobals)
+        if (\array_key_exists($name, Config::getValue('globals_type_map'))
+            || \in_array($name, Config::getValue('runkit_superglobals'))
         ) {
-            $type_string = $config->globals_type_map[$name] ?? '';
+            $type_string = Config::getValue('globals_type_map')[$name] ?? '';
             // Want to allow 'resource' or 'mixed' as a type here,
             return UnionType::fromStringInContext($type_string, new Context(), Type::FROM_PHPDOC);
         }

--- a/src/Phan/Language/Scope.php
+++ b/src/Phan/Language/Scope.php
@@ -223,7 +223,7 @@ abstract class Scope
      */
     public function hasAnyTemplateType() : bool
     {
-        if (!Config::get()->generic_types_enabled) {
+        if (!Config::getValue('generic_types_enabled')) {
             return false;
         }
 

--- a/src/Phan/Language/Type/NullType.php
+++ b/src/Phan/Language/Type/NullType.php
@@ -60,7 +60,7 @@ class NullType extends ScalarType
         }
 
         // NullType is a sub-type of ScalarType. So it's affected by scalar_implicit_cast.
-        if (Config::get()->scalar_implicit_cast && $type->isScalar()) {
+        if (Config::getValue('scalar_implicit_cast') && $type->isScalar()) {
             return true;
         }
 

--- a/src/Phan/Language/Type/ScalarType.php
+++ b/src/Phan/Language/Type/ScalarType.php
@@ -61,7 +61,7 @@ abstract class ScalarType extends NativeType
     protected function canCastToNonNullableType(Type $type) : bool
     {
         // Scalars may be configured to always cast to eachother
-        if (Config::get()->scalar_implicit_cast
+        if (Config::getValue('scalar_implicit_cast')
             && $type->isScalar()
         ) {
             return true;

--- a/src/Phan/Ordering.php
+++ b/src/Phan/Ordering.php
@@ -42,7 +42,7 @@ class Ordering
         \assert($process_count > 0,
             "The process count must be greater than zero.");
 
-        if (Config::get()->randomize_file_order) {
+        if (Config::getValue('randomize_file_order')) {
             $random_proc_file_map = [];
             $i = 0;
             shuffle($analysis_file_list);
@@ -53,7 +53,7 @@ class Ordering
         }
 
         // Construct a Hasher implementation based on config.
-        if (Config::get()->consistent_hashing_file_order) {
+        if (Config::getValue('consistent_hashing_file_order')) {
             sort($analysis_file_list, SORT_STRING);
             $hasher = new Consistent($process_count);
         } else {
@@ -91,7 +91,7 @@ class Ordering
             $file_names_for_classes[$file_name] = $class;
         }
 
-        if (Config::get()->consistent_hashing_file_order) {
+        if (Config::getValue('consistent_hashing_file_order')) {
             ksort($file_names_for_classes, SORT_STRING);
         }
 

--- a/src/Phan/Output/Colorizing.php
+++ b/src/Phan/Output/Colorizing.php
@@ -159,7 +159,7 @@ class Colorizing {
      */
     private static function initColorScheme() {
         self::$color_scheme = self::default_color_for_template;
-        foreach (Config::get()->color_scheme ?? [] as $template_type => $color_name) {
+        foreach (Config::getValue('color_scheme') ?? [] as $template_type => $color_name) {
             if (!\is_scalar($color_name) || !\array_key_exists($color_name, self::styles)) {
                 error_log("Invalid color name ($color_name)");
                 continue;

--- a/src/Phan/Output/Printer/PlainTextPrinter.php
+++ b/src/Phan/Output/Printer/PlainTextPrinter.php
@@ -25,7 +25,7 @@ final class PlainTextPrinter implements IssuePrinterInterface
         $issue   = $instance->getIssue();
         $type    = $issue->getType();
         $message = $instance->getMessage();
-        if (Config::get()->color_issue_messages) {
+        if (Config::getValue('color_issue_messages')) {
             switch($issue->getSeverity()) {
             case Issue::SEVERITY_CRITICAL:
                 $issue_type_template = '{ISSUETYPE_CRITICAL}';

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -745,7 +745,7 @@ class ParseVisitor extends ScopeVisitor
                     );
                 }
             } else if ($function_name === 'class_alias') {
-                if (Config::get()->enable_class_alias_support && $this->context->isInGlobalScope()) {
+                if (Config::getValue('enable_class_alias_support') && $this->context->isInGlobalScope()) {
                     $this->recordClassAlias($node);
                 }
             }

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -187,7 +187,7 @@ class ConfigPluginSet extends Plugin {
 
                     return $plugin_instance;
                 },
-                Config::get()->plugins
+                Config::getValue('plugins')
             );
         }
         return $this->pluginSet;

--- a/src/Phan/Prep.php
+++ b/src/Phan/Prep.php
@@ -27,7 +27,7 @@ class Prep {
             // of this method
             $node = \ast\parse_file(
                 $file_path,
-                Config::get()->ast_version
+                Config::getValue('ast_version')
             );
 
             // Skip empty files

--- a/src/Phan/Profile.php
+++ b/src/Phan/Profile.php
@@ -23,7 +23,7 @@ trait Profile
     protected static function time(string $label, \Closure $closure)
     {
 
-        if (!Config::get()->profiler_enabled) {
+        if (!Config::getValue('profiler_enabled')) {
             return $closure();
         }
 

--- a/src/phan.php
+++ b/src/phan.php
@@ -24,12 +24,12 @@ use Phan\Phan;
 try {
     $node = \ast\parse_code(
         '<?php 42;',
-        Config::get()->ast_version
+        Config::getValue('ast_version')
     );
 } catch (LogicException $throwable) {
     assert(false,
         'Unknown AST version ('
-        . Config::get()->ast_version
+        . Config::getValue('ast_version')
         . ') in configuration. '
         . 'You may need to rebuild the latest '
         . 'version of the php-ast extension.'

--- a/tests/Phan/ASTRewriterTest.php
+++ b/tests/Phan/ASTRewriterTest.php
@@ -41,7 +41,7 @@ class ASTRewriterTest extends AbstractPhanFileTest {
         $this->assertNotEquals(false, $original_src);
         $this->assertNotEquals(false, $expected_src);
 
-        $ast_version = Config::get()->ast_version;
+        $ast_version = Config::getValue('ast_version');
         $expected = \ast\parse_code($expected_src, $ast_version);
         $beforeTransform = \ast\parse_code($original_src, $ast_version);
 

--- a/tests/Phan/AnalyzerTest.php
+++ b/tests/Phan/AnalyzerTest.php
@@ -125,7 +125,7 @@ class AnalyzerTest extends BaseTest {
                 new Context,
                 \ast\parse_code(
                     '<?php ' . $code_stub,
-                    Config::get()->ast_version
+                    Config::getValue('ast_version')
                 )
             );
     }

--- a/tests/Phan/Language/ContextTest.php
+++ b/tests/Phan/Language/ContextTest.php
@@ -61,7 +61,7 @@ class ContextTest extends BaseTest {
 
         $stmt_list_node = \ast\parse_code(
             $code,
-            Config::get()->ast_version
+            Config::getValue('ast_version')
         );
 
         $class_node = $stmt_list_node->children[0];

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -145,7 +145,7 @@ class UnionTypeTest extends BaseTest {
             $this->code_base,
             \ast\parse_code(
                 $code,
-                Config::get()->ast_version
+                Config::getValue('ast_version')
             )->children[0]
         )->asExpandedTypes($this->code_base)->__toString();
     }


### PR DESCRIPTION
Be consistent about this.
For backwards compatibility, the magic getters and setters for
Config::get()->config_name will continue to work (e.g. for plugins)