### PR TITLE
Fixes #986 : Thoroughly check for undefined variables in nested expressions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -79,6 +79,7 @@ Bug Fixes
 + Work around known bugs in current releases of two PECL extensions (Issue #888, #889)
 + Fix typo - Change `PhanParamSignatureRealMismatch` to `PhanParamSignatureRealMismatchReturnType`
 + Consistently exit with non-zero exit code if there are multiple processes, and any process failed to return valid results. (Issue #868)
++ Fixes #986 : PhanUndeclaredVariable used to fail to be emitted in some deeply nested expressions, such as `return $undefVar . 'suffix';`
 
 Backwards Incompatible Changes
 + Fix categories of some issue types, renumber error ids for the pylint error formatter to be unique and consistent.

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -450,7 +450,9 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 \ast\AST_ASSIGN_REF     => true,  // Creates by reference?
                 \ast\AST_ASSIGN         => true,  // checked in visitAssign
                 \ast\AST_DIM            => true,  // should be checked elsewhere, as part of check for array access to non-array/string
+                \ast\AST_EMPTY          => true,  // TODO: Enable this in the future?
                 \ast\AST_GLOBAL         => true,  // global $var;
+                \ast\AST_ISSET          => true,  // TODO: Enable this in the future?
                 \ast\AST_PARAM_LIST     => true,  // this creates the variable
                 \ast\AST_STATIC         => true,  // static $var;
                 \ast\AST_STMT_LIST      => true,  // ;$var; (Implicitly creates the variable. Already checked to emit PhanNoopVariable)

--- a/tests/files/expected/0047_backwards_compatibility.php.expected
+++ b/tests/files/expected/0047_backwards_compatibility.php.expected
@@ -1,9 +1,12 @@
 %s:2 PhanCompatiblePHP7 Expression may not be PHP 7 compatible
+%s:2 PhanUndeclaredVariable Variable $bar is undeclared
 %s:2 PhanUndeclaredVariable Variable $foo is undeclared
 %s:3 PhanCompatiblePHP7 Expression may not be PHP 7 compatible
 %s:4 PhanCompatiblePHP7 Expression may not be PHP 7 compatible
+%s:4 PhanUndeclaredVariable Variable $bar is undeclared
 %s:4 PhanUndeclaredVariable Variable $foo is undeclared
 %s:5 PhanCompatiblePHP7 Expression may not be PHP 7 compatible
+%s:5 PhanUndeclaredVariable Variable $bar is undeclared
 %s:5 PhanUndeclaredVariable Variable $foo is undeclared
 %s:15 PhanCompatiblePHP7 Expression may not be PHP 7 compatible
 %s:28 PhanAccessPropertyStaticAsNonStatic Accessing static property \Test::$vals as non static

--- a/tests/files/expected/0101_one_of_each.php.expected
+++ b/tests/files/expected/0101_one_of_each.php.expected
@@ -2,6 +2,7 @@
 %s:9 PhanAccessPropertyProtected Cannot access protected property \C2::$p
 %s:14 PhanCompatiblePHP7 Expression may not be PHP 7 compatible
 %s:14 PhanUndeclaredVariable Variable $v1 is undeclared
+%s:14 PhanUndeclaredVariable Variable $v2 is undeclared
 %s:17 PhanContextNotObject Cannot access parent when not in object context
 %s:22 PhanDeprecatedFunction Call to deprecated function \f1() defined at %s:21
 %s:25 PhanNoopArray Unused array

--- a/tests/files/expected/0332_undeclared_variable_nested.php.expected
+++ b/tests/files/expected/0332_undeclared_variable_nested.php.expected
@@ -1,0 +1,6 @@
+%s:5 PhanUndeclaredVariable Variable $undefVar2 is undeclared
+%s:5 PhanUndeclaredVariable Variable $undefVar3 is undeclared
+%s:5 PhanUndeclaredVariable Variable $x is undeclared
+%s:6 PhanUndeclaredVariable Variable $undefInt2 is undeclared
+%s:9 PhanUndeclaredVariable Variable $undefInt is undeclared
+%s:10 PhanUndeclaredVariable Variable $undefVar4 is undeclared

--- a/tests/files/src/0332_undeclared_variable_nested.php
+++ b/tests/files/src/0332_undeclared_variable_nested.php
@@ -1,0 +1,11 @@
+<?php
+
+function undefInNestedExpr332(string $a, int $intVal) {
+    global $argc;
+    $b = $undefVar2 . $x . $undefVar3;
+    $c = $undefInt2 +
+        $intVal +
+        $argc +
+        $undefInt;
+    return $undefVar4 . $b;
+}


### PR DESCRIPTION
PhanUndeclaredVariable wasn't being emitted in some nested expression
where it should have been, due to recursion stopping early.

Emit PhanUndeclaredVariable in deeply nested expressions, in places
where the parent node is guaranteed to make it impossible that the
variable is being created by the statement.

- This may not be comprehensive yet, but no new regressions were
  observed so far.

Note: If the variable might be created some of the time,
there's already checks in other places.

Add tests, update NEWS