### PR TITLE
Fixes #963 : Warn (to stderr) if the installed php-ast version is too low.

### DIFF
--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -52,12 +52,12 @@ class Analysis
             if (\is_string($override_contents)) {
                 $node = \ast\parse_code(
                     $override_contents,
-                    Config::getValue('ast_version')
+                    Config::AST_VERSION
                 );
             } else {
                 $node = \ast\parse_file(
                     Config::projectPath($file_path),
-                    Config::getValue('ast_version')
+                    Config::AST_VERSION
                 );
             }
         } catch (\ParseError $parse_error) {
@@ -330,12 +330,12 @@ class Analysis
             if (\is_string($file_contents_override)) {
                 $node = \ast\parse_code(
                     $file_contents_override,
-                    Config::getValue('ast_version')
+                    Config::AST_VERSION
                 );
             } else {
                 $node = \ast\parse_file(
                     Config::projectPath($file_path),
-                    Config::getValue('ast_version')
+                    Config::AST_VERSION
                 );
             }
         } catch (\ParseError $parse_error) {

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -8,6 +8,12 @@ namespace Phan;
  */
 class Config
 {
+    /**
+     * The version of the AST (defined in php-ast) that we're using.
+     * Other versions are likely to have edge cases we no longer support,
+     * and version 45 will probably get rid of Decl.
+     */
+    const AST_VERSION = 40;
 
     /**
      * @var string|null
@@ -301,10 +307,6 @@ class Config
         // The number of processes to fork off during the analysis
         // phase.
         'processes' => 1,
-
-        // The vesion of the AST (defined in php-ast)
-        // we're using
-        'ast_version' => 40,
 
         // Set to true to emit profiling data on how long various
         // parts of Phan took to run. You likely don't care to do

--- a/src/Phan/Prep.php
+++ b/src/Phan/Prep.php
@@ -27,7 +27,7 @@ class Prep {
             // of this method
             $node = \ast\parse_file(
                 $file_path,
-                Config::getValue('ast_version')
+                Config::AST_VERSION
             );
 
             // Skip empty files

--- a/src/phan.php
+++ b/src/phan.php
@@ -20,22 +20,29 @@ use Phan\CodeBase;
 use Phan\Config;
 use Phan\Phan;
 
-
 try {
     $node = \ast\parse_code(
         '<?php 42;',
-        Config::getValue('ast_version')
+        Config::AST_VERSION
     );
 } catch (LogicException $throwable) {
     assert(false,
         'Unknown AST version ('
-        . Config::getValue('ast_version')
+        . Config::AST_VERSION
         . ') in configuration. '
         . 'You may need to rebuild the latest '
         . 'version of the php-ast extension.'
     );
 }
 
+if (extension_loaded('ast')) {
+    // Warn if the php-ast version is too low.
+    // (It's remotely possible \ast\parse_code could a pure PHP substitute for php-ast in the future)
+    $ast_version = (new ReflectionExtension('ast'))->getVersion();
+    if (version_compare($ast_version, '0.1.4') < 0) {
+        fprintf(STDERR, "Phan supports php-ast version 0.1.4 or newer, but the installed php-ast version is $ast_version. You may see bugs in some edge cases\n");
+    }
+}
 
 // Create our CLI interface and load arguments
 $cli = new CLI();

--- a/tests/Phan/ASTRewriterTest.php
+++ b/tests/Phan/ASTRewriterTest.php
@@ -41,7 +41,7 @@ class ASTRewriterTest extends AbstractPhanFileTest {
         $this->assertNotEquals(false, $original_src);
         $this->assertNotEquals(false, $expected_src);
 
-        $ast_version = Config::getValue('ast_version');
+        $ast_version = Config::AST_VERSION;
         $expected = \ast\parse_code($expected_src, $ast_version);
         $beforeTransform = \ast\parse_code($original_src, $ast_version);
 

--- a/tests/Phan/AnalyzerTest.php
+++ b/tests/Phan/AnalyzerTest.php
@@ -125,7 +125,7 @@ class AnalyzerTest extends BaseTest {
                 new Context,
                 \ast\parse_code(
                     '<?php ' . $code_stub,
-                    Config::getValue('ast_version')
+                    Config::AST_VERSION
                 )
             );
     }

--- a/tests/Phan/Language/ContextTest.php
+++ b/tests/Phan/Language/ContextTest.php
@@ -61,7 +61,7 @@ class ContextTest extends BaseTest {
 
         $stmt_list_node = \ast\parse_code(
             $code,
-            Config::getValue('ast_version')
+            Config::AST_VERSION
         );
 
         $class_node = $stmt_list_node->children[0];

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -145,7 +145,7 @@ class UnionTypeTest extends BaseTest {
             $this->code_base,
             \ast\parse_code(
                 $code,
-                Config::getValue('ast_version')
+                Config::AST_VERSION
             )->children[0]
         )->asExpandedTypes($this->code_base)->__toString();
     }


### PR DESCRIPTION
Don't allow users to override 'ast_version' in .phan/config.php,
this won't work, and Phan no longer supports versions older than 40.