### PR TITLE
Don't warn about global function __autoload being dead code.

### DIFF
--- a/src/Phan/Analysis/ReferenceCountsAnalyzer.php
+++ b/src/Phan/Analysis/ReferenceCountsAnalyzer.php
@@ -10,6 +10,7 @@ use Phan\Issue;
 use Phan\Language\Element\AddressableElement;
 use Phan\Language\Element\ClassConstant;
 use Phan\Language\Element\ClassElement;
+use Phan\Language\Element\Func;
 use Phan\Language\Element\Method;
 use Phan\Language\Element\Property;
 use Phan\Library\Map;
@@ -48,7 +49,7 @@ class ReferenceCountsAnalyzer
         self::analyzeElementListReferenceCounts(
             $code_base,
             $code_base->getFunctionMap(),
-            Issue::UnreferencedMethod,
+            Issue::UnreferencedFunction,
             $total_count,
             $i
         );
@@ -242,6 +243,9 @@ class ReferenceCountsAnalyzer
                         // then also treat it as a reference to the duplicate.
                         return;
                     }
+                }
+                if ($element instanceof Func && \strcasecmp($element->getName(), "__autoload") === 0) {
+                    return;
                 }
 
                 // If there are duplicate declarations, display issues for unreferenced elements on each declaration.

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -145,6 +145,7 @@ class Issue
     const NoopProperty              = 'PhanNoopProperty';
     const NoopVariable              = 'PhanNoopVariable';
     const UnreferencedClass         = 'PhanUnreferencedClass';
+    const UnreferencedFunction      = 'PhanUnreferencedFunction';
     const UnreferencedMethod        = 'PhanUnreferencedMethod';
     const UnreferencedProperty      = 'PhanUnreferencedProperty';
     const UnreferencedConstant      = 'PhanUnreferencedConstant';
@@ -1350,6 +1351,14 @@ class Issue
                 "Possibly zero references to constant {CONST}",
                 self::REMEDIATION_B,
                 6008
+            ),
+            new Issue(
+                self::UnreferencedFunction,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_NORMAL,
+                "Possibly zero references to function {FUNCTION}",
+                self::REMEDIATION_B,
+                6009
             ),
 
             // Issue::CATEGORY_REDEFINE

--- a/tests/plugin_test/expected/all_output.expected
+++ b/tests/plugin_test/expected/all_output.expected
@@ -9,7 +9,9 @@ src/000_plugins.php:40 PhanPluginNonBoolInLogicalArith Non bool value in logical
 src/000_plugins.php:47 PhanPluginNumericalComparison non numerical values compared by the operators '==' or '!=='
 src/000_plugins.php:49 PhanPluginNumericalComparison numerical values compared by the operators '===' or '!=='
 src/000_plugins.php:55 UnusedSuppression Element \testUnusedSuppressionPlugin suppresses issue PhanParamTooFew but does not use it
-src/000_plugins.php:61 PhanUnreferencedMethod Possibly zero references to method \testUnreferencedFunction
+src/000_plugins.php:61 PhanUnreferencedFunction Possibly zero references to function \testUnreferencedFunction
+src/000_plugins.php:66 PhanUnreferencedClass Possibly zero references to class \__autoload
+src/000_plugins.php:67 PhanUnreferencedConstant Possibly zero references to constant \__autoload
 src/001_globals_type_map.php:5 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \Exception|\Throwable but \intdiv() takes int
 src/001_globals_type_map.php:8 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \Error|\Throwable but \intdiv() takes int
 src/001_globals_type_map.php:12 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \Exception|\Throwable but \intdiv() takes int

--- a/tests/plugin_test/src/000_plugins.php
+++ b/tests/plugin_test/src/000_plugins.php
@@ -59,3 +59,9 @@ testUnusedSuppressionPlugin();
 
 // Dead code detection should detect this
 function testUnreferencedFunction() {}
+
+// Dead code detection should not warn about built in error handlers
+function __autoload($className) {}
+// meaningless things with the same names
+class __autoload {}
+const __autoload = 3;


### PR DESCRIPTION
And add PhanUndeclaredFunction as a new issue type.

Fixes #711