### PR TITLE
Fixes #975 - There are no php4 constructors for classes in namespaces.

### DIFF
--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -221,7 +221,7 @@ class Method extends ClassElement implements FunctionInterface
         Context $context,
         CodeBase $code_base
     ) : Method {
-        if ($clazz->hasMethodWithName($code_base, $clazz->getName())) {
+        if ($clazz->getFQSEN()->getNamespace() === '\\' && $clazz->hasMethodWithName($code_base, $clazz->getName())) {
             $old_style_constructor = $clazz->getMethodByName($code_base, $clazz->getName());
         } else {
             $old_style_constructor = null;

--- a/tests/files/expected/0325_php4_construct.php.expected
+++ b/tests/files/expected/0325_php4_construct.php.expected
@@ -1,4 +1,7 @@
-%s:6 PhanUndeclaredStaticMethod Static call to undeclared method \Bar325::__construct
-%s:6 PhanUndeclaredStaticMethod Static call to undeclared method self::__construct()
-%s:14 PhanTypeMismatchArgument Argument 1 (arg) is int but \Bar325::Bar325() takes array defined at %s:5
-%s:18 PhanTypeMismatchArgument Argument 1 (arg) is int but \Bar325::__construct() takes array defined at %s:5
+%s:7 PhanUndeclaredStaticMethod Static call to undeclared method \Bar325::__construct
+%s:7 PhanUndeclaredStaticMethod Static call to undeclared method self::__construct()
+%s:15 PhanTypeMismatchArgument Argument 1 (arg) is int but \Bar325::Bar325() takes array defined at %s:6
+%s:19 PhanTypeMismatchArgument Argument 1 (arg) is int but \Bar325::__construct() takes array defined at %s:6
+%s:34 PhanUndeclaredStaticMethod Static call to undeclared method \NS325\X325::__construct
+%s:35 PhanTypeMismatchArgument Argument 1 (arg) is int but \NS325\X325::X325() takes array defined at %s:26
+%s:39 PhanParamTooMany Call with 1 arg(s) to \NS325\X325::__construct() which only takes 0 arg(s) defined at %s:24

--- a/tests/files/src/0325_php4_construct.php
+++ b/tests/files/src/0325_php4_construct.php
@@ -1,5 +1,6 @@
 <?php
 
+namespace {
 class Bar325 {
     /** @return int */
     public function Bar325(array $arg) {
@@ -17,3 +18,24 @@ class Foo325 extends Bar325 {
 // error happens with/without the below lines.
 $f325 = new Bar325(11);
 $f325 = new Foo325(11);
+}  // end of global namespace
+
+namespace NS325 {
+class X325 {
+    /** @return int (should not warn about being static) */
+    public static function X325(array $arg) {
+        return 42;
+    }
+}
+
+class Y325 extends X325 {
+    public $arg;
+    public function __construct(int $arg) {
+        parent::__construct($arg);  // should warn that it doesn't exist
+        parent::X325($arg);  // should warn that it is incompatible
+    }
+}
+// error happens with/without the below lines.
+$f325 = new X325(11);  // PhanParamTooMany
+$f325 = new Y325(11);
+}  // end of NS325


### PR DESCRIPTION
If a class is not in the global namespaces,
the PHP interpreter does not support PHP4 constructors.
Make Phan's analysis reflect that.