### PR TITLE
Fixes #978: Add `\Closure` to the type system.

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -22,6 +22,7 @@ use Phan\Language\Type;
 use Phan\Language\Type\ArrayType;
 use Phan\Language\Type\BoolType;
 use Phan\Language\Type\CallableType;
+use Phan\Language\Type\ClosureType;
 use Phan\Language\Type\FloatType;
 use Phan\Language\Type\IntType;
 use Phan\Language\Type\IterableType;
@@ -1001,7 +1002,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                 $node
             );
 
-        $type = CallableType::instanceWithClosureFQSEN(
+        $type = ClosureType::instanceWithClosureFQSEN(
             $closure_fqsen
         )->asUnionType();
 
@@ -1775,8 +1776,7 @@ class UnionTypeVisitor extends AnalysisVisitor
         // have the constant we're looking for
         foreach ($union_type->nonNativeTypes()->getTypeSet() as $class_type) {
             // Get the class FQSEN
-            $class_fqsen = $class_type->asFQSEN();
-            \assert($class_fqsen instanceof FullyQualifiedClassName, 'Parsing a class node must return a class name fqsen');
+            $class_fqsen = $class_type->asClassFQSEN();
 
             // See if the class exists
             if (!$this->code_base->hasClassWithFQSEN($class_fqsen)) {

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -363,20 +363,20 @@ class ConditionVisitor extends KindVisitorImplementation
                     },
                     function(UnionType $union_type) use ($base_class_name) : UnionType {
                         $new_type = new UnionType();
-                        $hasNull = false;
-                        $hasOtherNullableTypes = false;
+                        $has_null = false;
+                        $has_other_nullable_types = false;
                         // Add types which are
                         foreach ($union_type->getTypeSet() as $type) {
                             if ($type instanceof $base_class_name) {
-                                $hasNull = $hasNull || $type->getIsNullable();
+                                $has_null = $has_null || $type->getIsNullable();
                                 continue;
                             }
                             assert($type instanceof Type);
-                            $hasOtherNullableTypes = $hasOtherNullableTypes || $type->getIsNullable();
+                            $has_other_nullable_types = $has_other_nullable_types || $type->getIsNullable();
                             $new_type->addType($type);
                         }
                         // Add Null if some of the rejected types were were nullable, and none of the accepted types were nullable
-                        if ($hasNull && !$hasOtherNullableTypes) {
+                        if ($has_null && !$has_other_nullable_types) {
                             $new_type->addType(NullType::instance(false));
                         }
                         return $new_type;
@@ -398,20 +398,53 @@ class ConditionVisitor extends KindVisitorImplementation
                 },
                 function(UnionType $union_type) : UnionType {
                     $new_type = new UnionType();
-                    $hasNull = false;
-                    $hasOtherNullableTypes = false;
+                    $has_null = false;
+                    $has_other_nullable_types = false;
                     // Add types which are
                     foreach ($union_type->getTypeSet() as $type) {
                         if ($type instanceof ScalarType && !($type instanceof NullType)) {
-                            $hasNull = $hasNull || $type->getIsNullable();
+                            $has_null = $has_null || $type->getIsNullable();
                             continue;
                         }
                         assert($type instanceof Type);
-                        $hasOtherNullableTypes = $hasOtherNullableTypes || $type->getIsNullable();
+                        $has_other_nullable_types = $has_other_nullable_types || $type->getIsNullable();
                         $new_type->addType($type);
                     }
                     // Add Null if some of the rejected types were were nullable, and none of the accepted types were nullable
-                    if ($hasNull && !$hasOtherNullableTypes) {
+                    if ($has_null && !$has_other_nullable_types) {
+                        $new_type->addType(NullType::instance(false));
+                    }
+                    return $new_type;
+                }
+            );
+        };
+        $remove_callable_callback = static function(ConditionVisitor $cv, Node $var_node, Context $context) : Context {
+            return $cv->updateVariableWithConditionalFilter(
+                $var_node,
+                $context,
+                // if (!is_callable($x)) removes non-callable/closure types from $x.
+                // TODO: Could check for __invoke()
+                function(UnionType $union_type) : bool {
+                    return $union_type->hasTypeMatchingCallback(function(Type $type) : bool {
+                        return $type->isCallable();
+                    });
+                },
+                function(UnionType $union_type) : UnionType {
+                    $new_type = new UnionType();
+                    $has_null = false;
+                    $has_other_nullable_types = false;
+                    // Add types which are
+                    foreach ($union_type->getTypeSet() as $type) {
+                        if ($type->isCallable()) {
+                            $has_null = $has_null || $type->getIsNullable();
+                            continue;
+                        }
+                        assert($type instanceof Type);
+                        $has_other_nullable_types = $has_other_nullable_types || $type->getIsNullable();
+                        $new_type->addType($type);
+                    }
+                    // Add Null if some of the rejected types were were nullable, and none of the accepted types were nullable
+                    if ($has_null && !$has_other_nullable_types) {
                         $new_type->addType(NullType::instance(false));
                     }
                     return $new_type;
@@ -424,7 +457,7 @@ class ConditionVisitor extends KindVisitorImplementation
             'is_null' => $remove_null_cb,
             'is_array' => $make_basic_negated_assertion_callback(ArrayType::class),
             // 'is_bool' => $make_basic_assertion_callback(BoolType::class),
-            'is_callable' => $make_basic_negated_assertion_callback(CallableType::class),
+            'is_callable' => $remove_callable_callback,
             'is_double' => $remove_float_callback,
             'is_float' => $remove_float_callback,
             'is_int' => $remove_int_callback,
@@ -847,6 +880,22 @@ class ConditionVisitor extends KindVisitorImplementation
             }
             $variable->setUnionType($newType);
         };
+        $callable_callback = static function(Variable $variable, array $args)
+        {
+            // Change the type to match the is_a relationship
+            // If we already have possible callable types, then keep those
+            // (E.g. Closure|false becomes Closure)
+            $newType = $variable->getUnionType()->callableTypes();
+            if ($newType->isEmpty()) {
+                // If there are no inferred types, or the only type we saw was 'null',
+                // assume there this can be any possible scalar.
+                // (Excludes `resource`, which is technically a scalar)
+                $newType->addType(CallableType::instance(false));
+            } else if ($newType->containsNullable()) {
+                $newType = $newType->nonNullableClone();
+            }
+            $variable->setUnionType($newType);
+        };
 
         $float_callback = $make_basic_assertion_callback('float');
         $int_callback = $make_basic_assertion_callback('int');
@@ -857,7 +906,7 @@ class ConditionVisitor extends KindVisitorImplementation
             'is_a' => $is_a_callback,
             'is_array' => $array_callback,
             'is_bool' => $make_basic_assertion_callback('bool'),
-            'is_callable' => $make_basic_assertion_callback('callable'),
+            'is_callable' => $callable_callback,
             'is_double' => $float_callback,
             'is_float' => $float_callback,
             'is_int' => $int_callback,

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -21,7 +21,7 @@ use Phan\Language\Element\Variable;
 use Phan\Language\FQSEN\FullyQualifiedFunctionName;
 use Phan\Language\Type;
 use Phan\Language\Type\ArrayType;
-use Phan\Language\Type\CallableType;
+use Phan\Language\Type\ClosureType;
 use Phan\Language\Type\NullType;
 use Phan\Language\Type\VoidType;
 use Phan\Language\UnionType;
@@ -722,7 +722,8 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 }
 
                 foreach ($union_type->getTypeSet() as $type) {
-                    if (!($type instanceof CallableType)) {
+                    // TODO: Allow CallableType to have FQSENs as well, e.g. `$x = [MyClass::class, 'myMethod']` has an FQSEN in a sense.
+                    if (!($type instanceof ClosureType)) {
                         continue;
                     }
 

--- a/src/Phan/Language/Type/BoolType.php
+++ b/src/Phan/Language/Type/BoolType.php
@@ -9,7 +9,7 @@ use Phan\Language\Type;
 assert(class_exists(FalseType::class));
 assert(class_exists(TrueType::class));
 
-class BoolType extends ScalarType
+final class BoolType extends ScalarType
 {
     const NAME = 'bool';
     public static function unionTypeInstance(bool $is_nullable) : UnionType

--- a/src/Phan/Language/Type/CallableType.php
+++ b/src/Phan/Language/Type/CallableType.php
@@ -4,70 +4,16 @@ namespace Phan\Language\Type;
 use Phan\Language\FQSEN;
 use Phan\Language\Type;
 
-class CallableType extends NativeType
+final class CallableType extends NativeType
 {
     const NAME = 'callable';
 
     /**
-     * @var FQSEN|null
-     */
-    private $fqsen;
-
-    // Same as instance(), but guaranteed not to have memoized state.
-    private static function callableInstance() : CallableType {
-        static $instance = null;
-        if (empty($instance)) {
-            $instance = self::make('\\', static::NAME, [], false, self::FROM_NODE);
-        }
-        return $instance;
-    }
-
-    public static function instanceWithClosureFQSEN(FQSEN $fqsen)
-    {
-        // Use an instance with no memoized or lazily initialized results.
-        // Avoids picking up changes to CallableType::instance(false) in the case that a result depends on asFQSEN()
-        $instance = clone(self::callableInstance());
-        $instance->fqsen = $fqsen;
-        $instance->memoizeFlushAll();
-        return $instance;
-    }
-
-    public function __clone() {
-        assert($this->fqsen === null, 'should only clone null fqsen');
-        $result = new static($this->namespace, $this->name, $this->template_parameter_type_list, $this->is_nullable);
-    }
-
-    /**
-     * Override asFQSEN to return the closure's FQSEN
-     */
-    public function asFQSEN() : FQSEN
-    {
-        if (!empty($this->fqsen)) {
-            return $this->fqsen;
-        }
-
-        return parent::asFQSEN();
-    }
-
-    /**
      * @return bool
-     * True if this Type can be cast to the given Type
-     * cleanly
+     * True if this type is a callable or a Closure.
      */
-    protected function canCastToNonNullableType(Type $type) : bool
+    public function isCallable() : bool
     {
-        $d = \strtolower((string)$type);
-        if ($d[0] == '\\') {
-            $d = \substr($d, 1);
-        }
-
-        // TODO: you can have a callable that isn't a closure
-        //       This is wrong
-        if ($d === 'closure') {
-            return true;
-        }
-
-        return parent::canCastToNonNullableType($type);
+        return true;
     }
-
 }

--- a/src/Phan/Language/Type/ClosureType.php
+++ b/src/Phan/Language/Type/ClosureType.php
@@ -1,0 +1,103 @@
+<?php declare(strict_types=1);
+namespace Phan\Language\Type;
+
+use Phan\Language\FQSEN;
+use Phan\Language\Type;
+
+final class ClosureType extends Type
+{
+    const NAME = 'Closure';
+
+    /**
+     * @var FQSEN|null
+     */
+    private $fqsen;
+
+    // Same as instance(), but guaranteed not to have memoized state.
+    private static function closureInstance() : ClosureType {
+        static $instance = null;
+        if (empty($instance)) {
+            $instance = self::make('\\', self::NAME, [], false, self::FROM_NODE);
+        }
+        return $instance;
+    }
+
+    public static function instanceWithClosureFQSEN(FQSEN $fqsen)
+    {
+        // Use an instance with no memoized or lazily initialized results.
+        // Avoids picking up changes to ClosureType::instance(false) in the case that a result depends on asFQSEN()
+        $instance = clone(self::closureInstance());
+        $instance->fqsen = $fqsen;
+        $instance->memoizeFlushAll();
+        return $instance;
+    }
+
+    public function __clone() {
+        assert($this->fqsen === null, 'should only clone null fqsen');
+        $result = new static($this->namespace, $this->name, $this->template_parameter_type_list, $this->is_nullable);
+    }
+
+    /**
+     * Override asFQSEN to return the closure's FQSEN
+     */
+    public function asFQSEN() : FQSEN
+    {
+        if (!empty($this->fqsen)) {
+            return $this->fqsen;
+        }
+
+        return parent::asFQSEN();
+    }
+
+    /**
+     * @return bool
+     * True if this Type can be cast to the given Type
+     * cleanly
+     */
+    protected function canCastToNonNullableType(Type $type) : bool
+    {
+        if ($type->isCallable()) {
+            return !$this->getIsNullable() || $type->getIsNullable();
+        }
+
+        return parent::canCastToNonNullableType($type);
+    }
+
+    /**
+     * @param bool $is_nullable
+     * If true, returns a nullable instance of this closure type
+     *
+     * @return static
+     */
+    public static function instance(bool $is_nullable)
+    {
+        if ($is_nullable) {
+            static $nullable_instance = null;
+
+            if (empty($nullable_instance)) {
+                $nullable_instance = self::make('\\', self::NAME, [], true, Type::FROM_NODE);
+            }
+            \assert($nullable_instance instanceof self);
+
+            return $nullable_instance;
+        }
+
+        static $instance = null;
+
+        if (empty($instance)) {
+            $instance = self::make('\\', self::NAME, [], false, Type::FROM_NODE);
+        }
+
+        \assert($instance instanceof self);
+        return $instance;
+    }
+
+    /**
+     * @return bool
+     * True if this type is a callable or a Closure.
+     */
+    public function isCallable() : bool
+    {
+        return true;
+    }
+}

--- a/src/Phan/Language/Type/FalseType.php
+++ b/src/Phan/Language/Type/FalseType.php
@@ -3,7 +3,7 @@ namespace Phan\Language\Type;
 
 use Phan\Language\Type;
 
-class FalseType extends ScalarType
+final class FalseType extends ScalarType
 {
     const NAME = 'false';
 

--- a/src/Phan/Language/Type/FloatType.php
+++ b/src/Phan/Language/Type/FloatType.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
-class FloatType extends ScalarType
+final class FloatType extends ScalarType
 {
     const NAME = 'float';
 }

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -3,7 +3,7 @@ namespace Phan\Language\Type;
 
 use Phan\Language\Type;
 
-class GenericArrayType extends ArrayType
+final class GenericArrayType extends ArrayType
 {
     const NAME = 'array';
 

--- a/src/Phan/Language/Type/IntType.php
+++ b/src/Phan/Language/Type/IntType.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
-class IntType extends ScalarType
+final class IntType extends ScalarType
 {
     const NAME = 'int';
 }

--- a/src/Phan/Language/Type/MixedType.php
+++ b/src/Phan/Language/Type/MixedType.php
@@ -6,7 +6,7 @@ use Phan\Language\Context;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
 
-class MixedType extends NativeType
+final class MixedType extends NativeType
 {
     const NAME = 'mixed';
 

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -8,6 +8,7 @@ abstract class NativeType extends Type
 {
     const NAME = '';
 
+    /** @override */
     const KEY_PREFIX = '!';
 
     /**

--- a/src/Phan/Language/Type/NullType.php
+++ b/src/Phan/Language/Type/NullType.php
@@ -5,7 +5,7 @@ use Phan\Config;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
 
-class NullType extends ScalarType
+final class NullType extends ScalarType
 {
     const NAME = 'null';
 

--- a/src/Phan/Language/Type/ObjectType.php
+++ b/src/Phan/Language/Type/ObjectType.php
@@ -4,7 +4,7 @@ namespace Phan\Language\Type;
 
 use Phan\Language\Type;
 
-class ObjectType extends NativeType
+final class ObjectType extends NativeType
 {
     const NAME = 'object';
 

--- a/src/Phan/Language/Type/ResourceType.php
+++ b/src/Phan/Language/Type/ResourceType.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
-class ResourceType extends NativeType
+final class ResourceType extends NativeType
 {
     const NAME = 'resource';
 }

--- a/src/Phan/Language/Type/StringType.php
+++ b/src/Phan/Language/Type/StringType.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
-class StringType extends ScalarType
+final class StringType extends ScalarType
 {
     const NAME = 'string';
 }

--- a/src/Phan/Language/Type/TemplateType.php
+++ b/src/Phan/Language/Type/TemplateType.php
@@ -3,7 +3,7 @@ namespace Phan\Language\Type;
 
 use Phan\Language\Type;
 
-class TemplateType extends Type
+final class TemplateType extends Type
 {
     /** @var string */
     private $template_type_identifier;

--- a/src/Phan/Language/Type/TrueType.php
+++ b/src/Phan/Language/Type/TrueType.php
@@ -4,7 +4,7 @@ namespace Phan\Language\Type;
 use Phan\Language\Type;
 
 // Not sure if it made sense to extend BoolType, so not doing that.
-class TrueType extends ScalarType
+final class TrueType extends ScalarType
 {
     const NAME = 'true';
 

--- a/src/Phan/Language/Type/VoidType.php
+++ b/src/Phan/Language/Type/VoidType.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
-class VoidType extends NativeType
+final class VoidType extends NativeType
 {
     const NAME = 'void';
 }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -1227,8 +1227,7 @@ class UnionType implements \Serializable
         foreach ($this->nonNativeTypes()->type_set as $class_type) {
 
             // Get the class FQSEN
-            $class_fqsen = $class_type->asFQSEN();
-            \assert($class_fqsen instanceof FullyQualifiedClassName);
+            $class_fqsen = $class_type->asClassFQSEN();
 
             if ($class_type->isStaticType()) {
                 if (!$context->isInClassScope()) {
@@ -1313,7 +1312,7 @@ class UnionType implements \Serializable
      * Takes "?MyClass" and returns an empty union type.
      *
      * @return UnionType
-     * A UnionType with known object types kept, other types filtered out.
+     * A UnionType with known scalar types kept, other types filtered out.
      *
      * @see nonGenericArrayTypes
      * @see genericArrayElementTypes
@@ -1323,6 +1322,27 @@ class UnionType implements \Serializable
         // TODO: is_scalar(null) is false, account for that in analysis.
         $types = \array_filter($this->type_set, function (Type $type) : bool {
             return $type->isScalar() && !($type instanceof NullType);
+        });
+        return new UnionType($types, true);
+    }
+
+    /**
+     * Returns the types for which is_callable($x) would be true.
+     * TODO: Check for __invoke()?
+     * Takes "Closure|false" and returns "Closure"
+     * Takes "?MyClass" and returns an empty union type.
+     *
+     * @return UnionType
+     * A UnionType with known callable types kept, other types filtered out.
+     *
+     * @see nonGenericArrayTypes
+     * @see genericArrayElementTypes
+     */
+    public function callableTypes() : UnionType
+    {
+        // TODO: is_scalar(null) is false, account for that in analysis.
+        $types = \array_filter($this->type_set, function (Type $type) : bool {
+            return $type->isCallable();
         });
         return new UnionType($types, true);
     }

--- a/tests/files/expected/0070_closure_type.php.expected
+++ b/tests/files/expected/0070_closure_type.php.expected
@@ -1,3 +1,3 @@
 %s:3 PhanUndeclaredTypeParameter Parameter of undeclared type \A\Closure
-%s:4 PhanTypeMismatchArgument Argument 1 (c) is callable but \A\f() takes \A\Closure defined at %s:3
-
+%s:4 PhanTypeMismatchArgument Argument 1 (c) is \Closure but \A\f() takes \A\Closure defined at %s:3
+%s:14 PhanTypeMismatchArgument Argument 1 (c) is callable but \C\f() takes \Closure defined at %s:13

--- a/tests/files/expected/0263_alias_outside_phpdoc.php.expected
+++ b/tests/files/expected/0263_alias_outside_phpdoc.php.expected
@@ -6,6 +6,6 @@
 %s:5 PhanTypeMismatchReturn Returning type false but foo263() is declared to return \boolean
 %s:7 PhanTypeMismatchArgument Argument 1 (a) is false but \foo263() takes \boolean defined at %s:4
 %s:7 PhanTypeMismatchArgument Argument 2 (b) is int but \foo263() takes \integer defined at %s:4
-%s:7 PhanTypeMismatchArgument Argument 3 (c) is callable but \foo263() takes \callback defined at %s:4
+%s:7 PhanTypeMismatchArgument Argument 3 (c) is \Closure but \foo263() takes \callback defined at %s:4
 %s:7 PhanTypeMismatchArgument Argument 4 (d) is float but \foo263() takes \double defined at %s:4
 %s:7 PhanTypeMismatchArgument Argument 5 (e) is float but \foo263() takes \double defined at %s:4

--- a/tests/files/src/0070_closure_type.php
+++ b/tests/files/src/0070_closure_type.php
@@ -9,3 +9,7 @@ namespace B {
     f(function () {});
 }
 
+namespace C {
+    function f(\Closure $c) {}
+    function g(callable $d) { f($d); }
+}


### PR DESCRIPTION
Add it as a first class type, and split it out of `callable`.
Allow `\Closure` to cast to `\Closure` and `callable`, in addition to
`object`. Don't allow `callable` to cast to `\Closure` without checking
if it's an instance of `\Closure` (add test).

Unrelated: Make any subclasses of Type final if they currently have no subclasses.

Update 2 tests expectations to expect the name `\Closure` instead of
`callable`. Analysis of parameter passed to closures continues to work.