### PR TITLE
Fixes #541 : Add config setting 'scalar_implicit_partial'

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -39,6 +39,13 @@ return [
     // are treated as if they can cast to each other.
     'scalar_implicit_cast' => false,
 
+    // If this has entries, scalars (int, float, bool, string, null)
+    // are allowed to perform the casts listed.
+    // E.g. ['int' => ['float', 'string'], 'float' => ['int'], 'string' => ['int'], 'null' => ['string']]
+    // allows casting null to a string, but not vice versa.
+    // (subset of scalar_implicit_cast)
+    'scalar_implicit_partial' => [],
+
     // If true, seemingly undeclared variables in the global
     // scope will be ignored. This is useful for projects
     // with complicated cross-file globals that you have no

--- a/NEWS
+++ b/NEWS
@@ -40,6 +40,8 @@ New Features (CLI, Configs)
   NOTE: this is still experimental.
 + Warn to stderr about running Phan analysis with XDebug (Issue #116)
   The warning can be disabled by the Phan config setting `skip_slow_php_options_warning` to true.
++ Add a config setting 'scalar_implicit_partial' to allow moving away from 'scalar_implicit_cast' (Issue #541)
+  This allows users to list out (and gradually remove) permitted scalar type casts.
 
 Maintenance
 + Reduce memory usage by around 15% by using a more efficient representation of union types (PR #729).

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -165,6 +165,13 @@ class Config
         // are treated as if they can cast to each other.
         'scalar_implicit_cast' => false,
 
+        // If this has entries, scalars (int, float, bool, string, null)
+        // are allowed to perform the casts listed.
+        // E.g. ['int' => ['float', 'string'], 'float' => ['int'], 'string' => ['int'], 'null' => ['string']]
+        // allows casting null to a string, but not vice versa.
+        // (subset of scalar_implicit_cast)
+        'scalar_implicit_partial' => [],
+
         // If true, seemingly undeclared variables in the global
         // scope will be ignored. This is useful for projects
         // with complicated cross-file globals that you have no


### PR DESCRIPTION
This allows large projects using etsy/phan to gradually move away from
scalar_implicit_cast.
Some types (e.g. int -> string) may be relatively safe and common,
while others (float -> bool) may be desirable to forbid.