### PR TITLE
Fixes #925: Check for signature compatibility against all ancestor classes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -44,6 +44,7 @@ New Features (CLI, Configs)
 Maintenance
 + Reduce memory usage by around 15% by using a more efficient representation of union types (PR #729).
   The optional extension https://github.com/runkit7/runkit_object_id can be installed to boost performance by around 10%.
++ Check method signatures compatibility against all overridden methods (e.g. interfaces with the same methods), not just the first ones (Issue #925)
 
 Bug Fixes
 + Work around known bugs in current releases of two PECL extensions (Issue #888, #889)

--- a/tests/files/expected/0324_override_multiple_parent_and_interface.php.expected
+++ b/tests/files/expected/0324_override_multiple_parent_and_interface.php.expected
@@ -1,0 +1,27 @@
+%s:4 PhanParamSignatureMismatch Declaration of function foo(int $x) : int should be compatible with function foo(int $x) : string defined in %s:12
+%s:4 PhanParamSignatureMismatch Declaration of function foo(int $x) : int should be compatible with function foo(int $x, int $y) : string defined in %s:16
+%s:4 PhanParamSignatureMismatch Declaration of function foo(int $x) : int should be compatible with function foo(string $x) : array defined in %s:30
+%s:4 PhanParamSignatureMismatch Declaration of function foo(int $x) : int should be compatible with function foo(string $x) : int defined in %s:26
+%s:4 PhanParamSignatureMismatch Declaration of function foo(int $x) : int should be compatible with function foo(string $x) : string defined in %s:20
+%s:4 PhanParamSignatureMismatch Declaration of function foo(int $x) : int should be compatible with function foo(string $x) : string defined in %s:8
+%s:4 PhanParamSignatureRealMismatchParamType Declaration of function foo(int $x) : int should be compatible with function foo(string $x) : array (parameter #1 of type 'int' cannot replace original parameter of type 'string') defined in %s:30
+%s:4 PhanParamSignatureRealMismatchParamType Declaration of function foo(int $x) : int should be compatible with function foo(string $x) : int (parameter #1 of type 'int' cannot replace original parameter of type 'string') defined in %s:26
+%s:4 PhanParamSignatureRealMismatchParamType Declaration of function foo(int $x) : int should be compatible with function foo(string $x) : string (parameter #1 of type 'int' cannot replace original parameter of type 'string') defined in %s:20
+%s:4 PhanParamSignatureRealMismatchParamType Declaration of function foo(int $x) : int should be compatible with function foo(string $x) : string (parameter #1 of type 'int' cannot replace original parameter of type 'string') defined in %s:8
+%s:4 PhanParamSignatureRealMismatchReturnType Declaration of function foo(int $x) : int should be compatible with function foo(int $x) : string (method returning 'int' cannot override method returning 'string') defined in %s:12
+%s:4 PhanParamSignatureRealMismatchReturnType Declaration of function foo(int $x) : int should be compatible with function foo(string $x) : array (method returning 'int' cannot override method returning 'array') defined in %s:30
+%s:4 PhanParamSignatureRealMismatchReturnType Declaration of function foo(int $x) : int should be compatible with function foo(string $x) : string (method returning 'int' cannot override method returning 'string') defined in %s:20
+%s:4 PhanParamSignatureRealMismatchReturnType Declaration of function foo(int $x) : int should be compatible with function foo(string $x) : string (method returning 'int' cannot override method returning 'string') defined in %s:8
+%s:4 PhanParamSignatureRealMismatchTooFewParameters Declaration of function foo(int $x) : int should be compatible with function foo(int $x, int $y) : string (the method override accepts 1 parameter(s), but the overridden method can accept 2) defined in %s:16
+%s:20 PhanParamSignatureMismatch Declaration of function foo(string $x) : string should be compatible with function foo(int $x) : int defined in %s:4
+%s:20 PhanParamSignatureMismatch Declaration of function foo(string $x) : string should be compatible with function foo(int $x) : string defined in %s:12
+%s:20 PhanParamSignatureMismatch Declaration of function foo(string $x) : string should be compatible with function foo(int $x, int $y) : string defined in %s:16
+%s:20 PhanParamSignatureMismatch Declaration of function foo(string $x) : string should be compatible with function foo(string $x) : array defined in %s:30
+%s:20 PhanParamSignatureMismatch Declaration of function foo(string $x) : string should be compatible with function foo(string $x) : int defined in %s:26
+%s:20 PhanParamSignatureRealMismatchParamType Declaration of function foo(string $x) : string should be compatible with function foo(int $x) : int (parameter #1 of type 'string' cannot replace original parameter of type 'int') defined in %s:4
+%s:20 PhanParamSignatureRealMismatchParamType Declaration of function foo(string $x) : string should be compatible with function foo(int $x) : string (parameter #1 of type 'string' cannot replace original parameter of type 'int') defined in %s:12
+%s:20 PhanParamSignatureRealMismatchReturnType Declaration of function foo(string $x) : string should be compatible with function foo(int $x) : int (method returning 'string' cannot override method returning 'int') defined in %s:4
+%s:20 PhanParamSignatureRealMismatchReturnType Declaration of function foo(string $x) : string should be compatible with function foo(string $x) : array (method returning 'string' cannot override method returning 'array') defined in %s:30
+%s:20 PhanParamSignatureRealMismatchReturnType Declaration of function foo(string $x) : string should be compatible with function foo(string $x) : int (method returning 'string' cannot override method returning 'int') defined in %s:26
+%s:20 PhanParamSignatureRealMismatchTooFewParameters Declaration of function foo(string $x) : string should be compatible with function foo(int $x, int $y) : string (the method override accepts 1 parameter(s), but the overridden method can accept 2) defined in %s:16
+%s:21 PhanTypeMismatchReturn Returning type int but foo() is declared to return string

--- a/tests/files/src/0324_override_multiple_parent_and_interface.php
+++ b/tests/files/src/0324_override_multiple_parent_and_interface.php
@@ -1,0 +1,38 @@
+<?php
+
+interface MyInterface324 {
+    public function foo(int $x) : int;
+}
+
+interface MyInterface324B {
+    public function foo(string $x) : string;
+}
+
+interface MyInterface324C {
+    public function foo(int $x) : string;
+}
+
+interface MyInterface324D {
+    public function foo(int $x, int $y) : string;
+}
+
+class MyBase324 {
+    public function foo(string $x) : string {
+        return strlen($x);
+    }
+}
+
+trait MyTrait324 {
+    public abstract function foo(string $x) : int;
+}
+
+trait MyTrait324B {
+    public abstract function foo(string $x) : array;
+}
+
+// The implementation inherited from MyBase324 should be type checked against that list of interfaces
+class MySubclass extends MyBase324 implements MyInterface324, MyInterface324B, MyInterface324C, MyInterface324D {
+    use MyTrait324;
+    use MyTrait324;
+    use MyTrait324B;
+}


### PR DESCRIPTION
Properly check method implementations against the **full** list of abstract
methods in parent classes and traits.