### PR TITLE
Prevent Phan termination on stat() error in daemon mode.

### DIFF
--- a/src/Phan/Bootstrap.php
+++ b/src/Phan/Bootstrap.php
@@ -42,11 +42,19 @@ set_exception_handler(function (Throwable $throwable) {
 });
 
 /**
+ * The error handler for PHP notices, etc.
+ * This is a named function instead of a closure to make stack traces easier to read.
+ *
  * @suppress PhanUnreferencedMethod
  */
 function phan_error_handler($errno, $errstr, $errfile, $errline)
 {
     error_log("$errfile:$errline [$errno] $errstr\n");
+    if (error_reporting() === 0) {
+        // https://secure.php.net/manual/en/language.operators.errorcontrol.php
+        // Don't make Phan terminate if the @-operator was being used on an expression.
+        return false;
+    }
 
     ob_start();
     debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);

--- a/src/Phan/CodeBase/UndoTracker.php
+++ b/src/Phan/CodeBase/UndoTracker.php
@@ -58,7 +58,7 @@ class UndoTracker {
     }
 
     /**
-     * @param string|null $current_parsed_file
+     * @param ?string $current_parsed_file
      * @return void
      */
     public function setCurrentParsedFile($current_parsed_file) {
@@ -71,7 +71,7 @@ class UndoTracker {
 
 
     /**
-     * @return string|null - This string should change when the file is modified. Returns null if the file somehow doesn't exist
+     * @return ?string - This string should change when the file is modified. Returns null if the file somehow doesn't exist
      */
     public static function getFileState(string $path) {
         clearstatcache(true, $path);  // TODO: does this work properly with symlinks? seems to.
@@ -79,7 +79,10 @@ class UndoTracker {
         if (!$real) {
             return null;
         }
-        $stat = @stat($real);  // suppress notices because phan's error_handler terminates on error.
+        if (!file_exists($real)) {
+            return null;
+        }
+        $stat = @stat($real);  // Double check: suppress to prevent phan's error_handler from terminating on error.
         if (!$stat) {
             return null;  // It was missing or unreadable.
         }


### PR DESCRIPTION
Fixes #955

https://secure.php.net/manual/en/language.operators.errorcontrol.php

> If you have set a custom error handler function with
> set_error_handler() then it will still get called
> (With @-operator)

Work around this by checking if error_reporting() is 0 in the
phan_error_handler