### PR TITLE
Fixes #936: warn about static access to non-static properties, and vi…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -28,6 +28,7 @@ New Features (Analysis)
 + Improved checking for `PhanUndeclaredVariable` in array keys and conditional conditions. (Issue #912)
 + Improved warnings and inferences about internal function references for functions such as `sort`, `preg_match` (Issue #871, #958)
   Phan is now aware of many internal functions which normally ignore the original values of references passed in (E.g. `preg_match`)
++ Properly when code attempts to access static/non-static properties as if they were non-static/static. (Issue #936)
 
 New Features (CLI, Configs)
 + Create `check_docblock_signature_param_type_match` (similar to `check_docblock_signature_return_type_match`) config setting

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -173,6 +173,7 @@ class Issue
     const AccessClassConstantPrivate     = 'PhanAccessClassConstantPrivate';
     const AccessClassConstantProtected   = 'PhanAccessClassConstantProtected';
     const AccessPropertyStaticAsNonStatic = 'PhanAccessPropertyStaticAsNonStatic';
+    const AccessPropertyNonStaticAsStatic = 'PhanAccessPropertyNonStaticAsStatic';
     const AccessOwnConstructor = 'PhanAccessOwnConstructor';
 
     const AccessConstantInternal    = 'PhanAccessConstantInternal';
@@ -1514,7 +1515,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Accessing own constructor directly via {CLASS}::__construct",
                 self::REMEDIATION_B,
-                1010
+                1020
             ),
             new Issue(
                 self::AccessMethodProtectedWithCallMagicMethod,
@@ -1587,6 +1588,14 @@ class Issue
                 "Declaration of phpdoc method {METHOD} is an unnecessary override of final method {METHOD} defined in {FILE}:{LINE}",
                 self::REMEDIATION_B,
                 1019
+            ),
+            new Issue(
+                self::AccessPropertyNonStaticAsStatic,
+                self::CATEGORY_ACCESS,
+                self::SEVERITY_CRITICAL,
+                "Accessing non static property {PROPERTY} as static",
+                self::REMEDIATION_B,
+                1021
             ),
 
             // Issue::CATEGORY_COMPATIBLE

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -792,15 +792,24 @@ class Clazz extends AddressableElement
             $property = $code_base->getPropertyByFQSEN(
                 $property_fqsen
             );
-            if ($is_static && !$property->isStatic()) {
-                // TODO: add additional warning about possible static/non-static confusion?
-                throw new IssueException(
-                    Issue::fromType(Issue::UndeclaredStaticProperty)(
-                        $context->getFile(),
-                        $context->getLineNumberStart(),
-                        [ $name, (string)$this->getFQSEN() ]
-                    )
-                );
+            if ($is_static != $property->isStatic()) {
+                if ($is_static) {
+                    throw new IssueException(
+                        Issue::fromType(Issue::AccessPropertyNonStaticAsStatic)(
+                            $context->getFile(),
+                            $context->getLineNumberStart(),
+                            [ "{$this->getFQSEN()}->\${$property->getName()}" ]
+                        )
+                    );
+                } else {
+                    throw new IssueException(
+                        Issue::fromType(Issue::AccessPropertyStaticAsNonStatic)(
+                            $context->getFile(),
+                            $context->getLineNumberStart(),
+                            [ "{$this->getFQSEN()}::\${$property->getName()}" ]
+                        )
+                    );
+                }
             }
 
             $is_remote_access = (
@@ -874,15 +883,6 @@ class Clazz extends AddressableElement
             if ($property->isProtected()) {
                 throw new IssueException(
                     Issue::fromType(Issue::AccessPropertyProtected)(
-                        $context->getFile(),
-                        $context->getLineNumberStart(),
-                        [ "{$this->getFQSEN()}::\${$property->getName()}" ]
-                    )
-                );
-            }
-            if (!$is_static && $property->isStatic()) {
-                throw new IssueException(
-                    Issue::fromType(Issue::AccessPropertyStaticAsNonStatic)(
                         $context->getFile(),
                         $context->getLineNumberStart(),
                         [ "{$this->getFQSEN()}::\${$property->getName()}" ]

--- a/src/Phan/Language/Type/NullType.php
+++ b/src/Phan/Language/Type/NullType.php
@@ -41,7 +41,7 @@ class NullType extends ScalarType
     public function canCastToNonNullableType(Type $type) : bool
     {
         // null_casts_as_any_type means that null or nullable can cast to any type?
-        return Config::get()->null_casts_as_any_type
+        return Config::get_null_casts_as_any_type()
             || parent::canCastToNonNullableType($type);
     }
 

--- a/src/Phan/Language/Type/ScalarType.php
+++ b/src/Phan/Language/Type/ScalarType.php
@@ -68,7 +68,7 @@ abstract class ScalarType extends NativeType
             $scalar_implicit_partial = Config::getValue('scalar_implicit_partial');
             if (\count($scalar_implicit_partial) > 0) {
                 // check if $type->getName() is in the list of permitted types $this->getName() can cast to.
-                if (\in_array($type->getName(), Config::get()->scalar_implicit_partial[$this->getName()] ?? [], true)) {
+                if (\in_array($type->getName(), $scalar_implicit_partial[$this->getName()] ?? [], true)) {
                     return true;
                 }
             }

--- a/tests/files/expected/0014_parent_property.php.expected
+++ b/tests/files/expected/0014_parent_property.php.expected
@@ -1,1 +1,1 @@
-%s:11 PhanUndeclaredStaticProperty Static property 'beta' on \A is undeclared
+%s:11 PhanAccessPropertyNonStaticAsStatic Accessing non static property \A->$beta as static

--- a/tests/files/expected/0047_backwards_compatibility.php.expected
+++ b/tests/files/expected/0047_backwards_compatibility.php.expected
@@ -6,4 +6,4 @@
 %s:5 PhanCompatiblePHP7 Expression may not be PHP 7 compatible
 %s:5 PhanUndeclaredVariable Variable $foo is undeclared
 %s:15 PhanCompatiblePHP7 Expression may not be PHP 7 compatible
-
+%s:28 PhanAccessPropertyStaticAsNonStatic Accessing static property \Test::$vals as non static

--- a/tests/files/expected/0329_warn_static_properties.php.expected
+++ b/tests/files/expected/0329_warn_static_properties.php.expected
@@ -1,0 +1,2 @@
+%s:8 PhanAccessPropertyStaticAsNonStatic Accessing static property \A329::$prop as non static
+%s:9 PhanUndeclaredStaticProperty Static property 'instance_prop' on \A329 is undeclared

--- a/tests/files/src/0329_warn_static_properties.php
+++ b/tests/files/src/0329_warn_static_properties.php
@@ -1,0 +1,11 @@
+<?php
+
+class A329 {
+    public static $prop = 3;
+    public $static_prop = 3;
+
+    function foo() {
+        var_dump($this->prop);
+        var_dump(self::$instance_prop);
+    }
+}


### PR DESCRIPTION
…ce versa

This would cause a runtime error in PHP.
Before, only one type of warning would be emitted.