### PR TITLE
Fixes #600 : Rewrite plugin system with a different architecture to be more efficient

### DIFF
--- a/.phan/plugins/DemoLegacyPlugin.php
+++ b/.phan/plugins/DemoLegacyPlugin.php
@@ -6,20 +6,18 @@ use Phan\Language\Context;
 use Phan\Language\Element\Clazz;
 use Phan\Language\Element\Func;
 use Phan\Language\Element\Method;
-use Phan\PluginV2;
-use Phan\PluginV2\AnalyzeClassCapability;
-use Phan\PluginV2\AnalyzeFunctionCapability;
-use Phan\PluginV2\AnalyzeMethodCapability;
-use Phan\PluginV2\AnalyzeNodeCapability;
-use Phan\PluginV2\PluginAwareAnalysisVisitor;
+use Phan\Plugin;
+use Phan\Plugin\PluginImplementation;
 use ast\Node;
 
 /**
- * This file demonstrates plugins for Phan.
- * This Plugin hooks into four events;
+ * @deprecated - Compare this with DemoPlugin.php to see how to upgrade a Plugin to PluginV2.
  *
- * - getAnalyzeNodeVisitorClassName
- *   This method returns a class that is called on every AST node from every
+ * This file demonstrates the old version of plugins for Phan. Plugins hook into
+ * four events;
+ *
+ * - analyzeNode
+ *   This method is called on every AST node from every
  *   file being analyzed
  *
  * - analyzeClass
@@ -36,8 +34,7 @@ use ast\Node;
  *
  * A plugin file must
  *
- * - Contain a class that inherits from \Phan\PluginV2
- *   and implements one or more `Capability`s.
+ * - Contain a class that inherits from \Phan\Plugin
  *
  * - End by returning an instance of that class.
  *
@@ -46,21 +43,38 @@ use ast\Node;
  *
  * Note: When adding new plugins,
  * add them to the corresponding section of README.md
- *
- * Compare this with DemoLegacyPlugin.php to see how to upgrade a subclass of the deprecated PluginImplementation to PluginV2.
  */
