### PR TITLE
Fixes #868 : Check if analysis worker failed to emit valid output

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -49,6 +49,7 @@ Maintenance
 Bug Fixes
 + Work around known bugs in current releases of two PECL extensions (Issue #888, #889)
 + Fix typo - Change `PhanParamSignatureRealMismatch` to `PhanParamSignatureRealMismatchReturnType`
++ Consistently exit with non-zero exit code if there are multiple processes, and any process failed to return valid results. (Issue #868)
 
 Backwards Incompatible Changes
 

--- a/tests/Phan/ForkPoolTest.php
+++ b/tests/Phan/ForkPoolTest.php
@@ -30,11 +30,11 @@ class ForkPoolTest extends BaseTest
 
         $worker_data = [];
         $pool = new ForkPool($data,
-            function() { },
-            function($i, $data) use(&$worker_data) {
+            function() : void { },
+            function($i, $data) use(&$worker_data) : void {
                 $worker_data[] = $data;
             },
-            function() use(&$worker_data) {
+            function() use(&$worker_data) : array {
                 return $worker_data;
             });
 
@@ -50,17 +50,19 @@ class ForkPoolTest extends BaseTest
         $did_startup = false;
         $pool = new ForkPool(
             [[1], [2], [3], [4]],
+            /** @return void */
             function() use(&$did_startup) {
                 $did_startup = true;
             },
+            /** @return void */
             function($i, $data) {
             },
-            function() use(&$did_startup){
-                return $did_startup;
+            function() use(&$did_startup) : array {
+                return [$did_startup];
             });
 
         $this->assertEquals(
-            [true, true, true, true],
+            [[true], [true], [true], [true]],
             $pool->wait());
     }
 }


### PR DESCRIPTION
Also, change code so that the analysis worker always sends a serialized
array on success (empty array if no errors were detected).

Make `./phan` exit with EXIT_FAILURE if one of the analysis workers failed to run, to make issues more noticeable.