### PR TITLE
Fixes #926 : Analyze @override in phpdoc of methods and class constants

### DIFF
--- a/.phan/plugins/DemoLegacyPlugin.php
+++ b/.phan/plugins/DemoLegacyPlugin.php
@@ -62,6 +62,8 @@ class DemoLegacyPlugin extends PluginImplementation {
      * The parent node of the given node (if one exists).
      *
      * @return void
+     *
+     * @override
      */
     public function analyzeNode(
         CodeBase $code_base,
@@ -85,6 +87,8 @@ class DemoLegacyPlugin extends PluginImplementation {
      * A class being analyzed
      *
      * @return void
+     *
+     * @override
      */
     public function analyzeClass(
         CodeBase $code_base,
@@ -113,6 +117,8 @@ class DemoLegacyPlugin extends PluginImplementation {
      * A method being analyzed
      *
      * @return void
+     *
+     * @override
      */
     public function analyzeMethod(
         CodeBase $code_base,
@@ -140,6 +146,8 @@ class DemoLegacyPlugin extends PluginImplementation {
      * A function being analyzed
      *
      * @return void
+     *
+     * @override
      */
     public function analyzeFunction(
         CodeBase $code_base,
@@ -195,6 +203,8 @@ class DemoLegacyNodeVisitor extends AnalysisVisitor {
      * A node to analyze
      *
      * @return void
+     *
+     * @override
      */
     public function visit(Node $node)
     {
@@ -212,6 +222,8 @@ class DemoLegacyNodeVisitor extends AnalysisVisitor {
      * A node to analyze
      *
      * @return void
+     *
+     * @override
      */
     public function visitInstanceof(Node $node)
     {

--- a/.phan/plugins/DemoPlugin.php
+++ b/.phan/plugins/DemoPlugin.php
@@ -71,6 +71,8 @@ class DemoPlugin extends PluginV2 implements
      * A class being analyzed
      *
      * @return void
+     *
+     * @override
      */
     public function analyzeClass(
         CodeBase $code_base,
@@ -99,6 +101,8 @@ class DemoPlugin extends PluginV2 implements
      * A method being analyzed
      *
      * @return void
+     *
+     * @override
      */
     public function analyzeMethod(
         CodeBase $code_base,
@@ -126,6 +130,8 @@ class DemoPlugin extends PluginV2 implements
      * A function being analyzed
      *
      * @return void
+     *
+     * @override
      */
     public function analyzeFunction(
         CodeBase $code_base,
@@ -161,6 +167,8 @@ class DemoNodeVisitor extends PluginAwareAnalysisVisitor {
      * A node to analyze
      *
      * @return void
+     *
+     * @override
      */
     public function visitInstanceof(Node $node)
     {

--- a/.phan/plugins/DuplicateArrayKeyPlugin.php
+++ b/.phan/plugins/DuplicateArrayKeyPlugin.php
@@ -17,6 +17,7 @@ use ast\Node;
 class DuplicateArrayKeyPlugin extends PluginV2 implements AnalyzeNodeCapability {
     /**
      * @return string - name of PluginAwareAnalysisVisitor subclass
+     * @override
      */
     public static function getAnalyzeNodeVisitorClassName() : string {
         return DuplicateArrayKeyVisitor::class;
@@ -40,6 +41,8 @@ class DuplicateArrayKeyVisitor extends PluginAwareAnalysisVisitor {
      * A node to analyze
      *
      * @return void
+     *
+     * @override
      */
     public function visitArray(Node $node) {
         $children = $node->children;

--- a/.phan/plugins/InvalidVariableIssetPlugin.php
+++ b/.phan/plugins/InvalidVariableIssetPlugin.php
@@ -13,6 +13,8 @@ class InvalidVariableIssetPlugin extends PluginV2 implements AnalyzeNodeCapabili
 
     /**
      * @return string - name of PluginAwareAnalysisVisitor subclass
+     *
+     * @override
      */
     public static function getAnalyzeNodeVisitorClassName() : string {
         return InvalidVariableIssetVisitor::class;

--- a/.phan/plugins/NonBoolBranchPlugin.php
+++ b/.phan/plugins/NonBoolBranchPlugin.php
@@ -13,6 +13,8 @@ use ast\Node;
 class NonBoolBranchPlugin extends PluginV2 implements AnalyzeNodeCapability {
     /**
      * @return string - name of PluginAwareAnalysisVisitor subclass
+     *
+     * @override
      */
     public static function getAnalyzeNodeVisitorClassName() : string
     {
@@ -23,6 +25,7 @@ class NonBoolBranchPlugin extends PluginV2 implements AnalyzeNodeCapability {
 class NonBoolBranchVisitor extends PluginAwareAnalysisVisitor {
     // A plugin's visitors should not override visit() unless they need to.
 
+    /** @override */
     public function visitIfelem(Node $node) : Context
     {
         $condition = $node->children['cond'];

--- a/.phan/plugins/NonBoolInLogicalArithPlugin.php
+++ b/.phan/plugins/NonBoolInLogicalArithPlugin.php
@@ -14,6 +14,8 @@ class NonBoolInLogicalArithPlugin extends PluginV2 implements AnalyzeNodeCapabil
 
     /**
      * @return string - name of PluginAwareAnalysisVisitor subclass
+     *
+     * @override
      */
     public static function getAnalyzeNodeVisitorClassName() : string {
         return NonBoolInLogicalArithVisitor::class;
@@ -31,6 +33,9 @@ class NonBoolInLogicalArithVisitor extends PluginAwareAnalysisVisitor {
 
     // A plugin's visitors should not override visit() unless they need to.
 
+    /**
+     * @override
+     */
     public function visitBinaryop(Node $node) : Context{
         // check every boolean binary operation
         if(in_array($node->flags, self::BINARY_BOOL_OPERATORS, true)){

--- a/.phan/plugins/NumericalComparisonPlugin.php
+++ b/.phan/plugins/NumericalComparisonPlugin.php
@@ -14,6 +14,8 @@ class NumericalComparisonPlugin extends PluginV2 implements AnalyzeNodeCapabilit
 
     /**
      * @return string - name of PluginAwareAnalysisVisitor subclass
+     *
+     * @override
      */
     public static function getAnalyzeNodeVisitorClassName() : string {
         return NumericalComparisonVisitor::class;
@@ -35,6 +37,9 @@ class NumericalComparisonVisitor extends PluginAwareAnalysisVisitor {
 
     // A plugin's visitors should not override visit() unless they need to.
 
+    /**
+     * @override
+     */
     public function visitBinaryop(Node $node) : Context {
         // get the types of left and right values
         $left_node = $node->children['left'];

--- a/.phan/plugins/UnusedSuppressionPlugin.php
+++ b/.phan/plugins/UnusedSuppressionPlugin.php
@@ -64,6 +64,8 @@ class UnusedSuppressionPlugin extends PluginV2 implements
      * A class being analyzed
      *
      * @return void
+     *
+     * @override
      */
     public function analyzeClass(
         CodeBase $code_base,
@@ -80,6 +82,8 @@ class UnusedSuppressionPlugin extends PluginV2 implements
      * A method being analyzed
      *
      * @return void
+     *
+     * @override
      */
     public function analyzeMethod(
         CodeBase $code_base,
@@ -102,6 +106,8 @@ class UnusedSuppressionPlugin extends PluginV2 implements
      * A function being analyzed
      *
      * @return void
+     *
+     * @override
      */
     public function analyzeFunction(
         CodeBase $code_base,

--- a/NEWS
+++ b/NEWS
@@ -29,6 +29,9 @@ New Features (Analysis)
 + Improved warnings and inferences about internal function references for functions such as `sort`, `preg_match` (Issue #871, #958)
   Phan is now aware of many internal functions which normally ignore the original values of references passed in (E.g. `preg_match`)
 + Properly when code attempts to access static/non-static properties as if they were non-static/static. (Issue #936)
++ Create `PhanCommentOverrideOnNonOverrideMethod` and `PhanCommentOverrideOnNonOverrideConstant`. (Issue #926)
+  These issue types will be emitted if `@override` is part of doc comment of a method or class constant which doesn't override or implement anything.
+  (`@Override` and `@phan-override` can also be used as aliases of `@override`. `@override` is not currently part of any phpdoc standard.)
 
 New Features (CLI, Configs)
 + Create `check_docblock_signature_param_type_match` (similar to `check_docblock_signature_return_type_match`) config setting
@@ -67,6 +70,7 @@ Bug Fixes
 + Consistently exit with non-zero exit code if there are multiple processes, and any process failed to return valid results. (Issue #868)
 
 Backwards Incompatible Changes
++ Fix categories of some issue types, renumber error ids for the pylint error formatter to be unique and consistent.
 
 0.9.2 Jun 13, 2017
 ------------------

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -8,6 +8,7 @@ use Phan\Language\Context;
  */
 class Issue
 {
+    // Issue::CATEGORY_SYNTAX
     const SyntaxError               = 'PhanSyntaxError';
 
     // Issue::CATEGORY_UNDEFINED
@@ -207,6 +208,8 @@ class Issue
     const UnextractableAnnotationPart      = 'PhanUnextractableAnnotationPart';
     const CommentParamWithoutRealParam     = 'PhanCommentParamWithoutRealParam';
     const CommentParamOnEmptyParamList     = 'PhanCommentParamOnEmptyParamList';
+    const CommentOverrideOnNonOverrideMethod = 'PhanCommentOverrideOnNonOverrideMethod';
+    const CommentOverrideOnNonOverrideConstant = 'PhanCommentOverrideOnNonOverrideConstant';
 
 
     const CATEGORY_ACCESS            = 1 << 1;
@@ -225,6 +228,7 @@ class Issue
     const CATEGORY_GENERIC           = 1 << 14;
     const CATEGORY_INTERNAL          = 1 << 15;
     const CATEGORY_COMMENT           = 1 << 16;
+    const CATEGORY_SYNTAX            = 1 << 17;
 
     const CATEGORY_NAME = [
         self::CATEGORY_ACCESS            => 'AccessError',
@@ -242,6 +246,7 @@ class Issue
         self::CATEGORY_PLUGIN            => 'Plugin',
         self::CATEGORY_GENERIC           => 'Generic',
         self::CATEGORY_INTERNAL          => 'Internal',
+        self::CATEGORY_SYNTAX            => 'Syntax',
     ];
 
     const SEVERITY_LOW      = 0;
@@ -364,13 +369,14 @@ class Issue
          * If new type ids are added, existing ones should not be changed.
          */
         $error_list = [
+            // Issue::CATEGORY_SYNTAX
             new Issue(
                 self::SyntaxError,
-                self::CATEGORY_UNDEFINED,
+                self::CATEGORY_SYNTAX,
                 self::SEVERITY_CRITICAL,
                 "%s",
                 self::REMEDIATION_A,
-                1
+                17000
             ),
 
             // Issue::CATEGORY_UNDEFINED
@@ -380,7 +386,7 @@ class Issue
                 self::SEVERITY_LOW,
                 "Empty file {FILE}",
                 self::REMEDIATION_B,
-                1000
+                11000
             ),
             new Issue(
                 self::ParentlessClass,
@@ -388,7 +394,7 @@ class Issue
                 self::SEVERITY_CRITICAL,
                 "Reference to parent of class {CLASS} that does not extend anything",
                 self::REMEDIATION_B,
-                1001
+                11001
             ),
             new Issue(
                 self::UndeclaredClass,
@@ -396,7 +402,7 @@ class Issue
                 self::SEVERITY_CRITICAL,
                 "Reference to undeclared class {CLASS}",
                 self::REMEDIATION_B,
-                1002
+                11002
             ),
             new Issue(
                 self::UndeclaredExtendedClass,
@@ -404,7 +410,7 @@ class Issue
                 self::SEVERITY_CRITICAL,
                 "Class extends undeclared class {CLASS}",
                 self::REMEDIATION_B,
-                1003
+                11003
             ),
             new Issue(
                 self::UndeclaredInterface,
@@ -412,7 +418,7 @@ class Issue
                 self::SEVERITY_CRITICAL,
                 "Class implements undeclared interface {INTERFACE}",
                 self::REMEDIATION_B,
-                1004
+                11004
             ),
             new Issue(
                 self::UndeclaredTrait,
@@ -420,7 +426,7 @@ class Issue
                 self::SEVERITY_CRITICAL,
                 "Class uses undeclared trait {TRAIT}",
                 self::REMEDIATION_B,
-                1005
+                11005
             ),
             new Issue(
                 self::UndeclaredClassCatch,
@@ -428,7 +434,7 @@ class Issue
                 self::SEVERITY_CRITICAL,
                 "Catching undeclared class {CLASS}",
                 self::REMEDIATION_B,
-                1006
+                11006
             ),
             new Issue(
                 self::UndeclaredClassConstant,
@@ -436,7 +442,7 @@ class Issue
                 self::SEVERITY_CRITICAL,
                 "Reference to constant {CONST} from undeclared class {CLASS}",
                 self::REMEDIATION_B,
-                1007
+                11007
             ),
             new Issue(
                 self::UndeclaredClassInstanceof,
@@ -444,7 +450,7 @@ class Issue
                 self::SEVERITY_CRITICAL,
                 "Checking instanceof against undeclared class {CLASS}",
                 self::REMEDIATION_B,
-                1008
+                11008
             ),
             new Issue(
                 self::UndeclaredClassMethod,
@@ -452,7 +458,7 @@ class Issue
                 self::SEVERITY_CRITICAL,
                 "Call to method {METHOD} from undeclared class {CLASS}",
                 self::REMEDIATION_B,
-                1009
+                11009
             ),
             new Issue(
                 self::UndeclaredClassReference,
@@ -460,7 +466,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Reference to undeclared class {CLASS}",
                 self::REMEDIATION_B,
-                1010
+                11010
             ),
             new Issue(
                 self::UndeclaredConstant,
@@ -468,7 +474,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Reference to undeclared constant {CONST}",
                 self::REMEDIATION_B,
-                1011
+                11011
             ),
             new Issue(
                 self::UndeclaredFunction,
@@ -476,7 +482,7 @@ class Issue
                 self::SEVERITY_CRITICAL,
                 "Call to undeclared function {FUNCTION}",
                 self::REMEDIATION_B,
-                1012
+                11012
             ),
             new Issue(
                 self::UndeclaredMethod,
@@ -484,7 +490,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Call to undeclared method {METHOD}",
                 self::REMEDIATION_B,
-                1013
+                11013
             ),
             new Issue(
                 self::UndeclaredStaticMethod,
@@ -492,7 +498,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Static call to undeclared method {METHOD}",
                 self::REMEDIATION_B,
-                1014
+                11014
             ),
             new Issue(
                 self::UndeclaredProperty,
@@ -500,7 +506,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Reference to undeclared property {PROPERTY}",
                 self::REMEDIATION_B,
-                1015
+                11015
             ),
             new Issue(
                 self::UndeclaredStaticProperty,
@@ -508,7 +514,7 @@ class Issue
                 self::SEVERITY_CRITICAL,
                 "Static property '{PROPERTY}' on {CLASS} is undeclared",
                 self::REMEDIATION_B,
-                1016
+                11016
             ),
             new Issue(
                 self::TraitParentReference,
@@ -516,7 +522,7 @@ class Issue
                 self::SEVERITY_LOW,
                 "Reference to parent from trait {TRAIT}",
                 self::REMEDIATION_B,
-                1017
+                11017
             ),
             new Issue(
                 self::UndeclaredVariable,
@@ -524,7 +530,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Variable \${VARIABLE} is undeclared",
                 self::REMEDIATION_B,
-                1018
+                11018
             ),
             new Issue(
                 self::UndeclaredTypeParameter,
@@ -532,7 +538,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Parameter of undeclared type {TYPE}",
                 self::REMEDIATION_B,
-                1019
+                11019
             ),
             new Issue(
                 self::UndeclaredTypeProperty,
@@ -540,7 +546,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Property {PROPERTY} has undeclared type {TYPE}",
                 self::REMEDIATION_B,
-                1020
+                11020
             ),
             new Issue(
                 self::UndeclaredClosureScope,
@@ -548,7 +554,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Reference to undeclared class {CLASS} in PhanClosureScope",
                 self::REMEDIATION_B,
-                1021
+                11021
             ),
             new Issue(
                 self::ClassContainsAbstractMethod,
@@ -556,7 +562,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "non-abstract class {CLASS} contains abstract method {METHOD} declared at {FILE}:{LINE}",
                 self::REMEDIATION_B,
-                1022
+                11022
             ),
             new Issue(
                 self::ClassContainsAbstractMethodInternal,
@@ -564,7 +570,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "non-abstract class {CLASS} contains abstract internal method {METHOD}",
                 self::REMEDIATION_B,
-                1023
+                11023
             ),
             new Issue(
                 self::UndeclaredAliasedMethodOfTrait,
@@ -572,7 +578,7 @@ class Issue
                 self::SEVERITY_CRITICAL,
                 "Alias {METHOD} was defined for a method {METHOD} which does not exist in trait {TRAIT}",
                 self::REMEDIATION_B,
-                1024
+                11024
             ),
             new Issue(
                 self::RequiredTraitNotAdded,
@@ -580,7 +586,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Required trait {TRAIT} for trait adaptation was not added to class",
                 self::REMEDIATION_B,
-                1025
+                11025
             ),
             new Issue(
                 self::AmbiguousTraitAliasSource,
@@ -588,7 +594,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Trait alias {METHOD} has an ambiguous source method {METHOD} with more than one possible source trait. Possibilities: {TRAIT}",
                 self::REMEDIATION_B,
-                1026
+                11026
             ),
             new Issue(
                 self::UndeclaredVariableDim,
@@ -596,7 +602,7 @@ class Issue
                 self::SEVERITY_LOW,
                 "Variable \${VARIABLE} was undeclared, but array fields are being added to it.",
                 self::REMEDIATION_B,
-                1027
+                11027
             ),
             new Issue(
                 self::UndeclaredTypeReturnType,
@@ -604,7 +610,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Return type of {METHOD} is undeclared type {TYPE}",
                 self::REMEDIATION_B,
-                1028
+                11028
             ),
             new Issue(
                 self::UndeclaredClassAliasOriginal,
@@ -612,7 +618,7 @@ class Issue
                 self::SEVERITY_CRITICAL,
                 "Reference to undeclared class {CLASS} for the original class of a class_alias for {CLASS}",
                 self::REMEDIATION_B,
-                1029
+                11029
             ),
 
             // Issue::CATEGORY_ANALYSIS
@@ -630,7 +636,7 @@ class Issue
                 self::SEVERITY_LOW,
                 "Unable to determine the method(s) which {METHOD} overrides, but Phan inferred that it did override something earlier. Please create an issue at https://github.com/etsy/phan/issues/new with a test case.",
                 self::REMEDIATION_B,
-                2000
+                2001
             ),
 
             // Issue::CATEGORY_TYPE
@@ -664,7 +670,7 @@ class Issue
                 self::SEVERITY_LOW,
                 "{PARAMETER} is not variadic in comment, but variadic in param ({PARAMETER})",
                 self::REMEDIATION_B,
-                10022
+                10023
             ),
             new Issue(
                 self::TypeMismatchArgument,
@@ -704,7 +710,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Doc-block of \${VARIABLE} in {METHOD} contains phpdoc param type {TYPE} which is incompatible with the param type {TYPE} declared in the signature",
                 self::REMEDIATION_B,
-                10021
+                10022
             ),
             new Issue(
                 self::TypeMissingReturn,
@@ -784,7 +790,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 "Invalid PhanClosureScope: expected a class name, got {TYPE}",
                 self::REMEDIATION_B,
-                10023
+                10024
             ),
             new Issue(
                 self::TypeInvalidRightOperand,
@@ -840,7 +846,7 @@ class Issue
                 self::SEVERITY_NORMAL,
                 'Indirect variable ${(expr)} has invalid inner expression type {TYPE}, expected string/integer',
                 self::REMEDIATION_B,
-                10023
+                10025
             ),
             new Issue(
                 self::TypeMagicVoidWithReturn,
@@ -848,7 +854,7 @@ class Issue
                 self::SEVERITY_LOW,
                 'Found a return statement with a value in the implementation of the magic method {METHOD}, expected void return type',
                 self::REMEDIATION_B,
-                10024
+                10026
             ),
 
             // Issue::CATEGORY_VARIABLE
@@ -1567,7 +1573,7 @@ class Issue
             ),
             new Issue(
                 self::AccessOverridesFinalMethod,
-                self::CATEGORY_PARAMETER,
+                self::CATEGORY_ACCESS,
                 self::SEVERITY_CRITICAL,
                 "Declaration of method {METHOD} overrides final method {METHOD} defined in {FILE}:{LINE}",
                 self::REMEDIATION_B,
@@ -1575,7 +1581,7 @@ class Issue
             ),
             new Issue(
                 self::AccessOverridesFinalMethodInternal,
-                self::CATEGORY_PARAMETER,
+                self::CATEGORY_ACCESS,
                 self::SEVERITY_CRITICAL,
                 "Declaration of method {METHOD} overrides final internal method {METHOD}",
                 self::REMEDIATION_B,
@@ -1583,7 +1589,7 @@ class Issue
             ),
             new Issue(
                 self::AccessOverridesFinalMethodPHPDoc,
-                self::CATEGORY_PARAMETER,
+                self::CATEGORY_ACCESS,
                 self::SEVERITY_LOW,
                 "Declaration of phpdoc method {METHOD} is an unnecessary override of final method {METHOD} defined in {FILE}:{LINE}",
                 self::REMEDIATION_B,
@@ -1713,7 +1719,7 @@ class Issue
                 self::MisspelledAnnotation,
                 self::CATEGORY_COMMENT,
                 self::SEVERITY_LOW,
-                "Saw misspelled annotation {COMMENT}, should be {COMMENT}",
+                "Saw misspelled annotation {COMMENT}, should be one of {COMMENT}",
                 self::REMEDIATION_B,
                 16001
             ),
@@ -1749,18 +1755,67 @@ class Issue
                 self::REMEDIATION_B,
                 16005
             ),
+            new Issue(
+                self::CommentOverrideOnNonOverrideMethod,
+                self::CATEGORY_COMMENT,
+                self::SEVERITY_LOW,
+                "Saw an @override annotation for method {METHOD}, but could not find an overridden method and it is not a magic method",
+                self::REMEDIATION_B,
+                16006
+            ),
+            new Issue(
+                self::CommentOverrideOnNonOverrideConstant,
+                self::CATEGORY_COMMENT,
+                self::SEVERITY_LOW,
+                "Saw an @override annotation for class constant {CONST}, but could not find an overridden constant",
+                self::REMEDIATION_B,
+                16007
+            ),
         ];
 
-        $error_map = [];
-        foreach ($error_list as $i => $error) {
+        self::sanityCheckErrorList($error_list);
+        // Verified the error meets preconditions, now add it.
+        foreach ($error_list as $error) {
             $error_type = $error->getType();
-            \assert(!\array_key_exists($error_type, $error_map), "Issue of type $error_type has multiple definitions");
-            \assert(\strncmp($error_type, 'Phan', 4) === 0, "Issue of type $error_type should begin with 'Phan'");
             $error_map[$error_type] = $error;
         }
 
         return $error_map;
     }
+
+    /**
+     * @param Issue[] $error_list
+     * @return void
+     */
+    private static function sanityCheckErrorList(array $error_list)
+    {
+        $error_map = [];
+        $unique_type_id_set = [];
+        foreach ($error_list as $error) {
+            $error_type = $error->getType();
+            \assert(!\array_key_exists($error_type, $error_map), "Issue of type $error_type has multiple definitions");
+            \assert(\strncmp($error_type, 'Phan', 4) === 0, "Issue of type $error_type should begin with 'Phan'");
+
+            $error_type_id = $error->getTypeId();
+            \assert(!\array_key_exists($error_type_id, $unique_type_id_set), "Multiple issues exist with pylint error id $error_type_id");
+            $unique_type_id_set[$error_type_id] = $error;
+            $category = $error->getCategory();
+            $expected_category_for_type_id_bitpos = (int)floor($error_type_id / 1000);
+            $expected_category_for_type_id = 1 << $expected_category_for_type_id_bitpos;
+            if ($category !== $expected_category_for_type_id) {
+                assert(false, sprintf(
+                    "Expected error %s of type %d to be category %d(1<<%d), got 1<<%d\n",
+                    $error_type,
+                    $error_type_id,
+                    $category,
+                    (int)round(log($category, 2)),
+                    $expected_category_for_type_id_bitpos
+                ));
+            }
+            $error_map[$error_type] = $error;
+        }
+    }
+
 
     /**
      * @return string

--- a/src/Phan/Language/Element/ClassConstant.php
+++ b/src/Phan/Language/Element/ClassConstant.php
@@ -50,4 +50,29 @@ class ClassConstant extends ClassElement implements ConstantInterface
         return $string . 'const ' . $this->getName();
     }
 
+    /**
+     * @return bool
+     * True if this class constant is intended to be an override of another class constant (contains (at)override)
+     */
+    public function isOverrideIntended() : bool {
+        return Flags::bitVectorHasState(
+            $this->getPhanFlags(),
+            Flags::IS_OVERRIDE_INTENDED
+        );
+    }
+
+    /**
+     * @param bool $is_override_intended - True if this class constant is intended to be an override of another class constant (contains (at)override)
+
+     * @return void
+     */
+    public function setIsOverrideIntended(bool $is_override_intended) {
+        $this->setPhanFlags(
+            Flags::bitVectorWithState(
+                $this->getPhanFlags(),
+                Flags::IS_OVERRIDE_INTENDED,
+                $is_override_intended
+            )
+        );
+    }
 }

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -932,6 +932,37 @@ class Clazz extends AddressableElement
     }
 
     /**
+     * Inherit a class constant from an ancestor class
+     *
+     * @return void
+     */
+    public function inheritConstant(
+        CodeBase $code_base,
+        ClassConstant $constant
+    ) {
+        $constant_fqsen = FullyQualifiedClassConstantName::make(
+            $this->getFQSEN(),
+            $constant->getName()
+        );
+
+        if ($code_base->hasClassConstantWithFQSEN($constant_fqsen)) {
+            // If the constant with that name already exists, mark it as an override.
+            $overriding_constant = $code_base->getClassConstantByFQSEN($constant_fqsen);
+            $overriding_constant->setIsOverride(true);
+            return;
+        }
+
+        // Update the FQSEN if its not associated with this
+        // class yet (always true)
+        if ($constant->getFQSEN() !== $constant_fqsen) {
+            $constant = clone($constant);
+            $constant->setFQSEN($constant_fqsen);
+        }
+
+        $code_base->addClassConstant($constant);
+    }
+
+    /**
      * Add a class constant
      *
      * @return void
@@ -1977,7 +2008,7 @@ class Clazz extends AddressableElement
 
         // Copy constants
         foreach ($class->getConstantMap($code_base) as $constant) {
-            $this->addConstant($code_base, $constant);
+            $this->inheritConstant($code_base, $constant);
         }
 
         // Copy methods
@@ -2168,6 +2199,9 @@ class Clazz extends AddressableElement
             )
         );
 
+        // Fetch the constants declared within the class, to check if they have override annotations later.
+        $original_declared_class_constants = $this->getConstantMap($code_base);
+
         // Load parent methods, properties, constants
         $this->importAncestorClasses($code_base);
 
@@ -2175,6 +2209,31 @@ class Clazz extends AddressableElement
         AbstractMethodAnalyzer::analyzeAbstractMethodsAreImplemented(
             $code_base, $this
         );
+
+        self::analyzeClassConstantOverrides($code_base, $original_declared_class_constants);
+    }
+
+    /**
+     * @param ClassConstant[] $original_declared_class_constants
+     * @return void
+     */
+    private function analyzeClassConstantOverrides(CodeBase $code_base, array $original_declared_class_constants)
+    {
+        foreach ($original_declared_class_constants as $constant) {
+            if ($constant->isOverrideIntended() && !$constant->getIsOverride()) {
+                if ($constant->hasSuppressIssue(Issue::CommentOverrideOnNonOverrideConstant)) {
+                    continue;
+                }
+                $context = $constant->getContext();
+                Issue::maybeEmit(
+                    $code_base,
+                    $context,
+                    Issue::CommentOverrideOnNonOverrideConstant,
+                    $context->getLineNumberStart(),
+                    (string)$constant->getFQSEN()
+                );
+            }
+        }
     }
 
     /**

--- a/src/Phan/Language/Element/Flags.php
+++ b/src/Phan/Language/Element/Flags.php
@@ -24,6 +24,10 @@ class Flags
     // These can be combined in 3 ways, see Parameter->getReferenceType()
     const IS_READ_REFERENCE            = (1 << 14);
     const IS_WRITE_REFERENCE           = (1 << 15);
+    // End of reference types
+
+    // This will be compared against IS_OVERRIDE
+    const IS_OVERRIDE_INTENDED         = (1 << 16);
 
     /**
      * Either enable or disable the given flag on

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -89,7 +89,33 @@ class Method extends ClassElement implements FunctionInterface
             Flags::bitVectorWithState(
                 $this->getPhanFlags(),
                 Flags::IS_FROM_PHPDOC,
-                true
+                $from_phpdoc
+            )
+        );
+    }
+
+    /**
+     * @return bool
+     * True if this method is intended to be an override of another method (contains (at)override)
+     */
+    public function isOverrideIntended() : bool {
+        return Flags::bitVectorHasState(
+            $this->getPhanFlags(),
+            Flags::IS_OVERRIDE_INTENDED
+        );
+    }
+
+    /**
+     * @param bool $is_override_intended - True if this method is intended to be an override of another method (contains (at)override)
+
+     * @return void
+     */
+    public function setIsOverrideIntended(bool $is_override_intended) {
+        $this->setPhanFlags(
+            Flags::bitVectorWithState(
+                $this->getPhanFlags(),
+                Flags::IS_OVERRIDE_INTENDED,
+                $is_override_intended
             )
         );
     }
@@ -375,6 +401,9 @@ class Method extends ClassElement implements FunctionInterface
         // the namespace.
         $method->setIsNSInternal($comment->isNSInternal());
 
+        // Set whether or not the comment indicates that the method is intended
+        // to override another method.
+        $method->setIsOverrideIntended($comment->isOverrideIntended());
         $method->setSuppressIssueList($comment->getSuppressIssueList());
 
         if ($method->getIsMagicCall() || $method->getIsMagicCallStatic()) {

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -573,6 +573,7 @@ class ParseVisitor extends ScopeVisitor
 
             $constant->setIsDeprecated($comment->isDeprecated());
             $constant->setIsNSInternal($comment->isNSInternal());
+            $constant->setIsOverrideIntended($comment->isOverrideIntended());
 
             $constant->setFutureUnionType(
                 new FutureUnionType(

--- a/tests/Phan/Output/Printer/CSVPrinterTest.php
+++ b/tests/Phan/Output/Printer/CSVPrinterTest.php
@@ -24,7 +24,7 @@ class CSVPrinterTest extends BaseTest {
         $this->assertEquals(0, $fields["line"]);
         $this->assertEquals(10, $fields["severity_ord"]);
         $this->assertEquals("critical", $fields["severity_name"]);
-        $this->assertEquals("UndefError", $fields["category"]);
+        $this->assertEquals("Syntax", $fields["category"]);
         $this->assertEquals("PhanSyntaxError", $fields["check_name"]);
         $this->assertEquals("foo", $fields["message"]);
     }
@@ -43,7 +43,7 @@ class CSVPrinterTest extends BaseTest {
         $printer->print(new IssueInstance(Issue::fromType(Issue::SyntaxError), 'test.php', 0, [$string]));
         $printer->flush();
 
-        $expected = 'test.php,0,10,critical,UndefError,PhanSyntaxError,' . $messageExpected;
+        $expected = 'test.php,0,10,critical,Syntax,PhanSyntaxError,' . $messageExpected;
         $actual = explode("\n", $output->fetch())[1]; // Ignore header
         $this->assertEquals($expected, $actual);
     }

--- a/tests/files/expected/0301_comment_checks.php.expected
+++ b/tests/files/expected/0301_comment_checks.php.expected
@@ -1,6 +1,6 @@
 %s:17 PhanInvalidCommentForDeclarationType The phpdoc comment for @param cannot occur on a class
 %s:17 PhanInvalidCommentForDeclarationType The phpdoc comment for @return cannot occur on a class
-%s:17 PhanMisspelledAnnotation Saw misspelled annotation @phan-forbid-this-is-a-typo, should be @phan-forbid-undeclared-magic-methods @phan-forbid-undeclared-magic-properties
+%s:17 PhanMisspelledAnnotation Saw misspelled annotation @phan-forbid-this-is-a-typo, should be one of @phan-forbid-undeclared-magic-methods @phan-forbid-undeclared-magic-properties @phan-closure-scope @phan-override
 %s:17 PhanUnextractableAnnotationPart Saw unextractable annotation for a fragment of comment * @method foo(string$invalidType $param1): string$invalidType $param1
 %s:17 PhanUnextractableAnnotation Saw unextractable annotation for comment * @method unmatched(
 %s:17 PhanUnextractableAnnotation Saw unextractable annotation for comment * @property int (Can't parse the variable name, so silently ignore)

--- a/tests/files/expected/0331_override_interface.php.expected
+++ b/tests/files/expected/0331_override_interface.php.expected
@@ -1,0 +1,4 @@
+%s:46 PhanCommentOverrideOnNonOverrideMethod Saw an @override annotation for method \Override331::offsetTypo, but could not find an overridden method and it is not a magic method
+%s:52 PhanCommentOverrideOnNonOverrideMethod Saw an @override annotation for method \Override331::offsetTypo2, but could not find an overridden method and it is not a magic method
+%s:58 PhanCommentOverrideOnNonOverrideMethod Saw an @override annotation for method \Override331::offsetTypo3, but could not find an overridden method and it is not a magic method
+%s:71 PhanCommentOverrideOnNonOverrideMethod Saw an @override annotation for method \Override331::offsetTypoSuppressed, but could not find an overridden method and it is not a magic method

--- a/tests/files/src/0331_override_interface.php
+++ b/tests/files/src/0331_override_interface.php
@@ -1,0 +1,73 @@
+<?php
+
+class Override331 implements ArrayAccess {
+    /**
+     * @override (Phan'll assume all magic methods are overriding the default behavior, to reduce false positives.)
+     */
+    public function __construct() {
+    }
+
+    /**
+     * @override (Phan'll assume all magic methods are overriding the default behavior, to reduce false positives.)
+     */
+    public function __call($method, $args) {
+        throw new RuntimeException("Missing $method");
+    }
+
+    /**
+     * @override
+     */
+    public function offsetGet($offset) {
+        return null;
+    }
+
+    /**
+     * @override
+     */
+    public function offsetExists($offset) {
+        return false;
+    }
+
+    /**
+     * @override
+     */
+    public function offsetSet($offset, $value) {
+    }
+
+    /**
+     * @override
+     */
+    public function offsetUnset($offset) {
+    }
+
+    /**
+     * @override
+     */
+    public function offsetTypo($offset) {
+    }
+
+    /**
+     * @Override
+     */
+    public function offsetTypo2($offset) {
+    }
+
+    /**
+     * @phan-override
+     */
+    public function offsetTypo3($offset) {
+    }
+
+    /**
+     * @not-an-override
+     */
+    public function offsetTypo4($offset) {
+    }
+
+    /**
+     * @override
+     * @suppress PhanCommentOverrideOnNonOverride
+     */
+    public function offsetTypoSuppressed($offset) {
+    }
+}


### PR DESCRIPTION
Create `CommentOverrideOnNonOverrideMethod` and
`CommentOverrideOnNonOverrideConstant`.
These issue types will be emitted if `@override` is part of doc comment
of a method or class constant which doesn't override or implement anything.

(Additionally, this won't warn about magic methods,
such as __construct(), __get() or __set(),)

Annotate demo plugins with @override

This makes it obvious to plugin developers that the examples are
overriding methods.

Phan will emit an error if those methods are misspelled or if the base
method are removed (unlikely).