### PR TITLE
Fixes #957 : set the parameter types inside function in non-quick mode

### DIFF
--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -13,6 +13,7 @@ use Phan\Exception\NodeException;
 use Phan\Exception\UnanalyzableException;
 use Phan\Issue;
 use Phan\Language\Context;
+use Phan\Language\Element\PassByReferenceVariable;
 use Phan\Language\Element\Parameter;
 use Phan\Language\Element\Variable;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
@@ -632,7 +633,7 @@ class AssignmentVisitor extends AnalysisVisitor
                     } else {
                         $variable = clone($variable);
                     }
-                } else {
+                } else if (!($variable instanceof PassByReferenceVariable)) {
                     $variable = clone($variable);
                 }
 

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -299,7 +299,8 @@ class ConditionVisitor extends KindVisitorImplementation
         // Negation
         // TODO: negate instanceof, other checks
         // TODO: negation would also go in the else statement
-        if (($negatedNode->kind ?? 0) === \ast\AST_CALL) {
+        $kind = $negatedNode->kind ?? 0;
+        if ($kind === \ast\AST_CALL) {
             $args = $negatedNode->children['args']->children;
             foreach ($args as $arg) {
                 if ($arg instanceof Node) {
@@ -328,6 +329,8 @@ class ConditionVisitor extends KindVisitorImplementation
                 }
                 return $callback($this, $args[0], $context);
             }
+        } else if ($kind === \ast\AST_VAR) {
+            return $this->removeTruthyFromVariable($negatedNode, $context);
         }
         return $context;
     }

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1813,17 +1813,23 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             return;
         }
 
-        // Create a copy of the method's original parameter list
-        // and scope so that we can reset it after re-analyzing
-        // it.
-        $original_method_scope = clone($method->getInternalScope());
-        $original_parameter_list = \array_map(function (Variable $parameter) : Variable {
-            return clone($parameter);
-        }, $method->getParameterList());
+        // Create a copy of the method's original scope so that we can reset it
+        // after re-analyzing it.
+        // Don't modify the parameter list - We use that to know when to emit PhanTypeMismatchArgument,
+        // so issues would be incorrectly emitted if it was temporarily modified.
+        $original_parameter_list = $method->getParameterList();
 
         if (\count($original_parameter_list) === 0) {
             return;  // No point in recursing if there's no changed parameters.
         }
+
+        $original_method_scope = $method->getInternalScope();
+        $method->setInternalScope(clone($original_method_scope));
+        // Even though we don't modify the parameter list, we still need to know the types
+        // -- as an optimization, we don't run quick mode again if the types didn't change?
+        $parameter_list = \array_map(function (Variable $parameter) : Variable {
+            return clone($parameter);
+        }, $original_parameter_list);
 
         // always resolve all arguments outside of quick mode to detect undefined variables, other problems in call arguments.
         // Fixes https://github.com/etsy/phan/issues/583
@@ -1840,53 +1846,61 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             );
         }
 
-        // Get the list of parameters on the method
-        $parameter_list = $method->getParameterList();
-
-        foreach ($parameter_list as $i => $parameter) {
-
+        foreach ($parameter_list as $i => $parameter_clone) {
+            // Add the parameter to the scope
+            $method->getInternalScope()->addVariable(
+                $parameter_clone
+            );
             $argument = $argument_list_node->children[$i] ?? null;
 
             if (!$argument
-                && $parameter->hasDefaultValue()
+                && $parameter_clone->hasDefaultValue()
             ) {
-                $parameter_list = $method->getParameterList();
-                $parameter_list[$i] = clone($parameter);
-                $parameter_type = $parameter->getDefaultValueType();
+                $parameter_type = $parameter_clone->getDefaultValueType();
                 if ($parameter_type->isType(NullType::instance(false))) {
                     // Treat a parameter default of null the same way as passing null to that parameter
                     // (Add null to the list of possibilities)
-                    $parameter_list[$i]->addUnionType($parameter_type);
+                    $parameter_clone->addUnionType($parameter_type);
                 } else {
                     // For other types (E.g. string), just replace the union type.
-                    $parameter_list[$i]->setUnionType($parameter_type);
+                    $parameter_clone->setUnionType($parameter_type);
                 }
-                $method->setParameterList($parameter_list);
             }
 
             // If there's no parameter at that offset, we may be in
             // a ParamTooMany situation. That is caught elsewhere.
             if (!$argument
-                || !$parameter->getNonVariadicUnionType()->isEmpty()
+                || !$parameter_clone->getNonVariadicUnionType()->isEmpty()
             ) {
                 continue;
             }
 
             $this->updateParameterTypeByArgument(
                 $method,
-                $parameter,
+                $parameter_clone,
                 $argument,
                 $argument_types[$i],
+                $parameter_list,
                 $i
             );
+        }
+        foreach ($parameter_list as $parameter_clone) {
+            if ($parameter_clone->isVariadic()) {
+                // We're using this parameter clone to analyze the **inside** of the method, it's never seen on the outside.
+                // Convert it immediately.
+                // TODO: Add tests of variadic references, fix those if necessary.
+                $method->getInternalScope()->addVariable(
+                    $parameter_clone->cloneAsNonVariadic()
+                );
+            }
         }
 
         // Now that we know something about the parameters used
         // to call the method, we can reanalyze the method with
         // the types of the parameter
-        $method->analyzeWithNewParams($method->getContext(), $code_base);
+        $method->analyzeWithNewParams($method->getContext(), $code_base, $parameter_list);
 
-        // Reset to the original parameter list and scope after
+        // Reset to the original parameter scope after
         // having tested the parameters with the types passed in
         $method->setParameterList($original_parameter_list);
         $method->setInternalScope($original_method_scope);
@@ -1917,6 +1931,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         Variable $parameter,
         $argument,
         UnionType $argument_type,
+        array &$parameter_list,
         int $parameter_offset
     ) {
         // Then set the new type on that parameter based
@@ -1994,18 +2009,13 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 $variable
             );
 
