### PR TITLE
Fixes #505 : Enable phpdoc param and return type comparison checks by default

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,9 +15,13 @@ New Features (Analysis)
 + Evaluate the third part of a for loop with the context after the inner body is evaluated (Issue #477)
 + Emit `PhanUndeclaredVariableDim` if adding an array field to an undeclared variable. (Issue #841)
   Better analyze `list($var['field']) = values`
-+ Improve accuracy of `PhanTypeMismatchDeclaredReturn` (Move the check to after params are parsed)
-+ Create `PhanTypeMismatchDeclaredParam` (Move the check to after params are parsed)
-  Also `prefer_narrowed_phpdoc_param_type` (See "New Features (CLI, Configs))
++ Improve accuracy of `PhanTypeMismatchDeclaredReturn` (Move the check to after parse phase is finished)
++ Enable `check_docblock_signature_return_type_match` and `check_docblock_signature_param_type_match` by default.
+  Improve performance of those checks.
+  Switch to checking individual types (of the union type) of the phpdoc types and emitting issues for each invalid part.
++ Create `PhanTypeMismatchDeclaredParam` (Move the check to after parse phase is finished)
+  Also add config setting `prefer_narrowed_phpdoc_param_type` (See "New Features (CLI, Configs))
+  This config is enabled by default.
 + Detect undeclared return types at point of declaration, and emit `PhanUndeclaredTypeReturnType` (Issue #835)
 + Create `PhanParamSignaturePHPDocMismatch*` issue types, for mismatches between `@method` and real signature/other `@method` tag.
 + Create `PhanAccessWrongInheritanceCategory*` issue types to warn about classes extending a trait/interface instead of class, etc. (#873)
@@ -39,12 +43,15 @@ New Features (Analysis)
 
 New Features (CLI, Configs)
 + Create `check_docblock_signature_param_type_match` (similar to `check_docblock_signature_return_type_match`) config setting
-  to enable warning if phpdoc types are incompatible with the real types. False by default.
+  to enable warning if phpdoc types are incompatible with the real types. True(enabled) by default.
 
-  Create `prefer_narrowed_phpdoc_param_type` config setting (requires `check_docblock_signature_return_type_match`).
-  This is off by default, set it to true to analyze phpdoc param types instead of provided signature types if the possible phpdoc types are narrower and compatible.
+  Create `prefer_narrowed_phpdoc_param_type` config setting (True by default, requires `check_docblock_signature_return_type_match` to be enabled).
+  When it is true, Phan will analyze each function using the phpdoc param types instead of the provided signature types 
+  if the possible phpdoc types are narrower and compatible with the signature.
   (E.g. indicate that subclasses are expected over base classes, indicate that non-nullable is expected instead of nullable)
   This affects analysis both inside and outside the method.
+
+  Aside: Phan currently defaults to preferring phpdoc type over real return type, and emits `PhanTypeMismatchDeclaredReturn` if the two are incompatible.
 + Create `enable_class_alias_support` config setting (disabled by default), which enables analyzing basic usage of class_alias. (Issue #586)
   Set it to true to enable it.
   NOTE: this is still experimental.

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -168,7 +168,7 @@ class Config
         // Issue::SEVERITY_CRITICAL. Setting it to only
         // critical issues is a good place to start on a big
         // sloppy mature code base.
-        'minimum_severity' => 0,
+        'minimum_severity' => Issue::SEVERITY_LOW,
 
         // If true, missing properties will be created when
         // they are first seen. If false, we'll report an
@@ -211,15 +211,13 @@ class Config
 
         // If true, check to make sure the return type declared
         // in the doc-block (if any) matches the return type
-        // declared in the method signature. This process is
-        // probably still slow.
-        'check_docblock_signature_return_type_match' => false,
+        // declared in the method signature.
+        'check_docblock_signature_return_type_match' => true,
 
         // If true, check to make sure the param types declared
         // in the doc-block (if any) matches the param types
-        // declared in the method signature. This process is
-        // probably still low.
-        'check_docblock_signature_param_type_match' => false,
+        // declared in the method signature.
+        'check_docblock_signature_param_type_match' => true,
 
         // (*Requires check_docblock_signature_param_type_match to be true*)
         // If true, make narrowed types from phpdoc override
@@ -227,7 +225,7 @@ class Config
         // (E.g. allows specifying desired lists of subclasses,
         //  or to indicate a preference for non-nullable types over nullable types)
         // Affects analysis of the body of the method and the param types passed in by callers.
-        'prefer_narrowed_phpdoc_param_type' => false,
+        'prefer_narrowed_phpdoc_param_type' => true,
 
         // Set to true in order to attempt to detect dead
         // (unreferenced) code. Keep in mind that the


### PR DESCRIPTION
Update NEWS to reflect that.

In addition to that, when there is a real type in the signature,
only use the phpdoc type if it is a narrowed version of the real type in the signature.
(E.g. a subclass or subtype is considered to be narrowed)

The performance of the phpdoc signature compatibility checks has been improved significantly, so enable them by default.

#505 is fixed in the sense that PhanTypeMismatchDeclaredReturn is emitted