### PR TITLE
Fixes #871: Improve warnings and inferences about function references

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -26,6 +26,8 @@ New Features (Analysis)
 + Create `PhanTypeMagicVoidWithReturn` to warn if `void` methods such as `__construct`, `__set`, etc return a value that would be ignored. (Issue #913)
 + Add check for `PhanTypeMissingReturn` within closures. Properly emit `PhanTypeMissingReturn` in functions/methods containing closures. (Issue #599)
 + Improved checking for `PhanUndeclaredVariable` in array keys and conditional conditions. (Issue #912)
++ Improved warnings and inferences about internal function references for functions such as `sort`, `preg_match` (Issue #871, #958)
+  Phan is now aware of many internal functions which normally ignore the original values of references passed in (E.g. `preg_match`)
 
 New Features (CLI, Configs)
 + Create `check_docblock_signature_param_type_match` (similar to `check_docblock_signature_return_type_match`) config setting

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -356,47 +356,54 @@ class ArgumentType
                     ? $alternate_parameter->getUnionType()
                     : 'unknown';
 
-                if (\is_object($parameter_type) && $parameter_type->hasTemplateType()) {
-                    // Don't worry about template types
-                } elseif ($method->isPHPInternal()) {
-                    // If we are not in strict mode and we accept a string parameter
-                    // and the argument we are passing has a __toString method then it is ok
-                    if(!$context->getIsStrictTypes() && \is_object($parameter_type) && $parameter_type->hasType(StringType::instance(false))) {
-                        try {
-                            foreach($argument_type_expanded->asClassList($code_base, $context) as $clazz) {
-                                if($clazz->hasMethodWithName($code_base, "__toString")) {
-                                    return;
-                                }
-                            }
-                        } catch (CodeBaseException $e) {
-                            // Swallow "Cannot find class", go on to emit issue
-                        }
-                    }
-                    Issue::maybeEmit(
-                        $code_base,
-                        $context,
-                        Issue::TypeMismatchArgumentInternal,
-                        $node->lineno ?? 0,
-                        ($i+1),
-                        $parameter_name,
-                        $argument_type_expanded,
-                        (string)$method->getFQSEN(),
-                        (string)$parameter_type
-                    );
+                if ($alternate_parameter instanceof Parameter) {
+                    $can_skip_type_check = $alternate_parameter->isPassByReference() && $alternate_parameter->getReferenceType() === Parameter::REFERENCE_WRITE_ONLY;
                 } else {
-                    Issue::maybeEmit(
-                        $code_base,
-                        $context,
-                        Issue::TypeMismatchArgument,
-                        $node->lineno ?? 0,
-                        ($i+1),
-                        $parameter_name,
-                        $argument_type_expanded,
-                        (string)$method->getFQSEN(),
-                        (string)$parameter_type,
-                        $method->getFileRef()->getFile(),
-                        $method->getFileRef()->getLineNumberStart()
-                    );
+                    $can_skip_type_check = false;  // is this possible?
+                }
+                if (!$can_skip_type_check) {
+                    if (\is_object($parameter_type) && $parameter_type->hasTemplateType()) {
+                        // Don't worry about template types
+                    } elseif ($method->isPHPInternal()) {
+                        // If we are not in strict mode and we accept a string parameter
+                        // and the argument we are passing has a __toString method then it is ok
+                        if(!$context->getIsStrictTypes() && \is_object($parameter_type) && $parameter_type->hasType(StringType::instance(false))) {
+                            try {
+                                foreach($argument_type_expanded->asClassList($code_base, $context) as $clazz) {
+                                    if($clazz->hasMethodWithName($code_base, "__toString")) {
+                                        return;
+                                    }
+                                }
+                            } catch (CodeBaseException $e) {
+                                // Swallow "Cannot find class", go on to emit issue
+                            }
+                        }
+                        Issue::maybeEmit(
+                            $code_base,
+                            $context,
+                            Issue::TypeMismatchArgumentInternal,
+                            $node->lineno ?? 0,
+                            ($i+1),
+                            $parameter_name,
+                            $argument_type_expanded,
+                            (string)$method->getFQSEN(),
+                            (string)$parameter_type
+                        );
+                    } else {
+                        Issue::maybeEmit(
+                            $code_base,
+                            $context,
+                            Issue::TypeMismatchArgument,
+                            $node->lineno ?? 0,
+                            ($i+1),
+                            $parameter_name,
+                            $argument_type_expanded,
+                            (string)$method->getFQSEN(),
+                            (string)$parameter_type,
+                            $method->getFileRef()->getFile(),
+                            $method->getFileRef()->getLineNumberStart()
+                        );
+                    }
                 }
             }
         }

--- a/src/Phan/Language/Element/Flags.php
+++ b/src/Phan/Language/Element/Flags.php
@@ -21,6 +21,10 @@ class Flags
     const IS_NS_INTERNAL               = (1 << 12);
     const IS_FROM_PHPDOC               = (1 << 13);
 
+    // These can be combined in 3 ways, see Parameter->getReferenceType()
+    const IS_READ_REFERENCE            = (1 << 14);
+    const IS_WRITE_REFERENCE           = (1 << 15);
+
     /**
      * Either enable or disable the given flag on
      * the given bit vector.

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -18,6 +18,9 @@ use ast\Node;
 
 class Parameter extends Variable
 {
+    const REFERENCE_DEFAULT = 1;
+    const REFERENCE_READ_WRITE = 2;
+    const REFERENCE_WRITE_ONLY = 3;
 
     /**
      * @var UnionType|null
@@ -486,6 +489,17 @@ class Parameter extends Variable
             $this->getFlags(),
             \ast\flags\PARAM_REF
         );
+    }
+
+    public function getReferenceType() : int
+    {
+        $flags = $this->getPhanFlags();
+        if (Flags::bitVectorHasState($flags, Flags::IS_READ_REFERENCE)) {
+            return self::REFERENCE_READ_WRITE;
+        } else if (Flags::bitVectorHasState($flags, Flags::IS_WRITE_REFERENCE)) {
+            return self::REFERENCE_WRITE_ONLY;
+        }
+        return self::REFERENCE_DEFAULT;
     }
 
     public function __toString() : string

--- a/tests/files/expected/0326_references_warn.php.expected
+++ b/tests/files/expected/0326_references_warn.php.expected
@@ -1,0 +1,3 @@
+%s:4 PhanTypeNonVarPassByRef Only variables can be passed by reference at argument 1 of \sort()
+%s:6 PhanTypeMismatchArgumentInternal Argument 1 (array_arg) is int but \sort() takes array
+%s:8 PhanTypeMismatchArgumentInternal Argument 1 (stack) is string but \array_shift() takes array

--- a/tests/files/expected/0327_references_sort_preserves_type.php.expected
+++ b/tests/files/expected/0327_references_sort_preserves_type.php.expected
@@ -1,0 +1,1 @@
+%s:6 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \stdClass but \intdiv() takes int

--- a/tests/files/expected/0328_references_preg_match_ignores_old_type.php.expected
+++ b/tests/files/expected/0328_references_preg_match_ignores_old_type.php.expected
@@ -1,0 +1,2 @@
+%s:6 PhanTypeNonVarPassByRef Only variables can be passed by reference at argument 3 of \preg_match()
+%s:8 PhanTypeMismatchArgumentInternal Argument 1 (string) is array but \strlen() takes string

--- a/tests/files/src/0326_references_warn.php
+++ b/tests/files/src/0326_references_warn.php
@@ -1,0 +1,9 @@
+<?php
+
+function test326() {
+    sort([]);
+    $x = 2;
+    sort($x);
+    $z = 'a';
+    $y = array_shift($z);
+}

--- a/tests/files/src/0327_references_sort_preserves_type.php
+++ b/tests/files/src/0327_references_sort_preserves_type.php
@@ -1,0 +1,7 @@
+<?php
+
+function test_sort_preserves_type() {
+    $x = [new stdClass(), new stdClass()];
+    sort($x);
+    echo intdiv($x[0], 2);
+}

--- a/tests/files/src/0328_references_preg_match_ignores_old_type.php
+++ b/tests/files/src/0328_references_preg_match_ignores_old_type.php
@@ -1,0 +1,10 @@
+<?php
+
+function test328(string $str) {
+    $matches = 'ignored';
+    preg_match('/foo/', 'foobar', $matches);  // doesn't warn about incompatibility
+    preg_match('/foo/', $str, 'hello');  // warns about non-reference being passed in
+    if ($matches) {
+        echo strlen($matches);  // warns that $matches is actually an array
+    }
+}


### PR DESCRIPTION
Fixes #958 (already "fixed" on master branch, but had different issues)

The internal function signature map prefixes references with "&w_" to
indicate that the a reference is write-only
(Previous value is ignored, and overridden unless there was an error)
It also adds "&rw_" to indicate that the original type should be preserved
without adding new types (e.g. for sorting methods)

- No way to specify this for user-defined functions/methods, yet.

This may change even more before the 0.9.3 release,
but the preg_match behavior and sort() tests should ideally continue passing.