### PR TITLE
Use simplify_ast both in parse and analysis phase

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -89,6 +89,8 @@ Bug Fixes
   Previously, it wouldn't emit warnings for global functions, only for methods.
 + Don't add `mixed` to inferred union types of properties which already have non-empty phpdoc types. (Issue #512)
   mixed would just result in Phan failing to emit any types of issues.
++ When `simplify_ast` is true, simplify the ASTs parsed in the parse mode as well.
+  Makes analysis consistent when `quick_mode` is false (AST nodes from the parse phase would also be used in the analysis phase)
 
 Backwards Incompatible Changes
 + Fix categories of some issue types, renumber error ids for the pylint error formatter to be unique and consistent.

--- a/src/Phan/AST/ASTSimplifier.php
+++ b/src/Phan/AST/ASTSimplifier.php
@@ -15,8 +15,8 @@ class ASTSimplifier {
     /** @var string - for debugging purposes */
     private $_filename;
 
-    public function __construct(string $filename = 'unknown') {
-        $this->_blockChecker = new BlockExitStatusChecker($filename);
+    public function __construct(\SplObjectStorage $exit_status_cache, string $filename = 'unknown') {
+        $this->_blockChecker = new BlockExitStatusChecker($exit_status_cache, $filename);
         $this->_filename = $filename;
     }
 
@@ -429,7 +429,7 @@ class ASTSimplifier {
     }
 
     public static function applyStatic(Node $node, string $filename = 'unknown') : Node {
-        $rewriter = new self($filename);
+        $rewriter = new self(new \SplObjectStorage(), $filename);
         $nodes = $rewriter->apply($node);
         \assert(\count($nodes) === 1);
         return $nodes[0];

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -75,6 +75,21 @@ class Analysis
             return $context;
         }
 
+        if (Config::getValue('simplify_ast')) {
+            try {
+                $newNode = ASTSimplifier::applyStatic($node);  // Transform the original AST, leaving the original unmodified.
+                $node = $newNode;  // Analyze the new AST instead.
+            } catch (\Exception $e) {
+                Issue::maybeEmit(
+                    $code_base,
+                    $context,
+                    Issue::SyntaxError,  // Not the right kind of error. I don't think it would throw, anyway.
+                    $e->getLine(),
+                    $e->getMessage()
+                );
+            }
+        }
+
         if (Config::getValue('dump_ast')) {
             echo $file_path . "\n"
                 . str_repeat("\u{00AF}", strlen($file_path))

--- a/src/Phan/Analysis/BlockExitStatusChecker.php
+++ b/src/Phan/Analysis/BlockExitStatusChecker.php
@@ -22,15 +22,15 @@ class BlockExitStatusChecker extends KindVisitorImplementation {
     const STATUS_THROW    = 4;  // All branches lead to a throw statement (Or possibly a return)
     const STATUS_RETURN   = 5;  // All branches lead to a return/exit statement
 
-    /** @var \SplObjectStorage */
+    /** @var \SplObjectStorage - A shared cache, re-used while analyzing a given file. */
     private $exit_status_cache;
-    /** @var string - filename, for debugging*/
-    private $_filename;
+    /** @var string - filename, for debugging */
+    private $filename;
 
-    public function __construct(string $filename = 'unknown')
+    public function __construct(\SplObjectStorage $exit_status_cache, string $filename = 'unknown')
     {
-        $this->exit_status_cache = new \SplObjectStorage();
-        $this->_filename = $filename;
+        $this->exit_status_cache = $exit_status_cache;
+        $this->filename = $filename;
     }
 
     public function check(Node $node = null) : int


### PR DESCRIPTION
When quick_mode is false, the parsed nodes from the parse phase would be
used when analyzing calls to other methods, so use simplify_ast during
parse too if it is enabled. (turned off by default)

Make it obvious that the SplObjectStorage is being reused to cache
the block exit status for all of the nodes in the given file
(It was already being reused properly, this just makes it obvious)