### PR TITLE
Don't unnecessarily track references to methods

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -102,6 +102,12 @@ return [
     // to make sense of.
     'dead_code_detection' => false,
 
+    // Set to true in order to force tracking references to elements
+    // (functions/methods/consts/protected).
+    // dead_code_detection is another option which also causes references
+    // to be tracked.
+    'force_tracking_references' => false,
+
     // Run a quick version of checks that takes less
     // time
     "quick_mode" => false,

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -296,7 +296,7 @@ class Analysis
         // in mind that the results here are just a guess and
         // we can't tell with certainty that anything is
         // definitely unreferenced.
-        if (!Config::get_dead_code_detection()) {
+        if (!Config::getValue('dead_code_detection')) {
             return;
         }
 

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1071,7 +1071,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             // If we can't figure out the class for this method
             // call, cry YOLO and mark every method with that
             // name with a reference.
-            if (Config::get_dead_code_detection()
+            if (Config::get_track_references()
                 && Config::getValue('dead_code_detection_prefer_false_negative')
             ) {
                 foreach ($this->code_base->getMethodSetByName(
@@ -1182,7 +1182,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             // If we can't figure out the class for this method
             // call, cry YOLO and mark every method with that
             // name with a reference.
-            if (Config::get_dead_code_detection()
+            if (Config::get_track_references()
                 && Config::getValue('dead_code_detection_prefer_false_negative')
             ) {
                 foreach ($this->code_base->getMethodSetByName(
@@ -1358,7 +1358,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             // If we can't figure out the class for this method
             // call, cry YOLO and mark every method with that
             // name with a reference.
-            if (Config::get_dead_code_detection()
+            if (Config::get_track_references()
                 && Config::getValue('dead_code_detection_prefer_false_negative')
             ) {
                 foreach ($this->code_base->getMethodSetByName(
@@ -1679,7 +1679,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 continue;
             }
 
-            if (Config::get_dead_code_detection()) {
+            if (Config::get_track_references()) {
                 (new ArgumentVisitor(
                     $this->code_base,
                     $this->context

--- a/src/Phan/Analysis/ReferenceCountsAnalyzer.php
+++ b/src/Phan/Analysis/ReferenceCountsAnalyzer.php
@@ -37,7 +37,7 @@ class ReferenceCountsAnalyzer
         // in mind that the results here are just a guess and
         // we can't tell with certainty that anything is
         // definitely unreferenced.
-        if (!Config::get_dead_code_detection()) {
+        if (!Config::getValue('dead_code_detection')) {
             return;
         }
 

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -557,10 +557,10 @@ class CodeBase
 
         $this->func_and_method_set->attach($method);
 
-        // If we're doing dead code detection and this is a
+        // If we're doing dead code detection(or something else) and this is a
         // method, map the name to the FQSEN so we can do hail-
         // mary references.
-        if (Config::get_dead_code_detection()) {
+        if (Config::get_track_references()) {
             if (empty($this->name_method_map[$method->getFQSEN()->getNameWithAlternateId()])) {
                 $this->name_method_map[$method->getFQSEN()->getNameWithAlternateId()] = new Set;
             }
@@ -619,9 +619,9 @@ class CodeBase
      */
     public function getMethodSetByName(string $name) : Set
     {
-        \assert(Config::get_dead_code_detection(),
+        \assert(Config::get_track_references(),
             __METHOD__ . ' can only be called when dead code '
-            . ' detection is enabled.'
+            . ' detection (or force_tracking_references) is enabled.'
         );
 
         return $this->name_method_map[$name] ?? new Set;

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -32,7 +32,7 @@ class Config
     private static $array_casts_as_null = false;
 
     /** @var bool */
-    private static $dead_code_detection = false;
+    private static $track_references = false;
 
     /** @var bool */
     private static $backward_compatibility_checks = false;
@@ -222,6 +222,12 @@ class Config
         // `$class->$method()`) in ways that we're unable
         // to make sense of.
         'dead_code_detection' => false,
+
+        // Set to true in order to force tracking references to elements
+        // (functions/methods/consts/protected).
+        // dead_code_detection is another option which also causes references
+        // to be tracked.
+        'force_tracking_references' => false,
 
         // If true, the dead code detection rig will
         // prefer false negatives (not report dead code) to
@@ -621,9 +627,14 @@ class Config
         return self::$array_casts_as_null;
     }
 
+    public static function get_track_references() : bool
+    {
+        return self::$track_references;
+    }
+
     public static function get_dead_code_detection() : bool
     {
-        return self::$dead_code_detection;
+        return self::getValue('dead_code_detection');
     }
 
     public static function get_backward_compatibility_checks() : bool
@@ -671,6 +682,7 @@ class Config
      */
     public static function setValue(string $name, $value)
     {
+        self::$configuration[$name] = $value;
         switch ($name) {
         case 'null_casts_as_any_type':
             self::$null_casts_as_any_type = $value;
@@ -682,7 +694,8 @@ class Config
             self::$array_casts_as_null = $value;
             break;
         case 'dead_code_detection':
-            self::$dead_code_detection = $value;
+        case 'force_tracking_references':
+            self::$track_references = self::getValue('dead_code_detection') || self::getValue('force_tracking_references');
             break;
         case 'backward_compatibility_checks':
             self::$backward_compatibility_checks = $value;
@@ -692,7 +705,6 @@ class Config
             break;
         }
 
-        self::$configuration[$name] = $value;
     }
 
     /**

--- a/src/Phan/Language/Element/AddressableElement.php
+++ b/src/Phan/Language/Element/AddressableElement.php
@@ -2,6 +2,7 @@
 namespace Phan\Language\Element;
 
 use Phan\CodeBase;
+use Phan\Config;
 use Phan\Language\Context;
 use Phan\Language\FQSEN;
 use Phan\Language\FQSEN\FullyQualifiedGlobalStructuralElement;
@@ -178,7 +179,9 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
      */
     public function addReference(FileRef $file_ref)
     {
-        $this->reference_list[] = $file_ref;
+        if (Config::get_track_references()) {
+            $this->reference_list[] = $file_ref;
+        }
     }
 
     /**


### PR DESCRIPTION
Reduces memory usage 3%

If things other than dead code detection (e.g. plugins) are configured
to use this info, they should set the config option
force_tracking_references to true while being initialized.