### PR TITLE
Fixes #541: Add null_casts_as_array and array_casts_as_null settings.

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -35,6 +35,16 @@ return [
     // type to be cast to null.
     "null_casts_as_any_type" => false,
 
+    // Allow null to be cast as any array-like type
+    // This is an incremental step in migrating away from null_casts_as_any_type.
+    // If null_casts_as_any_type is true, this has no effect.
+    'null_casts_as_array' => false,
+
+    // Allow any array-like type to be cast to null.
+    // This is an incremental step in migrating away from null_casts_as_any_type.
+    // If null_casts_as_any_type is true, this has no effect.
+    'array_casts_as_null' => false,
+
     // If enabled, scalars (int, float, bool, string, null)
     // are treated as if they can cast to each other.
     'scalar_implicit_cast' => false,

--- a/NEWS
+++ b/NEWS
@@ -42,6 +42,8 @@ New Features (CLI, Configs)
   The warning can be disabled by the Phan config setting `skip_slow_php_options_warning` to true.
 + Add a config setting 'scalar_implicit_partial' to allow moving away from 'scalar_implicit_cast' (Issue #541)
   This allows users to list out (and gradually remove) permitted scalar type casts.
++ Add `null_casts_as_array` and `array_casts_as_null` settings, which can be used while migrating away from `null_casts_as_any_type`.
+  These will be checked if one of the types has a union type of `null`, as well as when checking if a nullable array can cast to a regular array.
 
 Maintenance
 + Reduce memory usage by around 15% by using a more efficient representation of union types (PR #729).

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -21,9 +21,15 @@ class Config
      */
     private static $configuration = self::DEFAULT_CONFIGURATION;
 
-    // The 4 most commonly accessed configs:
+    // The 6 most commonly accessed configs:
     /** @var bool */
     private static $null_casts_as_any_type = false;
+
+    /** @var bool */
+    private static $null_casts_as_array = false;
+
+    /** @var bool */
+    private static $array_casts_as_null = false;
 
     /** @var bool */
     private static $dead_code_detection = false;
@@ -155,6 +161,16 @@ class Config
         // to a class property that wasn't explicitly
         // defined.
         'allow_missing_properties' => false,
+
+        // Allow null to be cast as any array-like type
+        // This is an incremental step in migrating away from null_casts_as_any_type.
+        // If null_casts_as_any_type is true, this has no effect.
+        'null_casts_as_array' => false,
+
+        // Allow any array-like type to be cast to null.
+        // This is an incremental step in migrating away from null_casts_as_any_type.
+        // If null_casts_as_any_type is true, this has no effect.
+        'array_casts_as_null' => false,
 
         // Allow null to be cast as any type and for any
         // type to be cast to null. Setting this to false
@@ -595,6 +611,16 @@ class Config
         return self::$null_casts_as_any_type;
     }
 
+    public static function get_null_casts_as_array() : bool
+    {
+        return self::$null_casts_as_array;
+    }
+
+    public static function get_array_casts_as_null() : bool
+    {
+        return self::$array_casts_as_null;
+    }
+
     public static function get_dead_code_detection() : bool
     {
         return self::$dead_code_detection;
@@ -648,6 +674,12 @@ class Config
         switch ($name) {
         case 'null_casts_as_any_type':
             self::$null_casts_as_any_type = $value;
+            break;
+        case 'null_casts_as_array':
+            self::$null_casts_as_array = $value;
+            break;
+        case 'array_casts_as_null':
+            self::$array_casts_as_null = $value;
             break;
         case 'dead_code_detection':
             self::$dead_code_detection = $value;

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1279,9 +1279,11 @@ class Type
         if ($this->getIsNullable() && !$type->getIsNullable()) {
 
             // If this is nullable, but that isn't, and we've
-            // configured nulls to cast as anything, ignore
+            // configured nulls to cast as anything (or as arrays), ignore
             // the nullable part.
             if (Config::get_null_casts_as_any_type()) {
+                return $this->withIsNullable(false)->canCastToType($type);
+            } else if (Config::get_null_casts_as_array() && $type->isArrayLike()) {
                 return $this->withIsNullable(false)->canCastToType($type);
             }
 

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -852,6 +852,13 @@ class UnionType implements \Serializable
             ) {
                 return true;
             }
+        } else {
+            // If null_casts_as_any_type isn't set, then try the other two fallbacks.
+            if (Config::get_null_casts_as_array() && $this->isType($null_type) && $target->hasArrayLike()) {
+                return true;
+            } else if (Config::get_array_casts_as_null() && $target->isType($null_type) && $this->hasArrayLike()) {
+                return true;
+            }
         }
 
         // mixed <-> mixed


### PR DESCRIPTION
These settings make it easier for large projects to move away from the
`null_casts_as_any_type` setting.
(It's generally safer to treat null like an array than to treat null
like an object)