### PR TITLE
Fixes #914: Return appropriate line for placeholder constructor.

### DIFF
--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -195,6 +195,11 @@ class Method extends ClassElement implements FunctionInterface
         Context $context,
         CodeBase $code_base
     ) : Method {
+        if ($clazz->hasMethodWithName($code_base, $clazz->getName())) {
+            $old_style_constructor = $clazz->getMethodByName($code_base, $clazz->getName());
+        } else {
+            $old_style_constructor = null;
+        }
 
         $method_fqsen = FullyQualifiedMethodName::make(
             $clazz->getFQSEN(),
@@ -202,19 +207,20 @@ class Method extends ClassElement implements FunctionInterface
         );
 
         $method = new Method(
-            $context,
+            $old_style_constructor ? $old_style_constructor->getContext() : $clazz->getContext(),
             '__construct',
             $clazz->getUnionType(),
             0,
             $method_fqsen
         );
 
-        if ($clazz->hasMethodWithName($code_base, $clazz->getName())) {
-            $old_style_constructor = $clazz->getMethodByName($code_base, $clazz->getName());
+        if ($old_style_constructor) {
             $method->setParameterList($old_style_constructor->getParameterList());
             $method->setRealParameterList($old_style_constructor->getRealParameterList());
             $method->setNumberOfRequiredParameters($old_style_constructor->getNumberOfRequiredParameters());
             $method->setNumberOfOptionalParameters($old_style_constructor->getNumberOfOptionalParameters());
+            $method->setRealReturnType($old_style_constructor->getRealReturnType());
+            $method->setUnionType($old_style_constructor->getUnionType());
         }
 
         return $method;

--- a/tests/files/expected/0278_internal_elements.php.expected
+++ b/tests/files/expected/0278_internal_elements.php.expected
@@ -1,6 +1,6 @@
 %s:92 PhanAccessMethodInternal Cannot access internal method \NS278\A\f of namespace \NS278\A defined at %s:33 from namespace \NS278\B
 %s:94 PhanAccessConstantInternal Cannot access internal constant \NS278\A\CONST_INTERNAL of namepace \NS278\A defined at %s:8 from namespace \NS278\B
-%s:96 PhanAccessMethodInternal Cannot access internal method \NS278\A\C1::__construct of namespace \NS278\A defined at %s:39 from namespace \NS278\B
+%s:96 PhanAccessMethodInternal Cannot access internal method \NS278\A\C1::__construct of namespace \NS278\A defined at %s:11 from namespace \NS278\B
 %s:97 PhanAccessPropertyInternal Cannot access internal property \NS278\A\C1::p of namespace \NS278\A defined at %s:13 from namespace \NS278\B
 %s:98 PhanAccessMethodInternal Cannot access internal method \NS278\A\C1::f of namespace \NS278\A defined at %s:14 from namespace \NS278\B
 %s:99 PhanAccessClassConstantInternal Cannot access internal class constant \NS278\A\C1::CONST_INTERNAL defined at %s:12

--- a/tests/files/expected/0310_self_construct.php.expected
+++ b/tests/files/expected/0310_self_construct.php.expected
@@ -5,4 +5,4 @@
 %s:20 PhanTypeMismatchArgument Argument 1 (arg) is string but \Foo310::__construct() takes int defined at %s:14
 %s:21 PhanParamTooMany Call with 1 arg(s) to \Bar310::__construct() which only takes 0 arg(s) defined at %s:7
 %s:25 PhanTypeMismatchArgument Argument 1 (arg) is string but \Foo310::__construct() takes int defined at %s:14
-%s:27 PhanParamTooMany Call with 1 arg(s) to \Baz310::__construct() which only takes 0 arg(s) defined at %s:27
+%s:27 PhanParamTooMany Call with 1 arg(s) to \Baz310::__construct() which only takes 0 arg(s) defined at %s:3

--- a/tests/files/expected/0325_php4_construct.php.expected
+++ b/tests/files/expected/0325_php4_construct.php.expected
@@ -1,0 +1,4 @@
+%s:6 PhanUndeclaredStaticMethod Static call to undeclared method \Bar325::__construct
+%s:6 PhanUndeclaredStaticMethod Static call to undeclared method self::__construct()
+%s:14 PhanTypeMismatchArgument Argument 1 (arg) is int but \Bar325::Bar325() takes array defined at %s:5
+%s:18 PhanTypeMismatchArgument Argument 1 (arg) is int but \Bar325::__construct() takes array defined at %s:5

--- a/tests/files/src/0325_php4_construct.php
+++ b/tests/files/src/0325_php4_construct.php
@@ -1,0 +1,19 @@
+<?php
+
+class Bar325 {
+    /** @return int */
+    public function Bar325(array $arg) {
+        self::__construct(23);  // The explicit constructor doesn't exist.
+        return 42;
+    }
+}
+
+class Foo325 extends Bar325 {
+    public $arg;
+    public function __construct(int $arg) {
+        parent::Bar325($arg);
+    }
+}
+// error happens with/without the below lines.
+$f325 = new Bar325(11);
+$f325 = new Foo325(11);


### PR DESCRIPTION
Previously, Phan would say it was defined where it was invoked.
Now, Phan says it's defined where the PHP4 constructor was defined,
or where the class was defined.