### PR TITLE
Fixes various bugs in the implementation of `@phan-closure-scope`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -32,6 +32,10 @@ New Features (Analysis)
 + Create `PhanCommentOverrideOnNonOverrideMethod` and `PhanCommentOverrideOnNonOverrideConstant`. (Issue #926)
   These issue types will be emitted if `@override` is part of doc comment of a method or class constant which doesn't override or implement anything.
   (`@Override` and `@phan-override` can also be used as aliases of `@override`. `@override` is not currently part of any phpdoc standard.)
++ Add `@phan-closure-scope`, which can be used to annotate closure definitions with the namespaced class it will be bound to (Issue #309, #590, #790)
+  (E.g. if the intent was that Closure->bindTo or Closure->bind would be called to bind it to `\MyNS\MyClass` (or an instance of that class),
+  then a closure could be declared as `/** @phan-closure-scope \MyNS\MyClass */ function() { $this->somePrivateMyClassMethod(); }`
+  
 
 New Features (CLI, Configs)
 + Create `check_docblock_signature_param_type_match` (similar to `check_docblock_signature_return_type_match`) config setting

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Phan is able to perform the following kinds of analysis.
 * Supports `@suppress <ISSUE_TYPE>` annotations for [suppressing issues](https://github.com/etsy/phan/wiki/Annotating-Your-Source-Code#suppress).
 * Supports [magic property annotations](https://github.com/etsy/phan/wiki/Annotating-Your-Source-Code#property) (partial) (`@property <union_type> <variable_name>`)
 * Supports [`class_alias` annotations (experimental, off by default)](https://github.com/etsy/phan/pull/586), as of 0.9.3-dev
+* Supports indicating the class to which a closure will be bound, via `@phan-closure-scope` ([example](tests/files/src/0264_closure_override_context.php))
 * Offers extensive configuration for weakening the analysis to make it useful on large sloppy code bases
 * Can be run on many cores. (requires `pcntl`)
 * [Can run in the background (daemon mode)](https://github.com/etsy/phan/wiki/Using-Phan-Daemon-Mode), to then quickly respond to requests to analyze the latest version of a file. (requires `pcntl`)

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -552,7 +552,7 @@ class Issue
                 self::UndeclaredClosureScope,
                 self::CATEGORY_UNDEFINED,
                 self::SEVERITY_NORMAL,
-                "Reference to undeclared class {CLASS} in PhanClosureScope",
+                "Reference to undeclared class {CLASS} in @phan-closure-scope",
                 self::REMEDIATION_B,
                 11021
             ),
@@ -788,7 +788,7 @@ class Issue
                 self::TypeInvalidClosureScope,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_NORMAL,
-                "Invalid PhanClosureScope: expected a class name, got {TYPE}",
+                "Invalid @phan-closure-scope: expected a class name, got {TYPE}",
                 self::REMEDIATION_B,
                 10024
             ),

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -129,7 +129,7 @@ class Comment
 
     /**
      * @var Option<Type>
-     * An optional class name defined by an (at)PhanClosureScope directive.
+     * An optional class name defined by an (at)phan-closure-scope directive.
      * (overrides the class in which it is analyzed)
      */
     private $closure_scope;
@@ -342,7 +342,7 @@ class Comment
                         $magic_method_list[] = $magic_method;
                     }
                 }
-            } elseif (\stripos($line, '@PhanClosureScope') !== false) {
+            } elseif (\strpos($line, '@PhanClosureScope') !== false) {
                 // TODO: different type for closures
                 $check_compatible('@PhanClosureScope', Comment::FUNCTION_LIKE);
                 $closure_scope = self::getPhanClosureScopeFromCommentLine($context, $line);
@@ -353,7 +353,7 @@ class Comment
                 } elseif (\stripos($line, '@phan-forbid-undeclared-magic-methods') !== false) {
                     $check_compatible('@phan-forbid-undeclared-magic-methods', [Comment::ON_CLASS]);
                     $comment_flags |= Flags::CLASS_FORBID_UNDECLARED_MAGIC_METHODS;
-                } elseif (\stripos($line, '@phan-closure-scope') !== false) {
+                } elseif (\stripos($line, '@phan-closure-scope') !== false && \preg_match('/@phan-closure-scope\b/', $line)) {
                     $check_compatible('@phan-closure-scope', Comment::FUNCTION_LIKE);
                     $closure_scope = self::getPhanClosureScopeFromCommentLine($context, $line);
                 } elseif (\stripos($line, '@phan-override') !== false) {
@@ -821,8 +821,8 @@ class Comment
         // a Closure would be bound with bind() or bindTo(), so using a custom tag.
         //
         // TODO: Also add a version which forbids using $this in the closure?
-        if (preg_match('/@PhanClosureScope\s+(' . UnionType::union_type_regex . '+)/', $line, $match)) {
-            $closure_scope_union_type_string = $match[1];
+        if (preg_match('/@(PhanClosureScope|phan-closure-scope)\s+(' . UnionType::union_type_regex . '+)/', $line, $match)) {
+            $closure_scope_union_type_string = $match[2];
         }
 
         if ($closure_scope_union_type_string !== '') {

--- a/src/Phan/Language/Scope.php
+++ b/src/Phan/Language/Scope.php
@@ -19,7 +19,7 @@ abstract class Scope
     /**
      * @var FQSEN|null
      */
-    private $fqsen = null;
+    protected $fqsen = null;
 
     /**
      * @var Variable[]

--- a/src/Phan/Language/Scope/ClosureScope.php
+++ b/src/Phan/Language/Scope/ClosureScope.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+namespace Phan\Language\Scope;
+
+use Phan\Language\FQSEN;
+use Phan\Language\FQSEN\FullyQualifiedClassName;
+
+// TODO: Wrap this with a ClosureLikeScope
+class ClosureScope extends FunctionLikeScope {
+    /**
+     * @var FullyQualifiedClassName|null
+     */
+    private $override_class_fqsen = null;
+
+    /**
+     * @return void
+     */
+    public function overrideClassFQSEN(FullyQualifiedClassName $fqsen = null)
+    {
+        $this->override_class_fqsen = $fqsen;
+    }
+
+    /**
+     * @return FullyQualifiedClassName|null
+     */
+    public function getOverrideClassFQSEN()
+    {
+        return $this->override_class_fqsen;
+    }
+
+    /**
+     * @return bool
+     * True if we're in a class scope
+     */
+    public function isInClassScope() : bool
+    {
+        if ($this->override_class_fqsen !== null) {
+            return true;
+        }
+        return parent::isInClassScope();
+    }
+
+    /**
+     * @return FullyQualifiedClassName
+     * Crawl the scope hierarchy to get a class FQSEN.
+     */
+    public function getClassFQSEN() : FullyQualifiedClassName
+    {
+        if ($this->override_class_fqsen) {
+            return $this->override_class_fqsen;
+        }
+        return parent::getClassFQSEN();
+    }
+
+}

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -299,8 +299,7 @@ final class ConfigPluginSet extends PluginV2 implements
                 /**
                  * Create an instance of $plugin_analysis_class and run the visit*() method corresponding to $node->kind.
                  *
-                 * @suppress PhanParamTooMany
-                 * @suppress PhanDeprecatedInterface (TODO: Fix bugs in PhanClosureScope)
+                 * @phan-closure-scope PluginAwarePreAnalysisVisitor
                  */
                 $closure = (static function(CodeBase $code_base, Context $context, Node $node) {
                     $fn_name = Element::VISIT_LOOKUP_TABLE[$node->kind];

--- a/tests/files/expected/0264_closure_override_context.php.expected
+++ b/tests/files/expected/0264_closure_override_context.php.expected
@@ -1,5 +1,9 @@
-%s:17 PhanTypeMissingReturn Method \closure264\TestFramework::mockA is declared to return string but has no return value
-%s:44 PhanUndeclaredProperty Reference to undeclared property \closure264\BoundClass264->d
-%s:50 PhanTypeInvalidClosureScope Invalid PhanClosureScope: expected a class name, got string
-%s:51 PhanUndeclaredProperty Reference to undeclared property \closure264\TestFramework->b
-%s:51 PhanUndeclaredProperty Reference to undeclared property \closure264\TestFramework->d
+%s:17 PhanTypeMissingReturn Method \NS264\TestFramework::mockA is declared to return string but has no return value
+%s:44 PhanUndeclaredProperty Reference to undeclared property \NS264\BoundClass264->d
+%s:50 PhanTypeInvalidClosureScope Invalid @phan-closure-scope: expected a class name, got string
+%s:51 PhanUndeclaredProperty Reference to undeclared property \NS264\TestFramework->b
+%s:51 PhanUndeclaredProperty Reference to undeclared property \NS264\TestFramework->d
+%s:60 PhanUndeclaredVariable Variable $prefix is undeclared
+%s:69 PhanUndeclaredClosureScope Reference to undeclared class \NS264\UndeclaredClass264 in @phan-closure-scope
+%s:70 PhanUndeclaredProperty Reference to undeclared property \NS264\TestFramework->b
+%s:80 PhanUndeclaredProperty Reference to undeclared property \NS264\BoundClass264->undefVar

--- a/tests/files/src/0264_closure_override_context.php
+++ b/tests/files/src/0264_closure_override_context.php
@@ -1,5 +1,5 @@
 <?php
-namespace closure264;
+namespace NS264;
 
 class BoundClass264 {
     /** @var string $b */
@@ -19,7 +19,7 @@ class TestFramework {
 
         /**
          * blank, should be ignored?
-         * @PhanClosureScope
+         * @phan-closure-scope
          */
         $w = function() : string {
             // BoundClass264::a_static_method();  // should emit an issue?
@@ -27,7 +27,7 @@ class TestFramework {
         };
 
         /**
-         * @PhanClosureScope BoundClass264
+         * @phan-closure-scope BoundClass264
          */
         $x = function() : string {
             BoundClass264::a_static_method();
@@ -36,7 +36,7 @@ class TestFramework {
         };
 
         /**
-         * @PhanClosureScope \closure264\BoundClass264
+         * @phan-closure-scope \NS264\BoundClass264
          */
         $y = function() : string {
             BoundClass264::a_static_method();
@@ -45,10 +45,37 @@ class TestFramework {
         };
         /**
          * BoundClass264 scope of a native type(string, array, object, bool, etc.) makes no sense. Phan should warn.
-         * @PhanClosureScope string
+         * @phan-closure-scope string
          */
         $z = function() : string {
             return $this->b . $this->d;
         };
+        $prefix = 'NotExplicitlyUsed';
+        $suffix = 'Suf';
+        /**
+         * BoundClass264 scope of a native type(string, array, object, bool, etc.) makes no sense. Phan should warn.
+         * @phan-closure-scope BoundClass264
+         */
+        $a = function() use($suffix) : string {
+            $str = $prefix;
+            $str .= $this->b;
+            $str .= $suffix;
+            return $str;
+        };
+
+        /**
+         * @phan-closure-scope UndeclaredClass264
+         */
+        $b = function() use($suffix) : string {
+            $str = $this->b;
+            $str .= $suffix;
+            return $str;
+        };
     }
 }
+/**
+ * @phan-closure-scope BoundClass264
+ */
+$global264 = function() : string {
+    return $this->b . $this->undefVar;
+};


### PR DESCRIPTION
- Add `@phan-closure-scope` to be consistent with names of other custom
  annotations. Leave in `@PhanClosureScope`, which will be removed eventually.

Fixes #309 : `@phan-closure-scope` should be stable enough to be used to analyze
code using Closure::bind and Closure::bindTo

- The place where the closure is used may be in a completely different
  file/module from the place where the closure is declared.

Fixes #590 : Emit the correct file name for closures that are annotated
with `@phan-closure-scope`

Fixes #790 : Didn't import variables with `use` when `@phan-closure-scope` was
added to a function.

---

This fixes issues in the original approach I created earlier for #309
Overriding the **entire** Context meant that the file name for issues was wrong, and
the variables were unavailable.
Overriding only the class FQSEN is closer to the intended behavior