### PR TITLE
Allow suppressing issues on constants, add tests

### DIFF
--- a/src/Phan/Language/Type/ArrayType.php
+++ b/src/Phan/Language/Type/ArrayType.php
@@ -5,7 +5,9 @@ use Phan\Language\Type;
 
 class ArrayType extends IterableType
 {
+    /** @phan-override */
     const NAME = 'array';
+
     public function getIsAlwaysTruthy() : bool
     {
         return false;

--- a/src/Phan/Language/Type/BoolType.php
+++ b/src/Phan/Language/Type/BoolType.php
@@ -11,6 +11,7 @@ assert(class_exists(TrueType::class));
 
 final class BoolType extends ScalarType
 {
+    /** @phan-override */
     const NAME = 'bool';
     public static function unionTypeInstance(bool $is_nullable) : UnionType
     {

--- a/src/Phan/Language/Type/CallableType.php
+++ b/src/Phan/Language/Type/CallableType.php
@@ -6,6 +6,7 @@ use Phan\Language\Type;
 
 final class CallableType extends NativeType
 {
+    /** @phan-override */
     const NAME = 'callable';
 
     /**

--- a/src/Phan/Language/Type/ClosureType.php
+++ b/src/Phan/Language/Type/ClosureType.php
@@ -6,6 +6,7 @@ use Phan\Language\Type;
 
 final class ClosureType extends Type
 {
+    /** Not an override */
     const NAME = 'Closure';
 
     /**

--- a/src/Phan/Language/Type/FalseType.php
+++ b/src/Phan/Language/Type/FalseType.php
@@ -5,6 +5,7 @@ use Phan\Language\Type;
 
 final class FalseType extends ScalarType
 {
+    /** @phan-override */
     const NAME = 'false';
 
     public function getIsPossiblyFalsey() : bool

--- a/src/Phan/Language/Type/FloatType.php
+++ b/src/Phan/Language/Type/FloatType.php
@@ -3,5 +3,6 @@ namespace Phan\Language\Type;
 
 final class FloatType extends ScalarType
 {
+    /** @phan-override */
     const NAME = 'float';
 }

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -5,6 +5,7 @@ use Phan\Language\Type;
 
 final class GenericArrayType extends ArrayType
 {
+    /** @phan-override */
     const NAME = 'array';
 
     /**

--- a/src/Phan/Language/Type/IntType.php
+++ b/src/Phan/Language/Type/IntType.php
@@ -3,5 +3,6 @@ namespace Phan\Language\Type;
 
 final class IntType extends ScalarType
 {
+    /** @phan-override */
     const NAME = 'int';
 }

--- a/src/Phan/Language/Type/IterableType.php
+++ b/src/Phan/Language/Type/IterableType.php
@@ -5,6 +5,7 @@ use Phan\Language\Type;
 
 class IterableType extends NativeType
 {
+    /** @phan-override */
     const NAME = 'iterable';
 
     public function isIterable() : bool

--- a/src/Phan/Language/Type/MixedType.php
+++ b/src/Phan/Language/Type/MixedType.php
@@ -8,6 +8,7 @@ use Phan\Language\UnionType;
 
 final class MixedType extends NativeType
 {
+    /** @phan-override */
     const NAME = 'mixed';
 
     // mixed or ?mixed can cast to/from anything.

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -8,7 +8,7 @@ abstract class NativeType extends Type
 {
     const NAME = '';
 
-    /** @override */
+    /** @phan-override */
     const KEY_PREFIX = '!';
 
     /**

--- a/src/Phan/Language/Type/NullType.php
+++ b/src/Phan/Language/Type/NullType.php
@@ -7,6 +7,7 @@ use Phan\Language\UnionType;
 
 final class NullType extends ScalarType
 {
+    /** @phan-override */
     const NAME = 'null';
 
     /**

--- a/src/Phan/Language/Type/ObjectType.php
+++ b/src/Phan/Language/Type/ObjectType.php
@@ -6,6 +6,7 @@ use Phan\Language\Type;
 
 final class ObjectType extends NativeType
 {
+    /** @phan-override */
     const NAME = 'object';
 
     protected function canCastToNonNullableType(Type $type) : bool {

--- a/src/Phan/Language/Type/ResourceType.php
+++ b/src/Phan/Language/Type/ResourceType.php
@@ -3,5 +3,6 @@ namespace Phan\Language\Type;
 
 final class ResourceType extends NativeType
 {
+    /** @phan-override */
     const NAME = 'resource';
 }

--- a/src/Phan/Language/Type/StaticType.php
+++ b/src/Phan/Language/Type/StaticType.php
@@ -8,6 +8,7 @@ use Phan\Language\UnionType;
 
 final class StaticType extends Type
 {
+    /** Not an override */
     const NAME = 'static';
 
     /**

--- a/src/Phan/Language/Type/StringType.php
+++ b/src/Phan/Language/Type/StringType.php
@@ -3,5 +3,6 @@ namespace Phan\Language\Type;
 
 final class StringType extends ScalarType
 {
+    /** @phan-override */
     const NAME = 'string';
 }

--- a/src/Phan/Language/Type/TrueType.php
+++ b/src/Phan/Language/Type/TrueType.php
@@ -6,6 +6,7 @@ use Phan\Language\Type;
 // Not sure if it made sense to extend BoolType, so not doing that.
 final class TrueType extends ScalarType
 {
+    /** @phan-override */
     const NAME = 'true';
 
     public function getIsPossiblyTruthy() : bool

--- a/src/Phan/Language/Type/VoidType.php
+++ b/src/Phan/Language/Type/VoidType.php
@@ -3,5 +3,6 @@ namespace Phan\Language\Type;
 
 final class VoidType extends NativeType
 {
+    /** @phan-override */
     const NAME = 'void';
 }

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -574,6 +574,7 @@ class ParseVisitor extends ScopeVisitor
             $constant->setIsDeprecated($comment->isDeprecated());
             $constant->setIsNSInternal($comment->isNSInternal());
             $constant->setIsOverrideIntended($comment->isOverrideIntended());
+            $constant->setSuppressIssueList($comment->getSuppressIssueList());
 
             $constant->setFutureUnionType(
                 new FutureUnionType(

--- a/tests/files/expected/0332_override_complex.php.expected
+++ b/tests/files/expected/0332_override_complex.php.expected
@@ -1,0 +1,7 @@
+%s:10 PhanCommentOverrideOnNonOverrideConstant Saw an @override annotation for class constant \A332::STATIC_CONST_2, but could not find an overridden constant
+%s:14 PhanCommentOverrideOnNonOverrideMethod Saw an @override annotation for method \A332::abstractMethodA2, but could not find an overridden method and it is not a magic method
+%s:24 PhanCommentOverrideOnNonOverrideMethod Saw an @override annotation for method \I332::abstractMethodI2, but could not find an overridden method and it is not a magic method
+%s:32 PhanInvalidCommentForDeclarationType The phpdoc comment for @override cannot occur on a class
+%s:40 PhanCommentOverrideOnNonOverrideMethod Saw an @override annotation for method \T332::method2, but could not find an overridden method and it is not a magic method
+%s:52 PhanCommentOverrideOnNonOverrideConstant Saw an @override annotation for class constant \Override332::STATIC_CONST_TYPO, but could not find an overridden constant
+%s:78 PhanCommentOverrideOnNonOverrideMethod Saw an @override annotation for method \Override332::notReallyAnOverride, but could not find an overridden method and it is not a magic method

--- a/tests/files/src/0332_override_complex.php
+++ b/tests/files/src/0332_override_complex.php
@@ -1,0 +1,85 @@
+<?php
+
+abstract class A332 {
+    /**
+     * In php 7.1, doc comments on class constants are recorded
+     */
+    const STATIC_CONST = 'value';
+
+    /** @override - should warn here and only here */
+    const STATIC_CONST_2 = 22;
+
+    public abstract function abstractMethodA();
+    /** @override - should warn */
+    public abstract function abstractMethodA2();
+
+    public function methodA() {
+        return static::STATIC_CONST;
+    }
+}
+
+interface I332 {
+    public function abstractMethodI(array $x);
+    /** @override - should warn */
+    public function abstractMethodI2(array $x);
+
+    public function method1(string $x);
+}
+
+/**
+ * @override - not sure what that means.
+ */
+trait T332 {
+    public abstract function abstractMethodT(int $x);
+
+    public function methodT(string $x) {}
+
+    public function method1(string $x) {}
+
+    /** @Override - should warn (And can use (at)override or (at)Override) */
+    public function method2(string $x) {}
+}
+
+class Override332 extends A332 implements I332 {
+    /**
+     * @override (Analyze overrides of static constants as well)
+     */
+    const STATIC_CONST = 'otherValue';
+
+    /**
+     * @override (should warn)
+     */
+    const STATIC_CONST_TYPO = 'otherValue';
+
+    use T332;
+
+    /** @override */
+    public function abstractMethodA() {}
+
+    /** Can omit override without a warning */
+    public function abstractMethodA2() {}
+
+    /** @override */
+    public function methodA() {}
+
+    /** @override */
+    public function abstractMethodI(array $x) { return $x; }
+
+    /** @override */
+    public function abstractMethodI2(array $x) { return []; }
+
+    /** @override */
+    public function abstractMethodT(int $x) { return $x; }
+
+    /** @override */
+    public function method2(string $x) { return $x; }
+
+    /** @override */
+    public function notReallyAnOverride() {}
+
+    /**
+     * @override (should warn and be suppressed)
+     * @suppress PhanCommentOverrideOnNonOverrideConstant
+     */
+    const STATIC_CONST_TYPO_2 = 'otherValue';
+}


### PR DESCRIPTION
Add test files for `@override` support

Check it for trait and abstract class ancestors as well.
Also, check that `@override` is analyzed on constants as well.

Use `@phan-override` for constants to indicate that they
are overriding a constant in an ancestor class
(Type accesses those constants as static::NAME)