-class DemoPlugin extends PluginV2 implements
-    AnalyzeClassCapability,
-    AnalyzeFunctionCapability,
-    AnalyzeMethodCapability,
-    AnalyzeNodeCapability {
+class DemoLegacyPlugin extends PluginImplementation {
 
     /**
-     * @return string - The name of the visitor that will be called (formerly analyzeNode)
+     * @param CodeBase $code_base
+     * The code base in which the node exists
+     *
+     * @param Context $context
+     * The context in which the node exits. This is
+     * the context inside the given node rather than
+     * the context outside of the given node
+     *
+     * @param Node $node
+     * The php-ast Node being analyzed.
+     *
+     * @param Node $node
+     * The parent node of the given node (if one exists).
+     *
+     * @return void
      */
-    public static function getAnalyzeNodeVisitorClassName() : string
-    {
-        return DemoNodeVisitor::class;
+    public function analyzeNode(
+        CodeBase $code_base,
+        Context $context,
+        Node $node,
+        Node $parent_node = null
+    ) {
+        // Invoke the `DemoLegacyNodeVisitor` (defined later in
+        // this file) on the given node, allowing it to run
+        // a method based on the kind of the given node.
+        (new DemoLegacyNodeVisitor($code_base, $context, $this))(
+            $node
+        );
     }
 
     /**
@@ -153,8 +167,45 @@ class DemoPlugin extends PluginV2 implements
  * Visitors such as this are useful for defining lots of different
  * checks on a node based on its kind.
  */
-class DemoNodeVisitor extends PluginAwareAnalysisVisitor {
-    // A plugin's visitors should NOT implement visit(), unless they need to.
+class DemoLegacyNodeVisitor extends AnalysisVisitor {
+
+    /** @var Plugin */
+    private $plugin;
+
+    public function __construct(
+        CodeBase $code_base,
+        Context $context,
+        Plugin $plugin
+    ) {
+        // After constructing on parent, `$code_base` and
+        // `$context` will be available as protected properties
+        // `$this->code_base` and `$this->context`.
+        parent::__construct($code_base, $context);
+
+        // We take the plugin so that we can call
+        // `$this->plugin->emitIssue(...)` on it to emit issues
+        // to the user.
+        $this->plugin = $plugin;
+    }
+
+    /**
+     * Default visitor that does nothing
+     *
+     * @param Node $node
+     * A node to analyze
+     *
+     * @return void
+     */
+    public function visit(Node $node)
+    {
+        // This method will be called on all nodes for which
+        // there is no implementation of it's kind visitor.
+        //
+        // To see what kinds of nodes are passing through here,
+        // you can run `Debug::printNode($node)`.
+
+        // Debug::printNode($node);
+    }
 
     /**
      * @param Node $node
@@ -177,7 +228,9 @@ class DemoNodeVisitor extends PluginAwareAnalysisVisitor {
         // As an example, enforce that we cannot call
         // instanceof against 'object'.
         if ($class_name == 'object') {
-            $this->emit(
+            $this->plugin->emitIssue(
+                $this->code_base,
+                $this->context,
                 'PhanPluginInstanceOfObject',
                 "Cannot call instanceof against `object`"
             );
@@ -187,4 +240,5 @@ class DemoNodeVisitor extends PluginAwareAnalysisVisitor {
 
 // Every plugin needs to return an instance of itself at the
 // end of the file in which its defined.
-return new DemoPlugin;
+/** @suppress PhanDeprecatedClass - Only using a closure so that I can suppress Phan issue types */
+return (function() : DemoLegacyPlugin { return new DemoLegacyPlugin(); })();

--- a/.phan/plugins/DemoPlugin.php
+++ b/.phan/plugins/DemoPlugin.php
@@ -6,13 +6,16 @@ use Phan\Language\Context;
 use Phan\Language\Element\Clazz;
 use Phan\Language\Element\Func;
 use Phan\Language\Element\Method;
-use Phan\Plugin;
-use Phan\Plugin\PluginImplementation;
+use Phan\PluginV2;
+use Phan\PluginV2\AnalyzeClassCapability;
+use Phan\PluginV2\AnalyzeFunctionCapability;
+use Phan\PluginV2\AnalyzeMethodCapability;
+use Phan\PluginV2\LegacyAnalyzeNodeCapability;
 use ast\Node;
 
 /**
- * This file demonstrates plugins for Phan. Plugins hook into
- * four events;
+ * This file demonstrates plugins for Phan.
+ * This Plugin hooks into four events;
  *
  * - analyzeNode
  *   This method is called on every AST node from every
@@ -42,7 +45,11 @@ use ast\Node;
  * Note: When adding new plugins,
  * add them to the corresponding section of README.md
  */
-class DemoPlugin extends PluginImplementation {
+class DemoPlugin extends PluginV2 implements
+    AnalyzeClassCapability,
+    AnalyzeFunctionCapability,
+    AnalyzeMethodCapability,
+    LegacyAnalyzeNodeCapability {
 
     /**
      * @param CodeBase $code_base
@@ -167,13 +174,13 @@ class DemoPlugin extends PluginImplementation {
  */
 class DemoNodeVisitor extends AnalysisVisitor {
 
-    /** @var Plugin */
+    /** @var PluginV2 */
     private $plugin;
 
     public function __construct(
         CodeBase $code_base,
         Context $context,
-        Plugin $plugin
+        PluginV2 $plugin
     ) {
         // After constructing on parent, `$code_base` and
         // `$context` will be available as protected properties

--- a/.phan/plugins/DemoPlugin.php
+++ b/.phan/plugins/DemoPlugin.php
@@ -10,15 +10,16 @@ use Phan\PluginV2;
 use Phan\PluginV2\AnalyzeClassCapability;
 use Phan\PluginV2\AnalyzeFunctionCapability;
 use Phan\PluginV2\AnalyzeMethodCapability;
-use Phan\PluginV2\LegacyAnalyzeNodeCapability;
+use Phan\PluginV2\AnalyzeNodeCapability;
+use Phan\PluginV2\PluginAwareAnalysisVisitor;
 use ast\Node;
 
 /**
  * This file demonstrates plugins for Phan.
  * This Plugin hooks into four events;
  *
- * - analyzeNode
- *   This method is called on every AST node from every
+ * - getPreAnalyzeNodeVisitorClassName
+ *   This method returns a class that is called on every AST node from every
  *   file being analyzed
  *
  * - analyzeClass
@@ -49,37 +50,14 @@ class DemoPlugin extends PluginV2 implements
     AnalyzeClassCapability,
     AnalyzeFunctionCapability,
     AnalyzeMethodCapability,
-    LegacyAnalyzeNodeCapability {
+    AnalyzeNodeCapability {
 
     /**
-     * @param CodeBase $code_base
-     * The code base in which the node exists
-     *
-     * @param Context $context
-     * The context in which the node exits. This is
-     * the context inside the given node rather than
-     * the context outside of the given node
-     *
-     * @param Node $node
-     * The php-ast Node being analyzed.
-     *
-     * @param Node $node
-     * The parent node of the given node (if one exists).
-     *
-     * @return void
+     * @return string - The name of the visitor that will be called (formerly analyzeNode)
      */
-    public function analyzeNode(
-        CodeBase $code_base,
-        Context $context,
-        Node $node,
-        Node $parent_node = null
-    ) {
-        // Invoke the `DemoNodeVisitor` (defined later in
-        // this file) on the given node, allowing it to run
-        // a method based on the kind of the given node.
-        (new DemoNodeVisitor($code_base, $context, $this))(
-            $node
-        );
+    public static function getAnalyzeNodeVisitorClassName() : string
+    {
+        return DemoNodeVisitor::class;
     }
 
     /**
@@ -172,45 +150,8 @@ class DemoPlugin extends PluginV2 implements
  * Visitors such as this are useful for defining lots of different
  * checks on a node based on its kind.
  */
-class DemoNodeVisitor extends AnalysisVisitor {
-
-    /** @var PluginV2 */
-    private $plugin;
-
-    public function __construct(
-        CodeBase $code_base,
-        Context $context,
-        PluginV2 $plugin
-    ) {
-        // After constructing on parent, `$code_base` and
-        // `$context` will be available as protected properties
-        // `$this->code_base` and `$this->context`.
-        parent::__construct($code_base, $context);
-
-        // We take the plugin so that we can call
-        // `$this->plugin->emitIssue(...)` on it to emit issues
-        // to the user.
-        $this->plugin = $plugin;
-    }
-
-    /**
-     * Default visitor that does nothing
-     *
-     * @param Node $node
-     * A node to analyze
-     *
-     * @return void
-     */
-    public function visit(Node $node)
-    {
-        // This method will be called on all nodes for which
-        // there is no implementation of it's kind visitor.
-        //
-        // To see what kinds of nodes are passing through here,
-        // you can run `Debug::printNode($node)`.
-
-        // Debug::printNode($node);
-    }
+class DemoNodeVisitor extends PluginAwareAnalysisVisitor {
+    // A plugin's visitors should NOT implement visit(), unless they need to.
 
     /**
      * @param Node $node
@@ -233,9 +174,7 @@ class DemoNodeVisitor extends AnalysisVisitor {
         // As an example, enforce that we cannot call
         // instanceof against 'object'.
         if ($class_name == 'object') {
-            $this->plugin->emitIssue(
-                $this->code_base,
-                $this->context,
+            $this->emitPluginIssueShort(
                 'PhanPluginInstanceOfObject',
                 "Cannot call instanceof against `object`"
             );

--- a/.phan/plugins/DemoPlugin.php
+++ b/.phan/plugins/DemoPlugin.php
@@ -174,7 +174,7 @@ class DemoNodeVisitor extends PluginAwareAnalysisVisitor {
         // As an example, enforce that we cannot call
         // instanceof against 'object'.
         if ($class_name == 'object') {
-            $this->emitPluginIssueShort(
+            $this->emit(
                 'PhanPluginInstanceOfObject',
                 "Cannot call instanceof against `object`"
             );

--- a/.phan/plugins/DollarDollarPlugin.php
+++ b/.phan/plugins/DollarDollarPlugin.php
@@ -3,8 +3,8 @@
 use Phan\AST\AnalysisVisitor;
 use Phan\CodeBase;
 use Phan\Language\Context;
-use Phan\Plugin;
-use Phan\Plugin\PluginImplementation;
+use Phan\PluginV2;
+use Phan\PluginV2\LegacyAnalyzeNodeCapability;
 use ast\Node;
 
 /**
@@ -39,7 +39,7 @@ use ast\Node;
  * Note: When adding new plugins,
  * add them to the corresponding section of README.md
  */
-class DollarDollarPlugin extends PluginImplementation {
+class DollarDollarPlugin extends PluginV2 implements LegacyAnalyzeNodeCapability {
 
     /**
      * @param CodeBase $code_base
@@ -79,13 +79,13 @@ class DollarDollarPlugin extends PluginImplementation {
  */
 class DollarDollarVisitor extends AnalysisVisitor {
 
-    /** @var Plugin */
+    /** @var PluginV2 */
     private $plugin;
 
     public function __construct(
         CodeBase $code_base,
         Context $context,
-        Plugin $plugin
+        PluginV2 $plugin
     ) {
         // After constructing on parent, `$code_base` and
         // `$context` will be available as protected properties

--- a/.phan/plugins/DuplicateArrayKeyPlugin.php
+++ b/.phan/plugins/DuplicateArrayKeyPlugin.php
@@ -4,8 +4,8 @@ use Phan\AST\AnalysisVisitor;
 use Phan\CodeBase;
 use Phan\Issue;
 use Phan\Language\Context;
-use Phan\Plugin;
-use Phan\Plugin\PluginImplementation;
+use Phan\PluginV2;
+use Phan\PluginV2\LegacyAnalyzeNodeCapability;
 use ast\Node;
 
 /**
@@ -13,7 +13,7 @@ use ast\Node;
  *
  * @see DollarDollarPlugin for generic plugin documentation.
  */
-class DuplicateArrayKeyPlugin extends PluginImplementation {
+class DuplicateArrayKeyPlugin extends PluginV2 implements LegacyAnalyzeNodeCapability {
 
     /**
      * @param CodeBase $code_base
@@ -55,13 +55,13 @@ class DuplicateArrayKeyPlugin extends PluginImplementation {
  */
 class DuplicateArrayKeyVisitor extends AnalysisVisitor {
 
-    /** @var Plugin */
+    /** @var PluginV2 */
     private $plugin;
 
     public function __construct(
         CodeBase $code_base,
         Context $context,
-        Plugin $plugin
+        PluginV2 $plugin
     ) {
         // After constructing on parent, `$code_base` and
         // `$context` will be available as protected properties
@@ -114,6 +114,7 @@ class DuplicateArrayKeyVisitor extends AnalysisVisitor {
                 // Skip non-literal keys. (TODO: Could check for constants (e.g. A::B) being used twice)
                 continue;
             }
+            \assert(is_scalar($key));  // redundant Phan annotation.
             if (isset($keySet[$key])) {
                 $normalizedKey = self::normalizeKey($key);
                 $this->plugin->emitIssue(

--- a/.phan/plugins/DuplicateArrayKeyPlugin.php
+++ b/.phan/plugins/DuplicateArrayKeyPlugin.php
@@ -67,7 +67,7 @@ class DuplicateArrayKeyVisitor extends PluginAwareAnalysisVisitor {
             \assert(is_scalar($key));  // redundant Phan annotation.
             if (isset($keySet[$key])) {
                 $normalizedKey = self::normalizeKey($key);
-                $this->emitPluginIssueShort(
+                $this->emit(
                     'PhanPluginDuplicateArrayKey',
                     "Duplicate/Equivalent array key literal({VARIABLE}) detected in array - the earlier entry will be ignored.",
                     [(string)$normalizedKey],
@@ -81,7 +81,7 @@ class DuplicateArrayKeyVisitor extends PluginAwareAnalysisVisitor {
         if ($hasEntryWithoutKey && count($keySet) > 0) {
             // This is probably a typo in most codebases. (e.g. ['foo' => 'bar', 'baz'])
             // In phan, InternalFunctionSignatureMap.php does this deliberately with the first parameter being the return type.
-            $this->emitPluginIssueShort(
+            $this->emit(
                 'PhanPluginMixedKeyNoKey',
                 "Should not mix array entries of the form [key => value,] with entries of the form [value,].",
                 [],

--- a/.phan/plugins/DuplicateArrayKeyPlugin.php
+++ b/.phan/plugins/DuplicateArrayKeyPlugin.php
@@ -5,7 +5,8 @@ use Phan\CodeBase;
 use Phan\Issue;
 use Phan\Language\Context;
 use Phan\PluginV2;
-use Phan\PluginV2\LegacyAnalyzeNodeCapability;
+use Phan\PluginV2\AnalyzeNodeCapability;
+use Phan\PluginV2\PluginAwareAnalysisVisitor;
 use ast\Node;
 
 /**
@@ -13,34 +14,12 @@ use ast\Node;
  *
  * @see DollarDollarPlugin for generic plugin documentation.
  */
-class DuplicateArrayKeyPlugin extends PluginV2 implements LegacyAnalyzeNodeCapability {
-
+class DuplicateArrayKeyPlugin extends PluginV2 implements AnalyzeNodeCapability {
     /**
-     * @param CodeBase $code_base
-     * The code base in which the node exists
-     *
-     * @param Context $context
-     * The context in which the node exits. This is
-     * the context inside the given node rather than
-     * the context outside of the given node
-     *
-     * @param Node $node
-     * The php-ast Node being analyzed.
-     *
-     * @param Node $node
-     * The parent node of the given node (if one exists).
-     *
-     * @return void
+     * @return string - name of PluginAwareAnalysisVisitor subclass
      */
-    public function analyzeNode(
-        CodeBase $code_base,
-        Context $context,
-        Node $node,
-        Node $parent_node = null
-    ) {
-        (new DuplicateArrayKeyVisitor($code_base, $context, $this))(
-            $node
-        );
+    public static function getAnalyzeNodeVisitorClassName() : string {
+        return DuplicateArrayKeyVisitor::class;
     }
 }
 
@@ -53,37 +32,8 @@ class DuplicateArrayKeyPlugin extends PluginV2 implements LegacyAnalyzeNodeCapab
  * Visitors such as this are useful for defining lots of different
  * checks on a node based on its kind.
  */
-class DuplicateArrayKeyVisitor extends AnalysisVisitor {
-
-    /** @var PluginV2 */
-    private $plugin;
-
-    public function __construct(
-        CodeBase $code_base,
-        Context $context,
-        PluginV2 $plugin
-    ) {
-        // After constructing on parent, `$code_base` and
-        // `$context` will be available as protected properties
-        // `$this->code_base` and `$this->context`.
-        parent::__construct($code_base, $context);
-
-        // We take the plugin so that we can call
-        // `$this->plugin->emitIssue(...)` on it to emit issues
-        // to the user.
-        $this->plugin = $plugin;
-    }
-
-    /**
-     * Default visitor that does nothing
-     *
-     * @param Node $node
-     * A node to analyze
-     *
-     * @return void
-     */
-    public function visit(Node $node) {
-    }
+class DuplicateArrayKeyVisitor extends PluginAwareAnalysisVisitor {
+    // Do not define the visit() method unless a plugin has code and needs to visit most/all node types.
 
     /**
      * @param Node $node
@@ -117,9 +67,7 @@ class DuplicateArrayKeyVisitor extends AnalysisVisitor {
             \assert(is_scalar($key));  // redundant Phan annotation.
             if (isset($keySet[$key])) {
                 $normalizedKey = self::normalizeKey($key);
-                $this->plugin->emitIssue(
-                    $this->code_base,
-                    $this->context,
+                $this->emitPluginIssueShort(
                     'PhanPluginDuplicateArrayKey',
                     "Duplicate/Equivalent array key literal({VARIABLE}) detected in array - the earlier entry will be ignored.",
                     [(string)$normalizedKey],
@@ -133,9 +81,7 @@ class DuplicateArrayKeyVisitor extends AnalysisVisitor {
         if ($hasEntryWithoutKey && count($keySet) > 0) {
             // This is probably a typo in most codebases. (e.g. ['foo' => 'bar', 'baz'])
             // In phan, InternalFunctionSignatureMap.php does this deliberately with the first parameter being the return type.
-            $this->plugin->emitIssue(
-                $this->code_base,
-                $this->context,
+            $this->emitPluginIssueShort(
                 'PhanPluginMixedKeyNoKey',
                 "Should not mix array entries of the form [key => value,] with entries of the form [value,].",
                 [],

--- a/.phan/plugins/InvalidVariableIssetPlugin.php
+++ b/.phan/plugins/InvalidVariableIssetPlugin.php
@@ -4,11 +4,11 @@
 use Phan\AST\AnalysisVisitor;
 use Phan\CodeBase;
 use Phan\Language\Context;
-use Phan\Plugin;
-use Phan\Plugin\PluginImplementation;
+use Phan\PluginV2;
+use Phan\PluginV2\LegacyAnalyzeNodeCapability;
 use ast\Node;
 
-class InvalidVariableIssetPlugin extends PluginImplementation {
+class InvalidVariableIssetPlugin extends PluginV2 implements LegacyAnalyzeNodeCapability {
 
     public function analyzeNode(
         CodeBase $code_base,
@@ -24,7 +24,7 @@ class InvalidVariableIssetPlugin extends PluginImplementation {
 
 class InvalidVariableIssetVisitor extends AnalysisVisitor {
 
-    /** @var Plugin */
+    /** @var PluginV2 */
     private $plugin;
 
     /** define classes to parse */
@@ -45,7 +45,7 @@ class InvalidVariableIssetVisitor extends AnalysisVisitor {
     public function __construct(
         CodeBase $code_base,
         Context $context,
-        Plugin $plugin
+        PluginV2 $plugin
     ) {
         parent::__construct($code_base, $context);
 

--- a/.phan/plugins/InvalidVariableIssetPlugin.php
+++ b/.phan/plugins/InvalidVariableIssetPlugin.php
@@ -5,27 +5,21 @@ use Phan\AST\AnalysisVisitor;
 use Phan\CodeBase;
 use Phan\Language\Context;
 use Phan\PluginV2;
-use Phan\PluginV2\LegacyAnalyzeNodeCapability;
+use Phan\PluginV2\AnalyzeNodeCapability;
+use Phan\PluginV2\PluginAwareAnalysisVisitor;
 use ast\Node;
 
-class InvalidVariableIssetPlugin extends PluginV2 implements LegacyAnalyzeNodeCapability {
+class InvalidVariableIssetPlugin extends PluginV2 implements AnalyzeNodeCapability {
 
-    public function analyzeNode(
-        CodeBase $code_base,
-        Context $context,
-        Node $node,
-        Node $parent_node = null
-    ) {
-        (new InvalidVariableIssetVisitor($code_base, $context, $this))(
-            $node
-        );
+    /**
+     * @return string - name of PluginAwareAnalysisVisitor subclass
+     */
+    public static function getAnalyzeNodeVisitorClassName() : string {
+        return InvalidVariableIssetVisitor::class;
     }
 }
 
-class InvalidVariableIssetVisitor extends AnalysisVisitor {
-
-    /** @var PluginV2 */
-    private $plugin;
+class InvalidVariableIssetVisitor extends PluginAwareAnalysisVisitor {
 
     /** define classes to parse */
     const CLASSES = [
@@ -42,48 +36,33 @@ class InvalidVariableIssetVisitor extends AnalysisVisitor {
         ast\AST_PROP,
     ];
 
-    public function __construct(
-        CodeBase $code_base,
-        Context $context,
-        PluginV2 $plugin
-    ) {
-        parent::__construct($code_base, $context);
+    // A plugin's visitors should not override visit() unless they need to.
 
-        $this->plugin = $plugin;
-    }
-
-    public function visit(Node $node){
-    }
-
+    /** @override */
     public function visitIsset(Node $node) : Context {
         $argument = $node->children['var'];
         $variable = $argument;
 
         // get variable name from argument
-        while(!isset($variable->children['name'])){
-            if(in_array($variable->kind, self::EXPRESSIONS)){
+        while (!isset($variable->children['name'])){
+            if (in_array($variable->kind, self::EXPRESSIONS)){
                 $variable = $variable->children['expr'];
-            }elseif(in_array($variable->kind, self::CLASSES)){
-                    $variable = $variable->children['class'];
+            } elseif (in_array($variable->kind, self::CLASSES)){
+                $variable = $variable->children['class'];
             }
         }
         $name = $variable->children['name'];
 
         // emit issue if name is not declared
-        if(!$this->context->getScope()->hasVariableWithName($name)){
-            $this->plugin->emitIssue(
-                $this->code_base,
-                $this->context,
+        if (!$this->context->getScope()->hasVariableWithName($name)){
+            $this->emitPluginIssueShort(
                 'PhanUndeclaredVariable',
                 "undeclared variables in isset()",
                 []
             );
-        }
-        // emit issue if argument is not array access
-        elseif($argument->kind !== ast\AST_DIM){
-            $this->plugin->emitIssue(
-                $this->code_base,
-                $this->context,
+        } elseif ($argument->kind !== ast\AST_DIM){
+            // emit issue if argument is not array access
+            $this->emitPluginIssueShort(
                 'PhanPluginInvalidVariableIsset',
                 "non array access in isset()",
                 []
@@ -91,7 +70,6 @@ class InvalidVariableIssetVisitor extends AnalysisVisitor {
         }
         return $this->context;
     }
-
 }
 
 return new InvalidVariableIssetPlugin;

--- a/.phan/plugins/InvalidVariableIssetPlugin.php
+++ b/.phan/plugins/InvalidVariableIssetPlugin.php
@@ -55,14 +55,14 @@ class InvalidVariableIssetVisitor extends PluginAwareAnalysisVisitor {
 
         // emit issue if name is not declared
         if (!$this->context->getScope()->hasVariableWithName($name)){
-            $this->emitPluginIssueShort(
+            $this->emit(
                 'PhanUndeclaredVariable',
                 "undeclared variables in isset()",
                 []
             );
         } elseif ($argument->kind !== ast\AST_DIM){
             // emit issue if argument is not array access
-            $this->emitPluginIssueShort(
+            $this->emit(
                 'PhanPluginInvalidVariableIsset',
                 "non array access in isset()",
                 []

--- a/.phan/plugins/NonBoolBranchPlugin.php
+++ b/.phan/plugins/NonBoolBranchPlugin.php
@@ -5,11 +5,11 @@ use Phan\AST\AnalysisVisitor;
 use Phan\CodeBase;
 use Phan\Language\Context;
 use Phan\Language\UnionType;
-use Phan\Plugin;
-use Phan\Plugin\PluginImplementation;
+use Phan\PluginV2;
+use Phan\PluginV2\LegacyAnalyzeNodeCapability;
 use ast\Node;
 
-class NonBoolBranchPlugin extends PluginImplementation {
+class NonBoolBranchPlugin extends PluginV2 implements LegacyAnalyzeNodeCapability {
 
     public function analyzeNode(
         CodeBase $code_base,
@@ -26,13 +26,13 @@ class NonBoolBranchPlugin extends PluginImplementation {
 
 class NonBoolBranchVisitor extends AnalysisVisitor {
 
-    /** @var Plugin */
+    /** @var PluginV2 */
     private $plugin;
 
     public function __construct(
         CodeBase $code_base,
         Context $context,
-        Plugin $plugin
+        PluginV2 $plugin
     ) {
         parent::__construct($code_base, $context);
 

--- a/.phan/plugins/NonBoolBranchPlugin.php
+++ b/.phan/plugins/NonBoolBranchPlugin.php
@@ -6,57 +6,37 @@ use Phan\CodeBase;
 use Phan\Language\Context;
 use Phan\Language\UnionType;
 use Phan\PluginV2;
-use Phan\PluginV2\LegacyAnalyzeNodeCapability;
+use Phan\PluginV2\AnalyzeNodeCapability;
+use Phan\PluginV2\PluginAwareAnalysisVisitor;
 use ast\Node;
 
-class NonBoolBranchPlugin extends PluginV2 implements LegacyAnalyzeNodeCapability {
-
-    public function analyzeNode(
-        CodeBase $code_base,
-        Context $context,
-        Node $node,
-        Node $parent_node = null
-    ) {
-        (new NonBoolBranchVisitor($code_base, $context, $this))(
-            $node
-        );
+class NonBoolBranchPlugin extends PluginV2 implements AnalyzeNodeCapability {
+    /**
+     * @return string - name of PluginAwareAnalysisVisitor subclass
+     */
+    public static function getAnalyzeNodeVisitorClassName() : string
+    {
+        return NonBoolBranchVisitor::class;
     }
-
 }
 
-class NonBoolBranchVisitor extends AnalysisVisitor {
+class NonBoolBranchVisitor extends PluginAwareAnalysisVisitor {
+    // A plugin's visitors should not override visit() unless they need to.
 
-    /** @var PluginV2 */
-    private $plugin;
-
-    public function __construct(
-        CodeBase $code_base,
-        Context $context,
-        PluginV2 $plugin
-    ) {
-        parent::__construct($code_base, $context);
-
-        $this->plugin = $plugin;
-    }
-
-    public function visit(Node $node){
-    }
-
-    public function visitIfelem(Node $node) : Context {
+    public function visitIfelem(Node $node) : Context
+    {
         $condition = $node->children['cond'];
 
         // dig nodes to avoid NOT('!') operator's converting its value to boolean type
-        while(isset($condition->flags) && $condition->flags === ast\flags\UNARY_BOOL_NOT){
+        while (isset($condition->flags) && $condition->flags === ast\flags\UNARY_BOOL_NOT){
             $condition = $condition->children['expr'];
         }
 
         // evaluate the type of conditional expression
         $union_type = UnionType::fromNode($this->context, $this->code_base, $condition);
         // $condition === null will be appeared in else-clause, then avoid them
-        if(($union_type->serialize() !== "bool") && $condition !== null){
-            $this->plugin->emitIssue(
-                $this->code_base,
-                $this->context,
+        if (($union_type->serialize() !== "bool") && $condition !== null) {
+            $this->emitPluginIssueShort(
                 'PhanPluginNonBoolBranch',
                 'Non bool value evaluated in if clause',
                 []

--- a/.phan/plugins/NonBoolBranchPlugin.php
+++ b/.phan/plugins/NonBoolBranchPlugin.php
@@ -36,7 +36,7 @@ class NonBoolBranchVisitor extends PluginAwareAnalysisVisitor {
         $union_type = UnionType::fromNode($this->context, $this->code_base, $condition);
         // $condition === null will be appeared in else-clause, then avoid them
         if (($union_type->serialize() !== "bool") && $condition !== null) {
-            $this->emitPluginIssueShort(
+            $this->emit(
                 'PhanPluginNonBoolBranch',
                 'Non bool value evaluated in if clause',
                 []

--- a/.phan/plugins/NonBoolInLogicalArithPlugin.php
+++ b/.phan/plugins/NonBoolInLogicalArithPlugin.php
@@ -5,11 +5,11 @@ use Phan\AST\AnalysisVisitor;
 use Phan\CodeBase;
 use Phan\Language\Context;
 use Phan\Language\UnionType;
-use Phan\Plugin;
-use Phan\Plugin\PluginImplementation;
+use Phan\PluginV2;
+use Phan\PluginV2\LegacyAnalyzeNodeCapability;
 use ast\Node;
 
-class NonBoolInLogicalArithPlugin extends PluginImplementation {
+class NonBoolInLogicalArithPlugin extends PluginV2 implements LegacyAnalyzeNodeCapability {
 
     public function analyzeNode(
         CodeBase $code_base,
@@ -26,7 +26,7 @@ class NonBoolInLogicalArithPlugin extends PluginImplementation {
 
 class NonBoolInLogicalArithVisitor extends AnalysisVisitor {
 
-    /** @var Plugin */
+    /** @var PluginV2 */
     private $plugin;
 
     /** define boolean operator list */
@@ -39,7 +39,7 @@ class NonBoolInLogicalArithVisitor extends AnalysisVisitor {
     public function __construct(
         CodeBase $code_base,
         Context $context,
-        Plugin $plugin
+        PluginV2 $plugin
     ) {
         parent::__construct($code_base, $context);
 

--- a/.phan/plugins/NonBoolInLogicalArithPlugin.php
+++ b/.phan/plugins/NonBoolInLogicalArithPlugin.php
@@ -53,7 +53,7 @@ class NonBoolInLogicalArithVisitor extends PluginAwareAnalysisVisitor {
 
             // if left or right type is NOT boolean, emit issue
             if($left_type->serialize() !== "bool" || $right_type->serialize() !== "bool"){
-                $this->emitPluginIssueShort(
+                $this->emit(
                     'PhanPluginNonBoolInLogicalArith',
                     'Non bool value in logical arithmetic',
                     []

--- a/.phan/plugins/NonBoolInLogicalArithPlugin.php
+++ b/.phan/plugins/NonBoolInLogicalArithPlugin.php
@@ -6,28 +6,21 @@ use Phan\CodeBase;
 use Phan\Language\Context;
 use Phan\Language\UnionType;
 use Phan\PluginV2;
-use Phan\PluginV2\LegacyAnalyzeNodeCapability;
+use Phan\PluginV2\AnalyzeNodeCapability;
+use Phan\PluginV2\PluginAwareAnalysisVisitor;
 use ast\Node;
 
-class NonBoolInLogicalArithPlugin extends PluginV2 implements LegacyAnalyzeNodeCapability {
+class NonBoolInLogicalArithPlugin extends PluginV2 implements AnalyzeNodeCapability {
 
-    public function analyzeNode(
-        CodeBase $code_base,
-        Context $context,
-        Node $node,
-        Node $parent_node = null
-    ) {
-        (new NonBoolInLogicalArithVisitor($code_base, $context, $this))(
-            $node
-        );
+    /**
+     * @return string - name of PluginAwareAnalysisVisitor subclass
+     */
+    public static function getAnalyzeNodeVisitorClassName() : string {
+        return NonBoolInLogicalArithVisitor::class;
     }
-
 }
 
-class NonBoolInLogicalArithVisitor extends AnalysisVisitor {
-
-    /** @var PluginV2 */
-    private $plugin;
+class NonBoolInLogicalArithVisitor extends PluginAwareAnalysisVisitor {
 
     /** define boolean operator list */
     const BINARY_BOOL_OPERATORS = [
@@ -36,22 +29,11 @@ class NonBoolInLogicalArithVisitor extends AnalysisVisitor {
         ast\flags\BINARY_BOOL_XOR,
     ];
 
-    public function __construct(
-        CodeBase $code_base,
-        Context $context,
-        PluginV2 $plugin
-    ) {
-        parent::__construct($code_base, $context);
-
-        $this->plugin = $plugin;
-    }
-
-    public function visit(Node $node){
-    }
+    // A plugin's visitors should not override visit() unless they need to.
 
     public function visitBinaryop(Node $node) : Context{
         // check every boolean binary operation
-        if(in_array($node->flags, self::BINARY_BOOL_OPERATORS)){
+        if(in_array($node->flags, self::BINARY_BOOL_OPERATORS, true)){
             // get left node and parse it
             // (dig nodes to avoid NOT('!') operator's converting its value to boolean type)
             $left_node = $node->children['left'];
@@ -71,9 +53,7 @@ class NonBoolInLogicalArithVisitor extends AnalysisVisitor {
 
             // if left or right type is NOT boolean, emit issue
             if($left_type->serialize() !== "bool" || $right_type->serialize() !== "bool"){
-                $this->plugin->emitIssue(
-                    $this->code_base,
-                    $this->context,
+                $this->emitPluginIssueShort(
                     'PhanPluginNonBoolInLogicalArith',
                     'Non bool value in logical arithmetic',
                     []

--- a/.phan/plugins/NumericalComparisonPlugin.php
+++ b/.phan/plugins/NumericalComparisonPlugin.php
@@ -5,11 +5,11 @@ use Phan\AST\AnalysisVisitor;
 use Phan\CodeBase;
 use Phan\Language\Context;
 use Phan\Language\UnionType;
-use Phan\Plugin;
-use Phan\Plugin\PluginImplementation;
+use Phan\PluginV2;
+use Phan\PluginV2\LegacyAnalyzeNodeCapability;
 use ast\Node;
 
-class NumericalComparisonPlugin extends PluginImplementation {
+class NumericalComparisonPlugin extends PluginV2 implements LegacyAnalyzeNodeCapability {
 
     public function analyzeNode(
         CodeBase $code_base,
@@ -26,7 +26,7 @@ class NumericalComparisonPlugin extends PluginImplementation {
 
 class NumericalComparisonVisitor extends AnalysisVisitor {
 
-    /** @var Plugin */
+    /** @var PluginV2 */
     private $plugin;
 
     /** define equal operator list */
@@ -44,7 +44,7 @@ class NumericalComparisonVisitor extends AnalysisVisitor {
     public function __construct(
         CodeBase $code_base,
         Context $context,
-        Plugin $plugin
+        PluginV2 $plugin
     ) {
         parent::__construct($code_base, $context);
 

--- a/.phan/plugins/NumericalComparisonPlugin.php
+++ b/.phan/plugins/NumericalComparisonPlugin.php
@@ -6,29 +6,21 @@ use Phan\CodeBase;
 use Phan\Language\Context;
 use Phan\Language\UnionType;
 use Phan\PluginV2;
-use Phan\PluginV2\LegacyAnalyzeNodeCapability;
+use Phan\PluginV2\AnalyzeNodeCapability;
+use Phan\PluginV2\PluginAwareAnalysisVisitor;
 use ast\Node;
 
-class NumericalComparisonPlugin extends PluginV2 implements LegacyAnalyzeNodeCapability {
+class NumericalComparisonPlugin extends PluginV2 implements AnalyzeNodeCapability {
 
-    public function analyzeNode(
-        CodeBase $code_base,
-        Context $context,
-        Node $node,
-        Node $parent_node = null
-    ) {
-        (new NumericalComparisonVisitor($code_base, $context, $this))(
-            $node
-        );
+    /**
+     * @return string - name of PluginAwareAnalysisVisitor subclass
+     */
+    public static function getAnalyzeNodeVisitorClassName() : string {
+        return NumericalComparisonVisitor::class;
     }
-
 }
 
-class NumericalComparisonVisitor extends AnalysisVisitor {
-
-    /** @var PluginV2 */
-    private $plugin;
-
+class NumericalComparisonVisitor extends PluginAwareAnalysisVisitor {
     /** define equal operator list */
     const BINARY_EQUAL_OPERATORS = [
         ast\flags\BINARY_IS_EQUAL,
@@ -41,18 +33,7 @@ class NumericalComparisonVisitor extends AnalysisVisitor {
         ast\flags\BINARY_IS_NOT_IDENTICAL,
     ];
 
-    public function __construct(
-        CodeBase $code_base,
-        Context $context,
-        PluginV2 $plugin
-    ) {
-        parent::__construct($code_base, $context);
-
-        $this->plugin = $plugin;
-    }
-
-    public function visit(Node $node){
-    }
+    // A plugin's visitors should not override visit() unless they need to.
 
     public function visitBinaryop(Node $node) : Context {
         // get the types of left and right values
@@ -67,9 +48,7 @@ class NumericalComparisonVisitor extends AnalysisVisitor {
                 !($this->isNumericalType($left_type->serialize())) &
                 !($this->isNumericalType($right_type->serialize()))
             ){
-                $this->plugin->emitIssue(
-                    $this->code_base,
-                    $this->context,
+                $this->emitPluginIssueShort(
                     'PhanPluginNumericalComparison',
                     "non numerical values compared by the operators '==' or '!=='",
                     []
@@ -81,9 +60,8 @@ class NumericalComparisonVisitor extends AnalysisVisitor {
                 $this->isNumericalType($left_type->serialize()) |
                 $this->isNumericalType($right_type->serialize())
             ){
-                $this->plugin->emitIssue(
-                    $this->code_base,
-                    $this->context,
+                // TODO: different name for this issue type?
+                $this->emitPluginIssueShort(
                     'PhanPluginNumericalComparison',
                     "numerical values compared by the operators '===' or '!=='",
                     []

--- a/.phan/plugins/NumericalComparisonPlugin.php
+++ b/.phan/plugins/NumericalComparisonPlugin.php
@@ -48,7 +48,7 @@ class NumericalComparisonVisitor extends PluginAwareAnalysisVisitor {
                 !($this->isNumericalType($left_type->serialize())) &
                 !($this->isNumericalType($right_type->serialize()))
             ){
-                $this->emitPluginIssueShort(
+                $this->emit(
                     'PhanPluginNumericalComparison',
                     "non numerical values compared by the operators '==' or '!=='",
                     []
@@ -61,7 +61,7 @@ class NumericalComparisonVisitor extends PluginAwareAnalysisVisitor {
                 $this->isNumericalType($right_type->serialize())
             ){
                 // TODO: different name for this issue type?
-                $this->emitPluginIssueShort(
+                $this->emit(
                     'PhanPluginNumericalComparison',
                     "numerical values compared by the operators '===' or '!=='",
                     []

--- a/.phan/plugins/UnusedSuppressionPlugin.php
+++ b/.phan/plugins/UnusedSuppressionPlugin.php
@@ -7,8 +7,10 @@ use Phan\Language\Element\Clazz;
 use Phan\Language\Element\Func;
 use Phan\Language\Element\Method;
 use Phan\Language\Element\AddressableElement;
-use Phan\Plugin;
-use Phan\Plugin\PluginImplementation;
+use Phan\PluginV2;
+use Phan\PluginV2\AnalyzeClassCapability;
+use Phan\PluginV2\AnalyzeFunctionCapability;
+use Phan\PluginV2\AnalyzeMethodCapability;
 use ast\Node;
 
 /**
@@ -17,7 +19,10 @@ use ast\Node;
  * NOTE! This plugin only produces correct results when Phan
  *       is run on a single processor (via the `-j1` flag).
  */
-class UnusedSuppressionPlugin extends PluginImplementation {
+class UnusedSuppressionPlugin extends PluginV2 implements
+    AnalyzeClassCapability,
+    AnalyzeFunctionCapability,
+    AnalyzeMethodCapability {
 
     /**
      * @param CodeBase $code_base

--- a/NEWS
+++ b/NEWS
@@ -48,6 +48,14 @@ New Features (CLI, Configs)
 + Add `null_casts_as_array` and `array_casts_as_null` settings, which can be used while migrating away from `null_casts_as_any_type`.
   These will be checked if one of the types has a union type of `null`, as well as when checking if a nullable array can cast to a regular array.
 
+Plugins
+
++ Redesign plugin system to be more efficient. (Issue #600)
+  New plugins should extend `\Phan\PluginV2` and implement the interfaces for capabilities they need to have,
+  such as `\Phan\PluginV2\AnalyzeClassCapability`.
+  In the new plugin system, plugins will only be run when they need to (Phan no longer needs to invoke an empty method body).
+  Old subclasses of `\Phan\Plugin\PluginImplementation` will continue to work, but will be less efficient.
+
 Maintenance
 + Reduce memory usage by around 15% by using a more efficient representation of union types (PR #729).
   The optional extension https://github.com/runkit7/runkit_object_id can be installed to boost performance by around 10%.

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -193,7 +193,7 @@ class Analysis
     public static function analyzeFunctions(CodeBase $code_base, array $file_filter = null)
     {
         $plugin_set = ConfigPluginSet::instance();
-        $has_plugins = $plugin_set->hasPlugins();
+        $has_function_or_method_plugins = $plugin_set->hasAnalyzeFunctionPlugins() || $plugin_set->hasAnalyzeMethodPlugins();
         $function_count = count($code_base->getFunctionAndMethodSet());
         $show_progress = CLI::shouldShowProgress();
         $i = 0;
@@ -231,7 +231,7 @@ class Analysis
             // Assumes that the given plugins will emit an issue in the same file as the function/method,
             // which isn't necessarily the case.
             // 0.06
-            if ($has_plugins) {
+            if ($has_function_or_method_plugins) {
                 if ($function_or_method instanceof Func) {
                     $plugin_set->analyzeFunction(
                         $code_base, $function_or_method

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -16,6 +16,15 @@ class Config
     const AST_VERSION = 40;
 
     /**
+     * The version of the Phan plugin system.
+     * Plugin files that wish to be backwards compatible may check this and return different classes based on its existence
+     * and the results of version_compare.
+     * PluginV2 will correspond to 2.x.y, PluginV3 will correspond to 3.x.y, etc.
+     * New features increment minor versions, and bug fixes increment patch versions.
+     */
+    const PHAN_PLUGIN_VERSION = '2.0.0';
+
+    /**
      * @var string|null
      * The root directory of the project. This is used to
      * store canonical path names and find project resources

--- a/src/Phan/Language/Internal/FunctionSignatureMap.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMap.php
@@ -7691,7 +7691,7 @@ return [
 'ReflectionMethod::__construct' => ['ReflectionMethod', 'class'=>'string|object', 'name'=>'string'],
 'ReflectionMethod::__construct\'1' => ['ReflectionMethod', 'class_method'=>'string'],
 'ReflectionMethod::export' => ['string', 'class'=>'', 'name'=>'string', 'return='=>'bool'],
-'ReflectionMethod::getClosure' => ['Closure', 'object'=>'object'],
+'ReflectionMethod::getClosure' => ['Closure', 'object'=>'object|null'],
 'ReflectionMethod::getDeclaringClass' => ['ReflectionClass'],
 'ReflectionMethod::getModifiers' => ['int'],
 'ReflectionMethod::getPrototype' => ['ReflectionMethod'],

--- a/src/Phan/Plugin.php
+++ b/src/Phan/Plugin.php
@@ -5,6 +5,11 @@ use Phan\Language\Context;
 use Phan\Language\Element\Clazz;
 use Phan\Language\Element\Method;
 use Phan\Language\Element\Func;
+use Phan\PluginV2\LegacyPreAnalyzeNodeCapability;
+use Phan\PluginV2\AnalyzeClassCapability;
+use Phan\PluginV2\AnalyzeFunctionCapability;
+use Phan\PluginV2\AnalyzeMethodCapability;
+use Phan\PluginV2\LegacyAnalyzeNodeCapability;
 use ast\Node;
 
 /**
@@ -15,7 +20,13 @@ use ast\Node;
  * Plugins must extends this class and return an instance
  * of themselves.
  */
-abstract class Plugin {
+abstract class Plugin extends PluginV2 implements
+    AnalyzeClassCapability,
+    AnalyzeFunctionCapability,
+    AnalyzeMethodCapability,
+    LegacyAnalyzeNodeCapability,
+    LegacyPreAnalyzeNodeCapability {
+
     /**
      * Do a first-pass analysis of a node before Phan
      * does its full analysis. This hook allows you to
@@ -110,70 +121,4 @@ abstract class Plugin {
         CodeBase $code_base,
         Func $function
     );
-
-    /**
-     * Emit an issue if it is not suppressed
-     *
-     * @param CodeBase $code_base
-     * The code base in which the issue was found
-     *
-     * @param Context $context
-     * The context in which the issue was found
-     *
-     * @param string $issue_type
-     * A name for the type of issue such as 'PhanPluginMyIssue'
-     *
-     * @param string $issue_message_fmt
-     * The complete issue message format string to emit such as
-     * 'class with fqsen {CLASS} is broken in some fashion' (preferred)
-     * or 'class with fqsen %s is broken in some fashion'
-     * The list of placeholders for between braces can be found
-     * in \Phan\Issue::uncolored_format_string_for_template.
-     *
-     * @param string[] $issue_message_args
-     * The arguments for this issue format.
-     * If this array is empty, $issue_message_args is kept in place
-     *
-     * @param int $severity
-     * A value from the set {Issue::SEVERITY_LOW,
-     * Issue::SEVERITY_NORMAL, Issue::SEVERITY_HIGH}.
-     *
-     * @param int $remediation_difficulty
-     * A guess at how hard the issue will be to fix from the
-     * set {Issue:REMEDIATION_A, Issue:REMEDIATION_B, ...
-     * Issue::REMEDIATION_F} with F being the hardest.
-     */
-    public function emitIssue(
-        CodeBase $code_base,
-        Context $context,
-        string $issue_type,
-        string $issue_message_fmt,
-        array $issue_message_args = [],
-        int $severity = Issue::SEVERITY_NORMAL,
-        int $remediation_difficulty = Issue::REMEDIATION_B,
-        int $issue_type_id = Issue::TYPE_ID_UNKNOWN
-    ) {
-        $issue = new Issue(
-            $issue_type,
-            Issue::CATEGORY_PLUGIN,
-            $severity,
-            $issue_message_fmt,
-            $remediation_difficulty,
-            $issue_type_id
-        );
-
-        $issue_instance = new IssueInstance(
-            $issue,
-            $context->getFile(),
-            $context->getLineNumberStart(),
-            $issue_message_args
-        );
-
-        Issue::maybeEmitInstance(
-            $code_base,
-            $context,
-            $issue_instance
-        );
-    }
-
 }

--- a/src/Phan/Plugin.php
+++ b/src/Phan/Plugin.php
@@ -19,6 +19,8 @@ use ast\Node;
  *
  * Plugins must extends this class and return an instance
  * of themselves.
+ *
+ * @deprecated - Use PluginV2 instead
  */
 abstract class Plugin extends PluginV2 implements
     AnalyzeClassCapability,
@@ -46,6 +48,8 @@ abstract class Plugin extends PluginV2 implements
      * The parent node of the given node (if one exists).
      *
      * @return void
+     *
+     * @deprecated
      */
     abstract public function preAnalyzeNode(
         CodeBase $code_base,
@@ -72,6 +76,8 @@ abstract class Plugin extends PluginV2 implements
      * The parent node of the given node (if one exists).
      *
      * @return void
+     *
+     * @deprecated
      */
     abstract public function analyzeNode(
         CodeBase $code_base,

--- a/src/Phan/Plugin/ClosuresForKind.php
+++ b/src/Phan/Plugin/ClosuresForKind.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+namespace Phan\Plugin;
+
+use Phan\AST\Visitor\Element;
+
+/**
+ * Maps an \ast\Node->kind value to the corresponding closures.
+ */
+class ClosuresForKind {
+    /**
+     * @var \Closure[][]
+     */
+    private $closures = [];
+
+    public function __construct() {}
+
+    public function record(int $kind, \Closure $c)
+    {
+        \assert(\array_key_exists($kind, Element::VISIT_LOOKUP_TABLE));
+        if (!isset($this->closures[$kind])) {
+            $this->closures[$kind] = [];
+        }
+        $this->closures[$kind][] = $c;
+    }
+
+    public function recordForKinds(array $kinds, \Closure $c)
+    {
+        foreach ($kinds as $kind) {
+            $this->record($kind, $c);
+        }
+    }
+
+    public function recordForAllKinds(\Closure $c)
+    {
+        $this->recordForKinds(array_keys(Element::VISIT_LOOKUP_TABLE), $c);
+    }
+
+    /**
+     * @return \Closure[]
+     */
+    public function getFlattenedClosures(\Closure $flattener)
+    {
+        ksort($this->closures);
+        $merged_closures = [];
+        foreach ($this->closures as $kind => $closure_list) {
+            assert(\count($closure_list) > 0);
+            if (\count($closure_list) === 1) {
+                $merged_closures[$kind] = $closure_list[0];
+            } else {
+                $merged_closures[$kind] = $flattener($closure_list);
+            }
+        }
+        return $merged_closures;
+    }
+}

--- a/src/Phan/Plugin/ClosuresForKind.php
+++ b/src/Phan/Plugin/ClosuresForKind.php
@@ -4,16 +4,25 @@ namespace Phan\Plugin;
 use Phan\AST\Visitor\Element;
 
 /**
- * Maps an \ast\Node->kind value to the corresponding closures.
+ * Tracks the closures that need to be executed for the set of possible \ast\Node->kind values.
+ * Once the plugin set is done adding closures, this will return an array
+ * mapping the node kind to a single Closure to execute
+ * (which will run all of the plugins)
+ *
+ * - If no closures were added for a given node kind, then there will be no entry in that array.
  */
 class ClosuresForKind {
     /**
-     * @var \Closure[][]
+     * @var \Closure[][] Maps a node kind to a list of 1 or more (unflattened) closures to execute on nodes of that kind.
      */
     private $closures = [];
 
     public function __construct() {}
 
+    /**
+     * @param int $kind - A valid value of a node kind
+     * @param \Closure $c
+     */
     public function record(int $kind, \Closure $c)
     {
         \assert(\array_key_exists($kind, Element::VISIT_LOOKUP_TABLE));
@@ -23,6 +32,12 @@ class ClosuresForKind {
         $this->closures[$kind][] = $c;
     }
 
+    /**
+     * @param int[] $kinds - A list of unique values of node kinds
+     * @param \Closure $c - The closure to execute on each of those kinds
+     *
+     * Record the fact that a Closure needs to be the given subset of values of node->kind
+     */
     public function recordForKinds(array $kinds, \Closure $c)
     {
         foreach ($kinds as $kind) {
@@ -30,13 +45,18 @@ class ClosuresForKind {
         }
     }
 
+    /**
+     * Record the fact that a Closure needs to be executed for all possible valid values of Node->kind
+     * @param \Closure $c - The closure to execute on all valid values of Node->kind
+     */
     public function recordForAllKinds(\Closure $c)
     {
-        $this->recordForKinds(array_keys(Element::VISIT_LOOKUP_TABLE), $c);
+        $this->recordForKinds(\array_keys(Element::VISIT_LOOKUP_TABLE), $c);
     }
 
     /**
-     * @return \Closure[]
+     * @param \Closure $flattener
+     * @return \Closure[] (Maps a subset of node kinds to a closure to execute for that node kind.)
      */
     public function getFlattenedClosures(\Closure $flattener)
     {
@@ -45,9 +65,13 @@ class ClosuresForKind {
         foreach ($this->closures as $kind => $closure_list) {
             assert(\count($closure_list) > 0);
             if (\count($closure_list) === 1) {
+                // If there's exactly one closure for a given kind, then execute it directly.
                 $merged_closures[$kind] = $closure_list[0];
             } else {
-                $merged_closures[$kind] = $flattener($closure_list);
+                // Create a closure which will execute 2 or more closures.
+                $closure = $flattener($closure_list);
+                assert($closure instanceof \Closure);
+                $merged_closures[$kind] = $closure;
             }
         }
         return $merged_closures;

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -8,6 +8,11 @@ use Phan\Language\Element\Clazz;
 use Phan\Language\Element\Func;
 use Phan\Language\Element\Method;
 use Phan\Plugin;
+use Phan\PluginV2\LegacyPreAnalyzeNodeCapability;
+use Phan\PluginV2\AnalyzeClassCapability;
+use Phan\PluginV2\AnalyzeFunctionCapability;
+use Phan\PluginV2\AnalyzeMethodCapability;
+use Phan\PluginV2\LegacyAnalyzeNodeCapability;
 use ast\Node;
 
 /**
@@ -17,9 +22,24 @@ use ast\Node;
  * (Note: This is called almost once per each AST node being analyzed.
  * Speed is preferred over using Phan\Memoize.)
  */
-class ConfigPluginSet extends Plugin {
+final class ConfigPluginSet extends Plugin {
     /** @var Plugin[]|null - Cached plugin set for this instance. Lazily generated. */
     private $pluginSet;
+
+    /** @var LegacyPreAnalyzeNodeCapability[]|null */
+    private $preAnalyzeNodePluginSet;
+
+    /** @var LegacyAnalyzeNodeCapability[]|null */
+    private $analyzeNodePluginSet;
+
+    /** @var AnalyzeClassCapability[]|null */
+    private $analyzeClassPluginSet;
+
+    /** @var AnalyzeFunctionCapability[]|null */
+    private $analyzeFunctionPluginSet;
+
+    /** @var AnalyzeMethodCapability[]|null */
+    private $analyzeMethodPluginSet;
 
     /**
      * Call `ConfigPluginSet::instance()` instead.
@@ -58,7 +78,8 @@ class ConfigPluginSet extends Plugin {
         Context $context,
         Node $node
     ) {
-        foreach ($this->getPlugins() as $plugin) {
+        $this->ensurePluginsExist();
+        foreach ($this->preAnalyzeNodePluginSet as $plugin) {
             $plugin->preAnalyzeNode(
                 $code_base,
                 $context,
@@ -90,7 +111,8 @@ class ConfigPluginSet extends Plugin {
         Node $node,
         Node $parent_node = null
     ) {
-        foreach ($this->getPlugins() as $plugin) {
+        $this->ensurePluginsExist();
+        foreach ($this->analyzeNodePluginSet as $plugin) {
             $plugin->analyzeNode(
                 $code_base,
                 $context,
@@ -113,7 +135,8 @@ class ConfigPluginSet extends Plugin {
         CodeBase $code_base,
         Clazz $class
     ) {
-        foreach ($this->getPlugins() as $plugin) {
+        $this->ensurePluginsExist();
+        foreach ($this->analyzeClassPluginSet as $plugin) {
             $plugin->analyzeClass(
                 $code_base,
                 $class
@@ -134,7 +157,8 @@ class ConfigPluginSet extends Plugin {
         CodeBase $code_base,
         Method $method
     ) {
-        foreach ($this->getPlugins() as $plugin) {
+        $this->ensurePluginsExist();
+        foreach ($this->analyzeMethodPluginSet as $plugin) {
             $plugin->analyzeMethod(
                 $code_base,
                 $method
@@ -155,7 +179,8 @@ class ConfigPluginSet extends Plugin {
         CodeBase $code_base,
         Func $function
     ) {
-        foreach ($this->getPlugins() as $plugin) {
+        $this->ensurePluginsExist();
+        foreach ($this->analyzeFunctionPluginSet as $plugin) {
             $plugin->analyzeFunction(
                 $code_base,
                 $function
@@ -168,27 +193,54 @@ class ConfigPluginSet extends Plugin {
         return \count($this->getPlugins()) > 0;
     }
 
+    /** @return void */
+    private function ensurePluginsExist()
+    {
+        if (!\is_null($this->pluginSet)) {
+            return;
+        }
+        $plugin_set = array_map(
+            function (string $plugin_file_name) : Plugin {
+                $plugin_instance =
+                    require($plugin_file_name);
+
+                \assert(!empty($plugin_instance),
+                    "Plugins must return an instance of the plugin. The plugin at $plugin_file_name does not.");
+
+                \assert($plugin_instance instanceof Plugin,
+                    "Plugins must extend \Phan\Plugin. The plugin at $plugin_file_name does not.");
+
+                return $plugin_instance;
+            },
+            Config::getValue('plugins')
+        );
+        $this->pluginSet = $plugin_set;
+
+        $this->preAnalyzeNodePluginSet      = self::filterByClass($plugin_set, LegacyPreAnalyzeNodeCapability::class);
+        $this->analyzeNodePluginSet         = self::filterByClass($plugin_set, LegacyAnalyzeNodeCapability::class);
+        $this->analyzeMethodPluginSet       = self::filterByClass($plugin_set, AnalyzeMethodCapability::class);
+        $this->analyzeFunctionPluginSet     = self::filterByClass($plugin_set, AnalyzeFunctionCapability::class);
+        $this->analyzeClassPluginSet        = self::filterByClass($plugin_set, AnalyzeClassCapability::class);
+    }
+
+    private static function filterByClass(array $plugin_set, string $interface_name) : array {
+        $result = [];
+        foreach ($plugin_set as $plugin) {
+            if ($plugin instanceof $interface_name) {
+                $result[] = $plugin;
+            }
+        }
+        return $result;
+    }
+
+
     /**
      * @return Plugin[]
      */
     private function getPlugins() : array
     {
         if (\is_null($this->pluginSet)) {
-            $this->pluginSet = array_map(
-                function (string $plugin_file_name) : Plugin {
-                    $plugin_instance =
-                        require($plugin_file_name);
-
-                    \assert(!empty($plugin_instance),
-                        "Plugins must return an instance of the plugin. The plugin at $plugin_file_name does not.");
-
-                    \assert($plugin_instance instanceof Plugin,
-                        "Plugins must extend \Phan\Plugin. The plugin at $plugin_file_name does not.");
-
-                    return $plugin_instance;
-                },
-                Config::getValue('plugins')
-            );
+            $this->ensurePluginsExist();
         }
         return $this->pluginSet;
     }

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -61,6 +61,7 @@ final class ConfigPluginSet extends PluginV2 implements
     /**
      * @return ConfigPluginSet
      * A shared single instance of this plugin
+     * @suppress PhanDeprecatedInterface
      */
     public static function instance() : ConfigPluginSet
     {
@@ -266,6 +267,7 @@ final class ConfigPluginSet extends PluginV2 implements
                 $empty_object = (new \ReflectionClass($plugin_analysis_class))->newInstanceWithoutConstructor();
                 /**
                  * @suppress PhanParamTooMany
+                 * @suppress PhanDeprecatedInterface (TODO: Fix bugs in PhanClosureScope)
                  */
                 $closure = (static function(CodeBase $code_base, Context $context, Node $node) {
                     (new static($code_base, $context))($node);
@@ -315,6 +317,7 @@ final class ConfigPluginSet extends PluginV2 implements
                 /**
                  * @suppress PhanParamTooMany
                  * @suppress PhanUndeclaredProperty
+                 * @suppress PhanDeprecatedInterface (TODO: Fix bugs in PhanClosureScope)
                  */
                 $closure = (static function(CodeBase $code_base, Context $context, Node $node, Node $parent_node = null) {
                     $visitor = new static($code_base, $context);

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -56,6 +56,7 @@ final class ConfigPluginSet extends Plugin {
         static $instance = null;
         if ($instance === null) {
             $instance = new self;
+            $instance->ensurePluginsExist();
         }
         return $instance;
     }
@@ -79,7 +80,6 @@ final class ConfigPluginSet extends Plugin {
         Context $context,
         Node $node
     ) {
-        $this->ensurePluginsExist();
         foreach ($this->preAnalyzeNodePluginSet as $plugin) {
             $plugin->preAnalyzeNode(
                 $code_base,
@@ -112,7 +112,6 @@ final class ConfigPluginSet extends Plugin {
         Node $node,
         Node $parent_node = null
     ) {
-        $this->ensurePluginsExist();
         foreach ($this->analyzeNodePluginSet as $plugin) {
             $plugin->analyzeNode(
                 $code_base,
@@ -136,7 +135,6 @@ final class ConfigPluginSet extends Plugin {
         CodeBase $code_base,
         Clazz $class
     ) {
-        $this->ensurePluginsExist();
         foreach ($this->analyzeClassPluginSet as $plugin) {
             $plugin->analyzeClass(
                 $code_base,
@@ -158,7 +156,6 @@ final class ConfigPluginSet extends Plugin {
         CodeBase $code_base,
         Method $method
     ) {
-        $this->ensurePluginsExist();
         foreach ($this->analyzeMethodPluginSet as $plugin) {
             $plugin->analyzeMethod(
                 $code_base,
@@ -180,7 +177,6 @@ final class ConfigPluginSet extends Plugin {
         CodeBase $code_base,
         Func $function
     ) {
-        $this->ensurePluginsExist();
         foreach ($this->analyzeFunctionPluginSet as $plugin) {
             $plugin->analyzeFunction(
                 $code_base,
@@ -191,7 +187,8 @@ final class ConfigPluginSet extends Plugin {
 
     // Micro-optimization in tight loops: check for plugins before calling config plugin set
     public function hasPlugins() : bool {
-        return \count($this->getPlugins()) > 0;
+        \assert(!\is_null($this->pluginSet));
+        return \count($this->pluginSet) > 0;
     }
 
     /** @return void */
@@ -240,9 +237,6 @@ final class ConfigPluginSet extends Plugin {
      */
     private function getPlugins() : array
     {
-        if (\is_null($this->pluginSet)) {
-            $this->ensurePluginsExist();
-        }
         return $this->pluginSet;
     }
 

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -1,9 +1,9 @@
 <?php declare(strict_types=1);
 namespace Phan\Plugin;
 
+use Phan\AST\Visitor\Element;
 use Phan\CodeBase;
 use Phan\Config;
-use Phan\Language\AST\Visitor\Element;
 use Phan\Language\Context;
 use Phan\Language\Element\Clazz;
 use Phan\Language\Element\Func;
@@ -270,7 +270,8 @@ final class ConfigPluginSet extends PluginV2 implements
                  * @suppress PhanDeprecatedInterface (TODO: Fix bugs in PhanClosureScope)
                  */
                 $closure = (static function(CodeBase $code_base, Context $context, Node $node) {
-                    (new static($code_base, $context))($node);
+                    $fn_name = Element::VISIT_LOOKUP_TABLE[$node->kind];
+                    return (new static($code_base, $context))->{$fn_name}($node);
                 })->bindTo(null, $plugin_analysis_class);
                 $handled_node_kinds = $plugin_analysis_class::getHandledNodeKinds();
                 if (\count($handled_node_kinds) === 0) {
@@ -322,7 +323,8 @@ final class ConfigPluginSet extends PluginV2 implements
                 $closure = (static function(CodeBase $code_base, Context $context, Node $node, Node $parent_node = null) {
                     $visitor = new static($code_base, $context);
                     $visitor->parent_node = $parent_node;
-                    $visitor($node);
+                    $fn_name = Element::VISIT_LOOKUP_TABLE[$node->kind];
+                    $visitor->{$fn_name}($node);
                 })->bindTo(null, $plugin_analysis_class);
                 $handled_node_kinds = $plugin_analysis_class::getHandledNodeKinds();
                 if (\count($handled_node_kinds) === 0) {

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -200,17 +200,26 @@ final class ConfigPluginSet extends PluginV2 implements
     }
 
     // Micro-optimization in tight loops: check for plugins before calling config plugin set
-    public function hasPlugins() : bool {
+    public function hasPlugins() : bool
+    {
         \assert(!\is_null($this->pluginSet));
         return \count($this->pluginSet) > 0;
     }
 
-    public function hasAnalyzeFunctionPlugins() : bool {
+    /**
+     * Returns true if analyzeFunction() will execute any plugins.
+     */
+    public function hasAnalyzeFunctionPlugins() : bool
+    {
         \assert(!\is_null($this->pluginSet));
         return \count($this->analyzeFunctionPluginSet) > 0;
     }
 
-    public function hasAnalyzeMethodPlugins() : bool {
+    /**
+     * Returns true if analyzeMethod() will execute any plugins.
+     */
+    public function hasAnalyzeMethodPlugins() : bool
+    {
         \assert(!\is_null($this->pluginSet));
         return \count($this->analyzeMethodPluginSet) > 0;
     }
@@ -261,11 +270,13 @@ final class ConfigPluginSet extends PluginV2 implements
                 $closures_for_kind->recordForAllKinds($closure);
             } else if ($plugin instanceof PreAnalyzeNodeCapability) {
                 $plugin_analysis_class = $plugin->getPreAnalyzeNodeVisitorClassName();
-                if (!is_subclass_of($plugin_analysis_class, PluginAwarePreAnalysisVisitor::class)) {
+                if (!\is_subclass_of($plugin_analysis_class, PluginAwarePreAnalysisVisitor::class)) {
                     throw new \TypeError(sprintf("Result of %s::getAnalyzeNodeVisitorClassName must be the name of a subclass of '%s', but '%s' is not", get_class($plugin), PluginAwarePreAnalysisVisitor::class, $plugin_analysis_class));
                 }
                 $empty_object = (new \ReflectionClass($plugin_analysis_class))->newInstanceWithoutConstructor();
                 /**
+                 * Create an instance of $plugin_analysis_class and run the visit*() method corresponding to $node->kind.
+                 *
                  * @suppress PhanParamTooMany
                  * @suppress PhanDeprecatedInterface (TODO: Fix bugs in PhanClosureScope)
                  */
@@ -312,10 +323,12 @@ final class ConfigPluginSet extends PluginV2 implements
                 $closures_for_kind->recordForAllKinds($closure);
             } else if ($plugin instanceof AnalyzeNodeCapability) {
                 $plugin_analysis_class = $plugin->getAnalyzeNodeVisitorClassName();
-                if (!is_subclass_of($plugin_analysis_class, PluginAwareAnalysisVisitor::class)) {
+                if (!\is_subclass_of($plugin_analysis_class, PluginAwareAnalysisVisitor::class)) {
                     throw new \TypeError(sprintf("Result of %s::getAnalyzeNodeVisitorClassName must be the name of a subclass of '%s', but '%s' is not", get_class($plugin), PluginAwareAnalysisVisitor::class, $plugin_analysis_class));
                 }
                 /**
+                 * Create an instance of $plugin_analysis_class and run the visit*() method corresponding to $node->kind.
+                 *
                  * @suppress PhanParamTooMany
                  * @suppress PhanUndeclaredProperty
                  * @suppress PhanDeprecatedInterface (TODO: Fix bugs in PhanClosureScope)
@@ -326,6 +339,7 @@ final class ConfigPluginSet extends PluginV2 implements
                     $fn_name = Element::VISIT_LOOKUP_TABLE[$node->kind];
                     $visitor->{$fn_name}($node);
                 })->bindTo(null, $plugin_analysis_class);
+
                 $handled_node_kinds = $plugin_analysis_class::getHandledNodeKinds();
                 if (\count($handled_node_kinds) === 0) {
                     fprintf(

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -3,17 +3,22 @@ namespace Phan\Plugin;
 
 use Phan\CodeBase;
 use Phan\Config;
+use Phan\Language\AST\Visitor\Element;
 use Phan\Language\Context;
 use Phan\Language\Element\Clazz;
 use Phan\Language\Element\Func;
 use Phan\Language\Element\Method;
 use Phan\Plugin;
 use Phan\PluginV2;
-use Phan\PluginV2\LegacyPreAnalyzeNodeCapability;
+use Phan\PluginV2\AnalyzeNodeCapability;
+use Phan\PluginV2\PreAnalyzeNodeCapability;
 use Phan\PluginV2\AnalyzeClassCapability;
 use Phan\PluginV2\AnalyzeFunctionCapability;
 use Phan\PluginV2\AnalyzeMethodCapability;
 use Phan\PluginV2\LegacyAnalyzeNodeCapability;
+use Phan\PluginV2\LegacyPreAnalyzeNodeCapability;
+use Phan\PluginV2\PluginAwareAnalysisVisitor;
+use Phan\PluginV2\PluginAwarePreAnalysisVisitor;
 use ast\Node;
 
 /**
@@ -23,14 +28,20 @@ use ast\Node;
  * (Note: This is called almost once per each AST node being analyzed.
  * Speed is preferred over using Phan\Memoize.)
  */
-final class ConfigPluginSet extends Plugin {
+final class ConfigPluginSet extends PluginV2 implements
+    AnalyzeClassCapability,
+    AnalyzeFunctionCapability,
+    AnalyzeMethodCapability,
+    LegacyAnalyzeNodeCapability,
+    LegacyPreAnalyzeNodeCapability {
+
     /** @var Plugin[]|null - Cached plugin set for this instance. Lazily generated. */
     private $pluginSet;
 
-    /** @var LegacyPreAnalyzeNodeCapability[]|null */
+    /** @var \Closure[]|null */
     private $preAnalyzeNodePluginSet;
 
-    /** @var LegacyAnalyzeNodeCapability[]|null */
+    /** @var \Closure[]|null */
     private $analyzeNodePluginSet;
 
     /** @var AnalyzeClassCapability[]|null */
@@ -80,8 +91,9 @@ final class ConfigPluginSet extends Plugin {
         Context $context,
         Node $node
     ) {
-        foreach ($this->preAnalyzeNodePluginSet as $plugin) {
-            $plugin->preAnalyzeNode(
+        $plugin_callback = $this->preAnalyzeNodePluginSet[$node->kind] ?? null;
+        if ($plugin_callback !== null) {
+            $plugin_callback(
                 $code_base,
                 $context,
                 $node
@@ -112,8 +124,9 @@ final class ConfigPluginSet extends Plugin {
         Node $node,
         Node $parent_node = null
     ) {
-        foreach ($this->analyzeNodePluginSet as $plugin) {
-            $plugin->analyzeNode(
+        $plugin_callback = $this->analyzeNodePluginSet[$node->kind] ?? null;
+        if ($plugin_callback !== null) {
+            $plugin_callback(
                 $code_base,
                 $context,
                 $node,
@@ -191,6 +204,16 @@ final class ConfigPluginSet extends Plugin {
         return \count($this->pluginSet) > 0;
     }
 
+    public function hasAnalyzeFunctionPlugins() : bool {
+        \assert(!\is_null($this->pluginSet));
+        return \count($this->analyzeFunctionPluginSet) > 0;
+    }
+
+    public function hasAnalyzeMethodPlugins() : bool {
+        \assert(!\is_null($this->pluginSet));
+        return \count($this->analyzeMethodPluginSet) > 0;
+    }
+
     /** @return void */
     private function ensurePluginsExist()
     {
@@ -214,14 +237,78 @@ final class ConfigPluginSet extends Plugin {
         );
         $this->pluginSet = $plugin_set;
 
-        $this->preAnalyzeNodePluginSet      = self::filterByClass($plugin_set, LegacyPreAnalyzeNodeCapability::class);
-        $this->analyzeNodePluginSet         = self::filterByClass($plugin_set, LegacyAnalyzeNodeCapability::class);
+        $this->preAnalyzeNodePluginSet      = self::filterPreAnalysisPlugins($plugin_set);
+        $this->analyzeNodePluginSet         = self::filterAnalysisPlugins($plugin_set);
         $this->analyzeMethodPluginSet       = self::filterByClass($plugin_set, AnalyzeMethodCapability::class);
         $this->analyzeFunctionPluginSet     = self::filterByClass($plugin_set, AnalyzeFunctionCapability::class);
         $this->analyzeClassPluginSet        = self::filterByClass($plugin_set, AnalyzeClassCapability::class);
     }
 
-    private static function filterByClass(array $plugin_set, string $interface_name) : array {
+    /**
+     * @return \Closure[] - [function(CodeBase $code_base, Context $context, Node $node, Node $parent_node = null): void]
+     */
+    private static function filterPreAnalysisPlugins(array $plugin_set) : array
+    {
+        $closures_for_kind = new ClosuresForKind();
+        foreach ($plugin_set as $plugin) {
+            if ($plugin instanceof LegacyPreAnalyzeNodeCapability) {
+                if ($plugin instanceof PreAnalyzeNodeCapability) {
+                    throw new \TypeError(sprintf("plugin %s should implement only one of LegacyPreAnalyzeNodeCapability and PreAnalyzeNodeCapability, not both", get_class($plugin)));
+                }
+                $closure = (new \ReflectionMethod($plugin, 'preAnalyzeNode'))->getClosure($plugin);
+                $closures_for_kind->recordForAllKinds($closure);
+            } else if ($plugin instanceof PreAnalyzeNodeCapability) {
+                $plugin_analysis_class = $plugin->getPreAnalyzeNodeVisitorClassName();
+                if (!is_subclass_of($plugin_analysis_class, PluginAwarePreAnalysisVisitor::class)) {
+                    throw new \TypeError(sprintf("Result of %s::getAnalyzeNodeVisitorClassName must be the name of a subclass of '%s', but '%s' is not", get_class($plugin), PluginAwarePreAnalysisVisitor::class, $plugin_analysis_class));
+                }
+                $closure = (new \ReflectionMethod($plugin_analysis_class, 'staticInvoke'))->getClosure(null);
+                $record_closure($plugin_analysis_class::get_handled_node_kinds(), $closure);
+            }
+        }
+        return $closures_for_kind->getFlattenedClosures(static function(array $closure_list) : \Closure {
+            return static function(CodeBase $code_base, Context $context, Node $node) use($closure_list) {
+                foreach ($closure_list as $closure) {
+                    $closure($code_base, $context, $node);
+                }
+            };
+        });
+    }
+
+    /**
+     * @return \Closure[][] - [function(CodeBase $code_base, Context $context, Node $node, Node $parent_node = null): void]
+     * @var \Closure[][] $closures_for_kind
+     */
+    private static function filterAnalysisPlugins(array $plugin_set) : array
+    {
+        $closures_for_kind = new ClosuresForKind();
+        foreach ($plugin_set as $plugin) {
+            if ($plugin instanceof LegacyAnalyzeNodeCapability) {
+                if ($plugin instanceof AnalyzeNodeCapability) {
+                    throw new \TypeError(sprintf("plugin %s should implement only one of LegacyAnalyzeNodeCapability and AnalyzeNodeCapability, not both", get_class($plugin)));
+                }
+                $closure = (new \ReflectionMethod($plugin, 'analyzeNode'))->getClosure($plugin);
+                $closures_for_kind->recordForAllKinds($closure);
+            } else if ($plugin instanceof AnalyzeNodeCapability) {
+                $plugin_analysis_class = $plugin->getAnalyzeNodeVisitorClassName();
+                if (!is_subclass_of($plugin_analysis_class, PluginAwareAnalysisVisitor::class)) {
+                    throw new \TypeError(sprintf("Result of %s::getAnalyzeNodeVisitorClassName must be the name of a subclass of '%s', but '%s' is not", get_class($plugin), PluginAwareAnalysisVisitor::class, $plugin_analysis_class));
+                }
+                $closure = (new \ReflectionMethod($plugin_analysis_class, 'staticInvoke'))->getClosure(null);
+                $closures_for_kind->recordForKinds($plugin_analysis_class::get_handled_node_kinds(), $closure);
+            }
+        }
+        return $closures_for_kind->getFlattenedClosures(static function(array $closure_list) : \Closure {
+           return static function(CodeBase $code_base, Context $context, Node $node, Node $parent_node = null) use($closure_list) {
+                foreach ($closure_list as $closure) {
+                    $closure($code_base, $context, $node, $parent_node);
+                }
+           };
+        });
+    }
+
+    private static function filterByClass(array $plugin_set, string $interface_name) : array
+    {
         $result = [];
         foreach ($plugin_set as $plugin) {
             if ($plugin instanceof $interface_name) {

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -8,6 +8,7 @@ use Phan\Language\Element\Clazz;
 use Phan\Language\Element\Func;
 use Phan\Language\Element\Method;
 use Phan\Plugin;
+use Phan\PluginV2;
 use Phan\PluginV2\LegacyPreAnalyzeNodeCapability;
 use Phan\PluginV2\AnalyzeClassCapability;
 use Phan\PluginV2\AnalyzeFunctionCapability;
@@ -200,15 +201,15 @@ final class ConfigPluginSet extends Plugin {
             return;
         }
         $plugin_set = array_map(
-            function (string $plugin_file_name) : Plugin {
+            function (string $plugin_file_name) : PluginV2 {
                 $plugin_instance =
                     require($plugin_file_name);
 
                 \assert(!empty($plugin_instance),
                     "Plugins must return an instance of the plugin. The plugin at $plugin_file_name does not.");
 
-                \assert($plugin_instance instanceof Plugin,
-                    "Plugins must extend \Phan\Plugin. The plugin at $plugin_file_name does not.");
+                \assert($plugin_instance instanceof PluginV2,
+                    "Plugins must extend \Phan\PluginV2. The plugin at $plugin_file_name does not.");
 
                 return $plugin_instance;
             },

--- a/src/Phan/Plugin/PluginImplementation.php
+++ b/src/Phan/Plugin/PluginImplementation.php
@@ -115,4 +115,16 @@ class PluginImplementation extends Plugin {
         Func $function
     ) {
     }
+
+    // Internal methods, for use by ConfigPluginSet
+
+    /**
+     * @return bool true if $method_name is defined by the subclass of PluginAwareAnalysisVisitor, and not by PluginAwareAnalysisVisitor or one of it's parents.
+     */
+    public static final function isDefinedInSubclass(string $method_name) : bool
+    {
+        $method = new \ReflectionMethod(static::class, $method_name);
+        return is_subclass_of($method->getDeclaringClass()->name, self::class);
+    }
+    // End of internal methods.
 }

--- a/src/Phan/PluginV2.php
+++ b/src/Phan/PluginV2.php
@@ -1,0 +1,84 @@
+<?php declare(strict_types=1);
+namespace Phan;
+
+use Phan\Language\Context;
+use Phan\Language\Element\Clazz;
+use Phan\Language\Element\Method;
+use Phan\Language\Element\Func;
+use ast\Node;
+
+/**
+ * Plugins can be defined in the config and will have
+ * their hooks called at appropriate times during analysis
+ * of each file, class, method and function.
+ *
+ * Plugins must extends this class and return an instance
+ * of themselves.
+ */
+abstract class PluginV2 {
+
+    /**
+     * Emit an issue if it is not suppressed
+     *
+     * @param CodeBase $code_base
+     * The code base in which the issue was found
+     *
+     * @param Context $context
+     * The context in which the issue was found
+     *
+     * @param string $issue_type
+     * A name for the type of issue such as 'PhanPluginMyIssue'
+     *
+     * @param string $issue_message_fmt
+     * The complete issue message format string to emit such as
+     * 'class with fqsen {CLASS} is broken in some fashion' (preferred)
+     * or 'class with fqsen %s is broken in some fashion'
+     * The list of placeholders for between braces can be found
+     * in \Phan\Issue::uncolored_format_string_for_template.
+     *
+     * @param string[] $issue_message_args
+     * The arguments for this issue format.
+     * If this array is empty, $issue_message_args is kept in place
+     *
+     * @param int $severity
+     * A value from the set {Issue::SEVERITY_LOW,
+     * Issue::SEVERITY_NORMAL, Issue::SEVERITY_HIGH}.
+     *
+     * @param int $remediation_difficulty
+     * A guess at how hard the issue will be to fix from the
+     * set {Issue:REMEDIATION_A, Issue:REMEDIATION_B, ...
+     * Issue::REMEDIATION_F} with F being the hardest.
+     */
+    public function emitIssue(
+        CodeBase $code_base,
+        Context $context,
+        string $issue_type,
+        string $issue_message_fmt,
+        array $issue_message_args = [],
+        int $severity = Issue::SEVERITY_NORMAL,
+        int $remediation_difficulty = Issue::REMEDIATION_B,
+        int $issue_type_id = Issue::TYPE_ID_UNKNOWN
+    ) {
+        $issue = new Issue(
+            $issue_type,
+            Issue::CATEGORY_PLUGIN,
+            $severity,
+            $issue_message_fmt,
+            $remediation_difficulty,
+            $issue_type_id
+        );
+
+        $issue_instance = new IssueInstance(
+            $issue,
+            $context->getFile(),
+            $context->getLineNumberStart(),
+            $issue_message_args
+        );
+
+        Issue::maybeEmitInstance(
+            $code_base,
+            $context,
+            $issue_instance
+        );
+    }
+}

--- a/src/Phan/PluginV2.php
+++ b/src/Phan/PluginV2.php
@@ -2,9 +2,7 @@
 namespace Phan;
 
 use Phan\Language\Context;
-use Phan\Language\Element\Clazz;
-use Phan\Language\Element\Method;
-use Phan\Language\Element\Func;
+use Phan\PluginV2\IssueEmitter;
 use ast\Node;
 
 /**
@@ -16,69 +14,7 @@ use ast\Node;
  * of themselves.
  */
 abstract class PluginV2 {
-
-    /**
-     * Emit an issue if it is not suppressed
-     *
-     * @param CodeBase $code_base
-     * The code base in which the issue was found
-     *
-     * @param Context $context
-     * The context in which the issue was found
-     *
-     * @param string $issue_type
-     * A name for the type of issue such as 'PhanPluginMyIssue'
-     *
-     * @param string $issue_message_fmt
-     * The complete issue message format string to emit such as
-     * 'class with fqsen {CLASS} is broken in some fashion' (preferred)
-     * or 'class with fqsen %s is broken in some fashion'
-     * The list of placeholders for between braces can be found
-     * in \Phan\Issue::uncolored_format_string_for_template.
-     *
-     * @param string[] $issue_message_args
-     * The arguments for this issue format.
-     * If this array is empty, $issue_message_args is kept in place
-     *
-     * @param int $severity
-     * A value from the set {Issue::SEVERITY_LOW,
-     * Issue::SEVERITY_NORMAL, Issue::SEVERITY_HIGH}.
-     *
-     * @param int $remediation_difficulty
-     * A guess at how hard the issue will be to fix from the
-     * set {Issue:REMEDIATION_A, Issue:REMEDIATION_B, ...
-     * Issue::REMEDIATION_F} with F being the hardest.
-     */
-    public function emitIssue(
-        CodeBase $code_base,
-        Context $context,
-        string $issue_type,
-        string $issue_message_fmt,
-        array $issue_message_args = [],
-        int $severity = Issue::SEVERITY_NORMAL,
-        int $remediation_difficulty = Issue::REMEDIATION_B,
-        int $issue_type_id = Issue::TYPE_ID_UNKNOWN
-    ) {
-        $issue = new Issue(
-            $issue_type,
-            Issue::CATEGORY_PLUGIN,
-            $severity,
-            $issue_message_fmt,
-            $remediation_difficulty,
-            $issue_type_id
-        );
-
-        $issue_instance = new IssueInstance(
-            $issue,
-            $context->getFile(),
-            $context->getLineNumberStart(),
-            $issue_message_args
-        );
-
-        Issue::maybeEmitInstance(
-            $code_base,
-            $context,
-            $issue_instance
-        );
+    use IssueEmitter {
+        emitPluginIssue as emitIssue;
     }
 }

--- a/src/Phan/PluginV2.php
+++ b/src/Phan/PluginV2.php
@@ -10,10 +10,57 @@ use ast\Node;
  * their hooks called at appropriate times during analysis
  * of each file, class, method and function.
  *
- * Plugins must extends this class and return an instance
- * of themselves.
+ * Plugins must extends this class
+ * (And at least one of the interfaces corresponding to plugin capabilities)
+ * and return an instance of themselves.
+ *
+ * List of capabilities which a plugin may implement:
+ *
+ *  1. public function analyzeClass(CodeBase $code_base, Clazz $class)
+ *     Analyze (and modify) a class definition, after parsing and before analyzing.
+ *     (implement \Phan\PluginV2\AnalyzeClassCapability)
+ *
+ *  2. public function analyzeFunction(CodeBase $code_base, Func $function)
+ *     Analyze (and modify) a function definition, after parsing and before analyzing.
+ *     (implement \Phan\PluginV2\AnalyzeFunctionCapability)
+ *
+ *  3. public function analyzeMethod(CodeBase $code_base, Method $method)
+ *     Analyze (and modify) a method definition, after parsing and before analyzing.
+ *     (implement \Phan\PluginV2\AnalyzeMethodCapability)
+ *
+ *  4. public static function getAnalyzeNodeVisitorClassName() : string
+ *     Returns the name of a class extending PluginAwareAnalysisVisitor, which will be used to analyze nodes in the analysis phase.
+ *     (implement \Phan\PluginV2\AnalyzeNodeCapability)
+ *
+ *  5. public static function getPreAnalyzeNodeVisitorClassName() : string
+ *     Returns the name of a class extending PluginAwarePreAnalysisVisitor, which will be used to pre-analyze nodes in the analysis phase.
+ *     (implement \Phan\PluginV2\PreAnalyzeNodeCapability)
+ *
+ * List of deprecated legacy capabilities
+ *
+ *  1. public static function analyzeNode(CodeBase $code_base, Context $context, Node $node, Node $parent_node = null)
+ *     Analyzes $node
+ *     (implement \Phan\PluginV2\LegacyAnalyzeNodeCapability)
+ *     (Deprecated in favor of \Phan\PluginV2\AnalyzeNodeCapability, which is faster)
+ *
+ *  2. public static function preAnalyzeNode(CodeBase $code_base, Context $context, Node $node)
+ *     Pre-analyzes $node
+ *     (implement \Phan\PluginV2\LegacyPreAnalyzeNodeCapability)
+ *     (Deprecated in favor of \Phan\PluginV2\PreAnalyzeNodeCapability, which is faster)
  */
 abstract class PluginV2 {
+    /**
+     * public function emitIssue(
+     *     CodeBase $code_base,
+     *     Context $context,
+     *     string $issue_type,
+     *     string $issue_message_fmt,
+     *     array $issue_message_args = [],
+     *     int $severity = Issue::SEVERITY_NORMAL,
+     *     int $remediation_difficulty = Issue::REMEDIATION_B,
+     *     int $issue_type_id = Issue::TYPE_ID_UNKNOWN
+     * )
+     */
     use IssueEmitter {
         emitPluginIssue as emitIssue;
     }

--- a/src/Phan/PluginV2/AnalyzeClassCapability.php
+++ b/src/Phan/PluginV2/AnalyzeClassCapability.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+namespace Phan\PluginV2;
+
+use Phan\CodeBase;
+use Phan\Language\Element\Clazz;
+
+interface AnalyzeClassCapability {
+    /**
+     * @param CodeBase $code_base
+     * The code base in which the class exists
+     *
+     * @param Clazz $class
+     * A class being analyzed
+     *
+     * @return void
+     */
+    public function analyzeClass(
+        CodeBase $code_base,
+        Clazz $class
+    );
+}

--- a/src/Phan/PluginV2/AnalyzeFunctionCapability.php
+++ b/src/Phan/PluginV2/AnalyzeFunctionCapability.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+namespace Phan\PluginV2;
+
+use Phan\CodeBase;
+use Phan\Language\Element\Func;
+
+interface AnalyzeFunctionCapability {
+    /**
+     * @param CodeBase $code_base
+     * The code base in which the function exists
+     *
+     * @param Func $function
+     * A function being analyzed
+     *
+     * @return void
+     */
+    public function analyzeFunction(
+        CodeBase $code_base,
+        Func $function
+    );
+}

--- a/src/Phan/PluginV2/AnalyzeMethodCapability.php
+++ b/src/Phan/PluginV2/AnalyzeMethodCapability.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+namespace Phan\PluginV2;
+
+use Phan\CodeBase;
+use Phan\Language\Element\Method;
+
+interface AnalyzeMethodCapability {
+    /**
+     * @param CodeBase $code_base
+     * The code base in which the method exists
+     *
+     * @param Method $method
+     * A method being analyzed
+     *
+     * @return void
+     */
+    public function analyzeMethod(
+        CodeBase $code_base,
+        Method $method
+    );
+}

--- a/src/Phan/PluginV2/AnalyzeNodeCapability.php
+++ b/src/Phan/PluginV2/AnalyzeNodeCapability.php
@@ -3,9 +3,11 @@ namespace Phan\PluginV2;
 
 interface AnalyzeNodeCapability {
     /**
-     * Returns the name of the class to be instantiated and invoked in the analysis phase.
-     * (To analyze a node, after preAnalysis is called)
+     * Returns the name of the visitor class to be instantiated and invoked to analyze a node in the analysis phase.
+     * (To analyze a node. AnalyzeNodeCapability is run after PreAnalyzeNodeCapability)
      * The class should be created by the plugin visitor, and must extend PluginAwareAnalysisVisitor.
+     *
+     * If state needs to be shared with a visitor and a plugin, a plugin author may use static variables of that plugin.
      *
      * @return string - The name of a class extending PluginAwareAnalysisVisitor
      */

--- a/src/Phan/PluginV2/AnalyzeNodeCapability.php
+++ b/src/Phan/PluginV2/AnalyzeNodeCapability.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+namespace Phan\PluginV2;
+
+interface AnalyzeNodeCapability {
+    /**
+     * Returns the name of the class to be instantiated and invoked in the analysis phase.
+     * (To analyze a node, after preAnalysis is called)
+     * The class should be created by the plugin visitor, and must extend PluginAwareAnalysisVisitor.
+     *
+     * @return string - The name of a class extending PluginAwareAnalysisVisitor
+     */
+    public static function getAnalyzeNodeVisitorClassName() : string;
+}

--- a/src/Phan/PluginV2/IssueEmitter.php
+++ b/src/Phan/PluginV2/IssueEmitter.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types=1);
+namespace Phan\PluginV2;
+
+use Phan\Language\Context;
+use Phan\CodeBase;
+use Phan\Config;
+use Phan\Issue;
+use Phan\IssueInstance;
+
+use ast\Node;
+
+/**
+ * A trait which allows plugins to emit issues with custom error messages
+ */
+trait IssueEmitter {
+    /**
+     * Emit an issue if it is not suppressed
+     *
+     * @param CodeBase $code_base
+     * The code base in which the issue was found
+     *
+     * @param Context $context
+     * The context in which the issue was found
+     *
+     * @param string $issue_type
+     * A name for the type of issue such as 'PhanPluginMyIssue'
+     *
+     * @param string $issue_message_fmt
+     * The complete issue message format string to emit such as
+     * 'class with fqsen {CLASS} is broken in some fashion' (preferred)
+     * or 'class with fqsen %s is broken in some fashion'
+     * The list of placeholders for between braces can be found
+     * in \Phan\Issue::uncolored_format_string_for_template.
+     *
+     * @param string[] $issue_message_args
+     * The arguments for this issue format.
+     * If this array is empty, $issue_message_args is kept in place
+     *
+     * @param int $severity
+     * A value from the set {Issue::SEVERITY_LOW,
+     * Issue::SEVERITY_NORMAL, Issue::SEVERITY_HIGH}.
+     *
+     * @param int $remediation_difficulty
+     * A guess at how hard the issue will be to fix from the
+     * set {Issue:REMEDIATION_A, Issue:REMEDIATION_B, ...
+     * Issue::REMEDIATION_F} with F being the hardest.
+     */
+    public function emitPluginIssue(
+        CodeBase $code_base,
+        Context $context,
+        string $issue_type,
+        string $issue_message_fmt,
+        array $issue_message_args = [],
+        int $severity = Issue::SEVERITY_NORMAL,
+        int $remediation_difficulty = Issue::REMEDIATION_B,
+        int $issue_type_id = Issue::TYPE_ID_UNKNOWN
+    ) {
+        $issue = new Issue(
+            $issue_type,
+            Issue::CATEGORY_PLUGIN,
+            $severity,
+            $issue_message_fmt,
+            $remediation_difficulty,
+            $issue_type_id
+        );
+
+        $issue_instance = new IssueInstance(
+            $issue,
+            $context->getFile(),
+            $context->getLineNumberStart(),
+            $issue_message_args
+        );
+
+        Issue::maybeEmitInstance(
+            $code_base,
+            $context,
+            $issue_instance
+        );
+    }
+}

--- a/src/Phan/PluginV2/LegacyAnalyzeNodeCapability.php
+++ b/src/Phan/PluginV2/LegacyAnalyzeNodeCapability.php
@@ -6,6 +6,9 @@ use Phan\Language\Context;
 
 use ast\Node;
 
+/**
+ * @deprecated - New plugins should use AnalyzeNodeCapability
+ */
 interface LegacyAnalyzeNodeCapability {
     /**
      * Analyze the given node in the given context after
@@ -26,6 +29,8 @@ interface LegacyAnalyzeNodeCapability {
      * The parent node of the given node (if one exists).
      *
      * @return void
+     *
+     * @deprecated
      */
     public function analyzeNode(
         CodeBase $code_base,

--- a/src/Phan/PluginV2/LegacyAnalyzeNodeCapability.php
+++ b/src/Phan/PluginV2/LegacyAnalyzeNodeCapability.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+namespace Phan\PluginV2;
+
+use Phan\CodeBase;
+use Phan\Language\Context;
+
+use ast\Node;
+
+interface LegacyAnalyzeNodeCapability {
+    /**
+     * Analyze the given node in the given context after
+     * Phan has analyzed the node.
+     *
+     * @param CodeBase $code_base
+     * The code base in which the node exists
+     *
+     * @param Context $context
+     * The context in which the node exits. This is
+     * the context inside the given node rather than
+     * the context outside of the given node
+     *
+     * @param Node $node
+     * The php-ast Node being analyzed.
+     *
+     * @param Node $node
+     * The parent node of the given node (if one exists).
+     *
+     * @return void
+     */
+    public function analyzeNode(
+        CodeBase $code_base,
+        Context $context,
+        Node $node,
+        Node $parent_node = null
+    );
+}

--- a/src/Phan/PluginV2/LegacyPreAnalyzeNodeCapability.php
+++ b/src/Phan/PluginV2/LegacyPreAnalyzeNodeCapability.php
@@ -7,6 +7,9 @@ use Phan\Language\Element\Clazz;
 
 use ast\Node;
 
+/**
+ * @deprecated - New plugins should use PreAnalyzeNodeCapability
+ */
 interface LegacyPreAnalyzeNodeCapability {
     /**
      * Do a first-pass analysis of a node before Phan
@@ -27,6 +30,8 @@ interface LegacyPreAnalyzeNodeCapability {
      * The parent node of the given node (if one exists).
      *
      * @return void
+     *
+     * @deprecated
      */
     public function preAnalyzeNode(
         CodeBase $code_base,

--- a/src/Phan/PluginV2/LegacyPreAnalyzeNodeCapability.php
+++ b/src/Phan/PluginV2/LegacyPreAnalyzeNodeCapability.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+namespace Phan\PluginV2;
+
+use Phan\CodeBase;
+use Phan\Language\Context;
+use Phan\Language\Element\Clazz;
+
+use ast\Node;
+
+interface LegacyPreAnalyzeNodeCapability {
+    /**
+     * Do a first-pass analysis of a node before Phan
+     * does its full analysis. This hook allows you to
+     * update types in the CodeBase before analysis
+     * happens.
+     *
+     * @param CodeBase $code_base
+     * The code base in which the node exists
+     *
+     * @param Context $context
+     * The context in which the node exits. This is
+     * the context inside the given node rather than
+     * the context outside of the given node
+     *
+     * @param Node $node
+     * The php-ast Node being analyzed.
+     * The parent node of the given node (if one exists).
+     *
+     * @return void
+     */
+    public function preAnalyzeNode(
+        CodeBase $code_base,
+        Context $context,
+        Node $node
+    );
+}

--- a/src/Phan/PluginV2/PluginAwareAnalysisVisitor.php
+++ b/src/Phan/PluginV2/PluginAwareAnalysisVisitor.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+namespace Phan\PluginV2;
+
+use Phan\AST\AnalysisVisitor;
+use Phan\AST\Visitor\Element;
+use Phan\CodeBase;
+use Phan\Language\Context;
+use ast\Node;
+
+/**
+ * For plugins which define their own post-order analysis behaviors in the analysis phase.
+ * Called on a node after PluginAwarePreAnalysisVisitor implementations.
+ */
+abstract class PluginAwareAnalysisVisitor extends AnalysisVisitor {
+    /**
+     * @var Node|null
+     */
+    protected $parent_node;
+
+    // Implementations should omit the constructor or call parent::__construct(CodeBase $code_base, Context $context, $parent_node)
+    public function __construct(CodeBase $code_base, Context $context, Node $parent_node = null) {
+        parent::__construct($code_base, $context);
+        $this->parent_node = $parent_node;
+    }
+
+    /**
+     * This is an empty visit() body.
+     * Don't override this unless you need to, analysis is more efficient if Phan knows it doesn't need to call a method.
+     * @see self::isDefinedInSubclass
+     *
+     * @return void
+     */
+    public function visit(Node $node)
+    {
+    }
+
+    /**
+     * @return int[] The list of $node->kind values this plugin is capable of analyzing.
+     */
+    public static final function getHandledNodeKinds() : array
+    {
+        $defines_visit = self::isDefinedInSubclass('visit');
+        $kinds = [];
+        foreach (Element::VISIT_LOOKUP_TABLE as $kind => $method_name) {
+            if ($defines_visit || self::isDefinedInSubclass($method_name)) {
+                $kinds[] = $kind;
+            }
+        }
+        return $kinds;
+    }
+
+    /**
+     * This is a utility function used by ConfigPluginSet
+     */
+    public static final function staticInvoke(CodeBase $code_base, Context $context, Node $node, Node $parent_node = null)
+    {
+        return (new static($code_base, $context, $parent_node))($node);
+    }
+
+    /**
+     * @return bool true if $method_name is defined by the subclass of PluginAwareAnalysisVisitor, and not by PluginAwareAnalysisVisitor or one of it's parents.
+     */
+    private static final function isDefinedInSubclass(string $method_name) : bool
+    {
+        $method = new \ReflectionMethod(static::class, $method_name);
+        return is_subclass_of($method->getDeclaringClass(), self::class);
+    }
+}

--- a/src/Phan/PluginV2/PluginAwareAnalysisVisitor.php
+++ b/src/Phan/PluginV2/PluginAwareAnalysisVisitor.php
@@ -71,19 +71,4 @@ abstract class PluginAwareAnalysisVisitor extends PluginAwareBaseAnalysisVisitor
             $issue_type_id
         );
     }
-
-    // Internal methods used by ConfigPluginSet are below.
-    // They aren't useful for plugins.
-
-    /**
-     * This is a utility function used by ConfigPluginSet
-     * @return void
-     */
-    public static final function staticInvoke(CodeBase $code_base, Context $context, Node $node, Node $parent_node = null)
-    {
-        $visitor = new static($code_base, $context);
-        $visitor->parent_node = $parent_node;
-        $visitor($node);
-    }
-    // End of internal methods.
 }

--- a/src/Phan/PluginV2/PluginAwareAnalysisVisitor.php
+++ b/src/Phan/PluginV2/PluginAwareAnalysisVisitor.php
@@ -12,8 +12,8 @@ use ast\Node;
  * Called on a node after PluginAwarePreAnalysisVisitor implementations.
  *
  * - visit<VisitSuffix>(...) (Override these methods)
- * - emitPluginIssue(...) (Call these methods)
- * - emitPluginIssueShort(...)
+ * - emitPluginIssue(CodeBase $code_base, Config $config, ...) (Call these methods)
+ * - emit(...)
  * - Public methods from Phan\AST\AnalysisVisitor
  *
  * NOTE: Subclasses should not implement the visit() method unless they absolutely need to.
@@ -52,7 +52,7 @@ abstract class PluginAwareAnalysisVisitor extends PluginAwareBaseAnalysisVisitor
      * set {Issue:REMEDIATION_A, Issue:REMEDIATION_B, ...
      * Issue::REMEDIATION_F} with F being the hardest.
      */
-    public function emitPluginIssueShort(
+    public function emit(
         string $issue_type,
         string $issue_message_fmt,
         array $issue_message_args = [],

--- a/src/Phan/PluginV2/PluginAwareBaseAnalysisVisitor.php
+++ b/src/Phan/PluginV2/PluginAwareBaseAnalysisVisitor.php
@@ -86,6 +86,7 @@ abstract class PluginAwareBaseAnalysisVisitor extends AnalysisVisitor {
         }
         return $kinds;
     }
+
     /**
      * @return bool true if $method_name is defined by the subclass of PluginAwareAnalysisVisitor, and not by PluginAwareAnalysisVisitor or one of it's parents.
      */

--- a/src/Phan/PluginV2/PluginAwareBaseAnalysisVisitor.php
+++ b/src/Phan/PluginV2/PluginAwareBaseAnalysisVisitor.php
@@ -68,9 +68,9 @@ abstract class PluginAwareBaseAnalysisVisitor extends AnalysisVisitor {
             $issue_type_id
         );
     }
+
     // Internal methods used by ConfigPluginSet are below.
     // They aren't useful for plugins.
-
 
     /**
      * @return int[] The list of $node->kind values this plugin is capable of analyzing.

--- a/src/Phan/PluginV2/PluginAwareBaseAnalysisVisitor.php
+++ b/src/Phan/PluginV2/PluginAwareBaseAnalysisVisitor.php
@@ -1,32 +1,30 @@
 <?php declare(strict_types=1);
 namespace Phan\PluginV2;
 
+use Phan\AST\AnalysisVisitor;
 use Phan\AST\Visitor\Element;
 use Phan\CodeBase;
-use Phan\Language\Context;
 use Phan\Issue;
+use Phan\Language\Context;
 use ast\Node;
 
 /**
- * For plugins which define their own post-order analysis behaviors in the analysis phase.
- * Called on a node after PluginAwarePreAnalysisVisitor implementations.
+ * This augments AnalysisVisitor with public and internal methods.
  *
- * - visit<VisitSuffix>(...) (Override these methods)
- * - emitPluginIssue(...) (Call these methods)
- * - emitPluginIssueShort(...)
- * - Public methods from Phan\AST\AnalysisVisitor
- *
- * NOTE: Subclasses should not implement the visit() method unless they absolutely need to.
- * (E.g. if the body would be empty, or if it could be replaced with a small number of more specific methods such as visitFuncDecl, visitVar, etc.)
- *
- * - Phan is able to figure out which methods a subclass implements, and only call the plugin's visitor for those types,
- *   but only when the plugin's visitor does not override the fallback visit() method.
  */
-abstract class PluginAwareAnalysisVisitor extends PluginAwareBaseAnalysisVisitor {
-    /** @var Node|null - Set after the constructor is called */
-    protected $parent_node;
+abstract class PluginAwareBaseAnalysisVisitor extends AnalysisVisitor {
+    use IssueEmitter;  // defines emitPluginIssue
 
-    // Implementations should omit the constructor or call parent::__construct(CodeBase $code_base, Context $context)
+    /**
+     * This is an empty visit() body.
+     * Don't override this unless you need to, analysis is more efficient if Phan knows it doesn't need to call a plugin on a node type.
+     * @see self::isDefinedInSubclass
+     *
+     * @return void
+     */
+    public function visit(Node $node)
+    {
+    }
 
     /**
      * @param string $issue_type
@@ -71,19 +69,31 @@ abstract class PluginAwareAnalysisVisitor extends PluginAwareBaseAnalysisVisitor
             $issue_type_id
         );
     }
-
     // Internal methods used by ConfigPluginSet are below.
     // They aren't useful for plugins.
 
+
     /**
-     * This is a utility function used by ConfigPluginSet
-     * @return void
+     * @return int[] The list of $node->kind values this plugin is capable of analyzing.
      */
-    public static final function staticInvoke(CodeBase $code_base, Context $context, Node $node, Node $parent_node = null)
+    public static final function getHandledNodeKinds() : array
     {
-        $visitor = new static($code_base, $context);
-        $visitor->parent_node = $parent_node;
-        $visitor($node);
+        $defines_visit = self::isDefinedInSubclass('visit');
+        $kinds = [];
+        foreach (Element::VISIT_LOOKUP_TABLE as $kind => $method_name) {
+            if ($defines_visit || self::isDefinedInSubclass($method_name)) {
+                $kinds[] = $kind;
+            }
+        }
+        return $kinds;
     }
-    // End of internal methods.
+    /**
+     * @return bool true if $method_name is defined by the subclass of PluginAwareAnalysisVisitor, and not by PluginAwareAnalysisVisitor or one of it's parents.
+     */
+    private static function isDefinedInSubclass(string $method_name) : bool
+    {
+        $method = new \ReflectionMethod(static::class, $method_name);
+        return is_subclass_of($method->getDeclaringClass()->name, self::class);
+    }
+    // End of methods for internal use.
 }

--- a/src/Phan/PluginV2/PluginAwareBaseAnalysisVisitor.php
+++ b/src/Phan/PluginV2/PluginAwareBaseAnalysisVisitor.php
@@ -10,7 +10,6 @@ use ast\Node;
 
 /**
  * This augments AnalysisVisitor with public and internal methods.
- *
  */
 abstract class PluginAwareBaseAnalysisVisitor extends AnalysisVisitor {
     use IssueEmitter;  // defines emitPluginIssue
@@ -50,7 +49,7 @@ abstract class PluginAwareBaseAnalysisVisitor extends AnalysisVisitor {
      * set {Issue:REMEDIATION_A, Issue:REMEDIATION_B, ...
      * Issue::REMEDIATION_F} with F being the hardest.
      */
-    public function emitPluginIssueShort(
+    public function emit(
         string $issue_type,
         string $issue_message_fmt,
         array $issue_message_args = [],

--- a/src/Phan/PluginV2/PluginAwarePreAnalysisVisitor.php
+++ b/src/Phan/PluginV2/PluginAwarePreAnalysisVisitor.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+namespace Phan\PluginV2;
+
+use Phan\AST\AnalysisVisitor;
+use Phan\AST\Visitor\Element;
+use Phan\CodeBase;
+use Phan\Language\Context;
+use ast\Node;
+
+/**
+ * For plugins which define their own pre-order analysis behaviors in the analysis phase.
+ * Called on a node before PluginAwareAnalysisVisitor implementations.
+ */
+abstract class PluginAwarePreAnalysisVisitor extends AnalysisVisitor {
+    // Implementations should omit the constructor or call parent::__construct(CodeBase $code_base, Context $context)
+
+    /**
+     * This is an empty visit() body.
+     * Don't override this unless you need to, analysis is more efficient if Phan knows it doesn't need to call a method.
+     * @see self::isDefinedInSubclass
+     *
+     * @return void
+     */
+    public function visit(Node $node)
+    {
+    }
+
+    /**
+     * @return int[] The list of $node->kind values this plugin is capable of analyzing.
+     */
+    public static final function getHandledNodeKinds() : array
+    {
+        $defines_visit = self::isDefinedInSubclass('visit');
+        $kinds = [];
+        foreach (Element::VISIT_LOOKUP_TABLE as $kind => $method_name) {
+            if ($defines_visit || self::isDefinedInSubclass($method_name)) {
+                $kinds[] = $kind;
+            }
+        }
+        return $kinds;
+    }
+
+    /**
+     * This is a utility function used by ConfigPluginSet
+     */
+    public static final function staticInvoke(CodeBase $code_base, Context $context, Node $node)
+    {
+        // For backwards compatibility reasons, PreAnalysisVisitor doesn't support parent_node
+        return (new static($code_base, $context))($node);
+    }
+
+    /**
+     * @return bool true if $method_name is defined by the subclass of PluginAwarePreAnalysisVisitor, and not by PluginAwarePreAnalysisVisitor or one of it's parents.
+     */
+    private static final function isDefinedInSubclass(string $method_name) : bool
+    {
+        $method = new \ReflectionMethod(static::class, $method_name);
+        return is_subclass_of($method->getDeclaringClass()->getName(), self::class);
+    }
+}

--- a/src/Phan/PluginV2/PluginAwarePreAnalysisVisitor.php
+++ b/src/Phan/PluginV2/PluginAwarePreAnalysisVisitor.php
@@ -14,8 +14,8 @@ use ast\Node;
  * Public APIs for use by plugins:
  *
  * - visit<VisitSuffix>(...) (Override these methods)
- * - emitPluginIssue(...) (Call these methods)
- * - emitPluginIssueShort(...)
+ * - emitPluginIssue(CodeBase $code_base, Config $config, ...) (Call these methods)
+ * - emit(...)
  * - Public methods from Phan\AST\AnalysisVisitor
  *
  * NOTE: Subclasses should not implement the visit() method unless they absolutely need to.

--- a/src/Phan/PluginV2/PluginAwarePreAnalysisVisitor.php
+++ b/src/Phan/PluginV2/PluginAwarePreAnalysisVisitor.php
@@ -26,16 +26,4 @@ use ast\Node;
  */
 abstract class PluginAwarePreAnalysisVisitor extends PluginAwareBaseAnalysisVisitor {
     // For backwards compatibility reasons, parent_node isn't available in PreAnalysis visitors
-
-    // Internal methods used by ConfigPluginSet are below.
-    // They aren't useful for plugins.
-
-    /**
-     * This is a utility function used by ConfigPluginSet
-     * @return void
-     */
-    public static final function staticInvoke(CodeBase $code_base, Context $context, Node $node)
-    {
-        (new static($code_base, $context))($node);
-    }
 }

--- a/src/Phan/PluginV2/PreAnalyzeNodeCapability.php
+++ b/src/Phan/PluginV2/PreAnalyzeNodeCapability.php
@@ -3,11 +3,14 @@ namespace Phan\PluginV2;
 
 interface PreAnalyzeNodeCapability {
     /**
-     * Returns the name of the class to be instantiated and invoked in the analysis phase.
+     * Returns the name of the visitor class to be instantiated and invoked to pre-analyze a node in the analysis phase.
      * (To pre-analyze a node)
+     * (PreAnalyzeNodeCapability is run before AnalyzeNodeCapability)
      * The class should be created by the plugin visitor, and must extend PluginAwarePreAnalysisVisitor.
      *
-     * @return string
+     * If state needs to be shared with a visitor and a plugin, a plugin author may use static variables of that plugin.
+     *
+     * @return string - The name of a class extending PluginAwarePreAnalysisVisitor
      */
     public static function getPreAnalyzeNodeVisitorClassName() : string;
 }

--- a/src/Phan/PluginV2/PreAnalyzeNodeCapability.php
+++ b/src/Phan/PluginV2/PreAnalyzeNodeCapability.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+namespace Phan\PluginV2;
+
+interface PreAnalyzeNodeCapability {
+    /**
+     * Returns the name of the class to be instantiated and invoked in the analysis phase.
+     * (To pre-analyze a node)
+     * The class should be created by the plugin visitor, and must extend PluginAwarePreAnalysisVisitor.
+     *
+     * @return string
+     */
+    public static function getPreAnalyzeNodeVisitorClassName() : string;
+}


### PR DESCRIPTION
Existing `Plugin`s tracked outside of Phan are intended to continue to work after this PR is finished, but it's recommended to update them to PluginV2 once there's an official release.

See https://github.com/etsy/phan/issues/600#issuecomment-309309325 for all of the functionality that this plans to include. New functionality may be added in a subsequent PR.

Goals:

- Improve performance when a large number of PluginV2s are used. If a plugin's visitor implements only visitVar, then the ConfigPluginSet should call that plugin's visitor for only visitVar (and not visitArray, etc.)
- If a plugin implements only visitClass, then the ConfigPluginSet should only call that plugin on classes, not on functions, `\ast\Node`, or anything else.
- A plugin should continue to be able to implement any combination of capabilities.
- Should continue to be easy to support new features in the future (done through interfaces)
