### PR TITLE
Fixes #564: Start returning return types of Closures to analyze

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -80,6 +80,7 @@ Bug Fixes
 + Fix typo - Change `PhanParamSignatureRealMismatch` to `PhanParamSignatureRealMismatchReturnType`
 + Consistently exit with non-zero exit code if there are multiple processes, and any process failed to return valid results. (Issue #868)
 + Fixes #986 : PhanUndeclaredVariable used to fail to be emitted in some deeply nested expressions, such as `return $undefVar . 'suffix';`
++ Make Phan infer the return types of closures, both for closures invoked inline and closures declared then invoked later (Issue #564)
 
 Backwards Incompatible Changes
 + Fix categories of some issue types, renumber error ids for the pylint error formatter to be unique and consistent.

--- a/tests/files/expected/0333_closure_return_types.php.expected
+++ b/tests/files/expected/0333_closure_return_types.php.expected
@@ -1,0 +1,4 @@
+%s:4 PhanTypeMismatchReturn Returning type \stdClass but f333() is declared to return int
+%s:6 PhanTypeMismatchArgument Argument 1 (arg) is string but \closure_%s() takes int defined at %s:4
+%s:14 PhanParamTooFew Call with 0 arg(s) to \closure_%s() which requires 1 arg(s) defined at %s:11
+%s:15 PhanTypeMismatchReturn Returning type \stdClass but g333() is declared to return int

--- a/tests/files/src/0333_closure_return_types.php
+++ b/tests/files/src/0333_closure_return_types.php
@@ -1,0 +1,18 @@
+<?php
+function f333(): int {
+    // Test invoking closures inline
+    return (function(int $arg): stdClass {
+        return new stdClass;
+    })('notanint');
+}
+
+function g333(): int {
+    // Test invoking closures declared elsewhere
+    $func = function(int $arg): stdClass {
+        return new stdClass;
+    };
+    $result = $func();
+    return $result;
+}
+f333();
+g333();


### PR DESCRIPTION
TODO: add tests

Unify the helpers used to get the functions to have parameters analyzed, and the helpers to get the return types to guess the return types.

If there are multiple possible closures for a variable, reduce false positives and take the union of both return types (Ignore empty union types for now)

Start supporting the analysis of inline closures

```php
<?php
function f(): int {
    return (function(int $arg): stdClass {
        return new stdClass;
    })('notanint');
}
f();
```