-        // Substitute the new type in for the parameter's type
-        $parameter_list = $method->getParameterList();
-        $parameter_list[$parameter_offset] =
-            $pass_by_reference_variable;
-        $method->setParameterList($parameter_list);
-
-        // Add it to the scope of the function wrapped
+        // Add it to the (cloned) scope of the function wrapped
         // in a way that makes it addressable as the
         // parameter its mimicking
         $method->getInternalScope()->addVariable(
             $pass_by_reference_variable
         );
+        $parameter_list[$parameter_offset] = $pass_by_reference_variable;
     }
 
     /**

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -174,10 +174,15 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         // Add each method parameter to the scope. We clone it
         // so that changes to the variable don't alter the
         // parameter definition
-        foreach ($method->getParameterList() as $parameter) {
-            $context->addScopeVariable(
-                $parameter->cloneAsNonVariadic()
-            );
+        if ($method->getRecursionDepth() === 0) {
+            // Add each method parameter to the scope. We clone it
+            // so that changes to the variable don't alter the
+            // parameter definition
+            foreach ($method->getParameterList() as $parameter) {
+                $context->addScopeVariable(
+                    $parameter->cloneAsNonVariadic()
+                );
+            }
         }
 
         if ($this->analyzeFunctionLikeIsGenerator($node)) {
@@ -260,13 +265,15 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
             );
         }
 
-        // Add each method parameter to the scope. We clone it
-        // so that changes to the variable don't alter the
-        // parameter definition
-        foreach ($function->getParameterList() as $parameter) {
-            $context->addScopeVariable(
-                $parameter->cloneAsNonVariadic()
-            );
+        if ($function->getRecursionDepth() === 0) {
+            // Add each method parameter to the scope. We clone it
+            // so that changes to the variable don't alter the
+            // parameter definition
+            foreach ($function->getParameterList() as $parameter) {
+                $context->addScopeVariable(
+                    $parameter->cloneAsNonVariadic()
+                );
+            }
         }
 
         if ($this->analyzeFunctionLikeIsGenerator($node)) {

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -184,7 +184,7 @@ interface FunctionInterface extends AddressableElementInterface {
      * in the given context.
      * This function's parameter list may or may not have been modified.
      */
-    public function analyzeWithNewParams(Context $context, CodeBase $code_base) : Context;
+    public function analyzeWithNewParams(Context $context, CodeBase $code_base, array $parameter_list) : Context;
 
     public function getElementNamespace(CodeBase $code_base) : string;
 

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -64,6 +64,8 @@ class Method extends ClassElement implements FunctionInterface
         // if it isn't.
         $this->setDefiningFQSEN($fqsen);
 
+        // Record the FQSEN of this method (With the current Clazz),
+        // to prevent recursing from a method into itself in non-quick mode.
         $this->setInternalScope(new FunctionLikeScope(
             $context->getScope(), $fqsen
         ));

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -67,7 +67,7 @@ class Property extends ClassElement
             $union_type = new UnionType();
         }
 
-        $string .= "$union_type {$this->getName()}";
+        $string .= "$union_type \${$this->getName()}";
 
 
         return $string;

--- a/tests/files/expected/0330_recurse.php.expected
+++ b/tests/files/expected/0330_recurse.php.expected
@@ -1,0 +1,4 @@
+%s:6 PhanTypeMismatchArgument Argument 1 (x) is int but \callSelf() takes bool|false defined at %s:3
+%s:7 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is false but \intdiv() takes int
+%s:16 PhanTypeMismatchArgument Argument 1 (x) is int but \A330::callSelf() takes bool|false defined at %s:12
+%s:17 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is false but \intdiv() takes int

--- a/tests/files/src/0330_recurse.php
+++ b/tests/files/src/0330_recurse.php
@@ -1,0 +1,27 @@
+<?php
+
+function callSelf(bool $x = false) {
+    if (!$x) {
+        callSelf(true);
+        callSelf(42);  // should warn about expecting **bool**
+        echo intdiv($x, 20);
+    }
+}
+
+class A330 {
+    function callSelf(bool $x = false) {
+        if (!$x) {
+            self::callSelf(true);
+            A330::callSelf(true);
+            self::callSelf(42);  // should warn about expecting **bool**
+            echo intdiv($x, 20);
+        }
+    }
+}
+
+class B330 extends A330 {
+}
+$a330 = new A330();
+$a330->callSelf();
+$b330 = new B330();
+$b330->callSelf();


### PR DESCRIPTION
Previously, Phan was setting the parameter types when recursively
analyzing other functions, when quick mode was false.
(E.g. setting it to a parameter's default value, for `bool $x = false`)

This would result in unexpected error messages, where the expected
parameter type was different than what Phan inferred from real types or
phpdoc types.

Add a unit tests with the expected inferred types.

- The test expectation currently says `bool|false`.
  `bool` would make more sense, but adding `false` is harmless for
  the callers and callee.