### PR TITLE
Add an LRU file cache, to cache information about file contents

### DIFF
--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -33,6 +33,7 @@ use Phan\Language\Type\NullType;
 use Phan\Language\Type\ObjectType;
 use Phan\Language\Type\StringType;
 use Phan\Language\UnionType;
+use Phan\Library\FileCache;
 use Phan\Library\None;
 use Phan\Library\Some;
 use ast\Node;
@@ -1482,11 +1483,10 @@ class ContextNode
                 || $temp->kind == \ast\AST_NAME
             )
         ) {
-            $ftemp = new \SplFileObject($this->context->getFile());
-            $ftemp->seek($this->node->lineno-1);
-            $line = $ftemp->current();
+            $cache_entry = FileCache::getOrReadEntry($this->context->getFile());
+            $line = $cache_entry->getLine($this->node->lineno);
             \assert(\is_string($line));
-            unset($ftemp);
+            unset($cache_entry);
             if (strpos($line, '}[') === false
                 || strpos($line, ']}') === false
                 || strpos($line, '>{') === false

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -10,6 +10,7 @@ use Phan\Language\Context;
 use Phan\Language\Element\Clazz;
 use Phan\Language\Element\Func;
 use Phan\Language\Element\Method;
+use Phan\Library\FileCache;
 use Phan\Parse\ParseVisitor;
 use Phan\Plugin\ConfigPluginSet;
 use ast\Node;
@@ -42,6 +43,7 @@ class Analysis
      */
     public static function parseFile(CodeBase $code_base, string $file_path, bool $suppress_parse_errors = false, string $override_contents = null) : Context
     {
+
         $code_base->setCurrentParsedFile($file_path);
         $context = (new Context)->withFile($file_path);
 
@@ -50,16 +52,28 @@ class Analysis
         // of this method
         try {
             if (\is_string($override_contents)) {
-                $node = \ast\parse_code(
-                    $override_contents,
-                    Config::AST_VERSION
-                );
+                $cache_entry = FileCache::addEntry($file_path, $override_contents);
             } else {
-                $node = \ast\parse_file(
-                    Config::projectPath($file_path),
-                    Config::AST_VERSION
-                );
+                $cache_entry = FileCache::getOrReadEntry($file_path);
             }
+            $file_contents = $cache_entry->getContents();
+            if ($file_contents === '') {
+                // php-ast would return null for 0 byte files as an implementation detail.
+                // Make Phan consistently emit this warning.
+                Issue::maybeEmit(
+                    $code_base,
+                    $context,
+                    Issue::EmptyFile,
+                    0,
+                    $file_path
+                );
+
+                return $context;
+            }
+            $node = \ast\parse_code(
+                $file_contents,
+                Config::AST_VERSION
+            );
         } catch (\ParseError $parse_error) {
             if ($suppress_parse_errors) {
                 return $context;
@@ -70,6 +84,27 @@ class Analysis
                 Issue::SyntaxError,
                 $parse_error->getLine(),
                 $parse_error->getMessage()
+            );
+
+            return $context;
+        }
+
+        if (Config::getValue('dump_ast')) {
+            echo $file_path . "\n"
+                . str_repeat("\u{00AF}", strlen($file_path))
+                . "\n";
+            Debug::printNode($node);
+            return $context;
+        }
+
+        if (empty($node)) {
+            // php-ast would return an empty node for 0 byte files.
+            Issue::maybeEmit(
+                $code_base,
+                $context,
+                Issue::EmptyFile,
+                0,
+                $file_path
             );
 
             return $context;
@@ -90,25 +125,6 @@ class Analysis
             }
         }
 
-        if (Config::getValue('dump_ast')) {
-            echo $file_path . "\n"
-                . str_repeat("\u{00AF}", strlen($file_path))
-                . "\n";
-            Debug::printNode($node);
-            return $context;
-        }
-
-        if (empty($node)) {
-            Issue::maybeEmit(
-                $code_base,
-                $context,
-                Issue::EmptyFile,
-                0,
-                $file_path
-            );
-
-            return $context;
-        }
 
         return self::parseNodeInContext(
             $code_base,
@@ -325,15 +341,16 @@ class Analysis
      * @param CodeBase $code_base
      * The global code base holding all state
      *
-     * @param string $file_path
-     * A list of files to scan
+     * @param ?string $override_contents
+     * If this is not null, this function will act as if $file_path's contents
+     * were $override_contents
      *
      * @return Context
      */
     public static function analyzeFile(
         CodeBase $code_base,
         string $file_path,
-        string $file_contents_override = null
+        string $override_contents = null
     ) : Context {
         // Set the file on the context
         $context = (new Context)->withFile($file_path);
@@ -342,17 +359,29 @@ class Analysis
         // before passing it on to the recursive version
         // of this method
         try {
-            if (\is_string($file_contents_override)) {
-                $node = \ast\parse_code(
-                    $file_contents_override,
-                    Config::AST_VERSION
-                );
+            if (\is_string($override_contents)) {
+                $cache_entry = FileCache::addEntry($file_path, $override_contents);
             } else {
-                $node = \ast\parse_file(
-                    Config::projectPath($file_path),
-                    Config::AST_VERSION
-                );
+                $cache_entry = FileCache::getOrReadEntry($file_path);
             }
+            $file_contents = $cache_entry->getContents();
+            if ($file_contents === '') {
+                // php-ast would return null for 0 byte files as an implementation detail.
+                // Make Phan consistently emit this warning.
+                Issue::maybeEmit(
+                    $code_base,
+                    $context,
+                    Issue::EmptyFile,
+                    0,
+                    $file_path
+                );
+
+                return $context;
+            }
+            $node = \ast\parse_code(
+                $file_contents,
+                Config::AST_VERSION
+            );
         } catch (\ParseError $parse_error) {
             Issue::maybeEmit(
                 $code_base,

--- a/src/Phan/Daemon.php
+++ b/src/Phan/Daemon.php
@@ -2,6 +2,7 @@
 namespace Phan;
 
 use Phan\Daemon\Request;
+use Phan\Library\FileCache;
 
 /**
  * an analyzing daemon, to be used by IDEs.

--- a/src/Phan/Daemon/Request.php
+++ b/src/Phan/Daemon/Request.php
@@ -7,6 +7,7 @@ use Phan\Config;
 use Phan\Daemon;
 use Phan\Language\FileRef;
 use Phan\Language\Type;
+use Phan\Library\FileCache;
 use Phan\Output\IssuePrinterInterface;
 use Phan\Output\PrinterFactory;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -229,6 +230,7 @@ class Request {
      * @return Request|null - non-null if this is a worker process with work to do. null if request failed or this is the master.
      */
     public static function accept(CodeBase $code_base, \Closure $file_path_lister, $conn) {
+        FileCache::clear();
         Daemon::debugf("Got a connection");  // debugging code
         // Efficient for large strings, e.g. long file lists.
         $data = [];
@@ -237,6 +239,7 @@ class Request {
         }
         $request_bytes = implode('', $data);
         $request = json_decode($request_bytes, true);
+
         if (!\is_array($request)) {
             Daemon::debugf("Received invalid request, expected JSON: %s", json_encode($request_bytes));
             self::sendJSONResponseOverSocket($conn, [

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -438,6 +438,7 @@ class Type
             'E_ALL'                 => $int,
             'E_STRICT'              => $int,
             '__COMPILER_HALT_OFFSET__' => $int,
+            '__LINE__'              => $int,
             'TRUE'                  => $true,
             'FALSE'                 => $false,
             'NULL'                  => $null,

--- a/src/Phan/Library/FileCache.php
+++ b/src/Phan/Library/FileCache.php
@@ -1,0 +1,101 @@
+<?php declare(strict_Types=1);
+namespace Phan\Library;
+
+/**
+ * An LRU cache for the contents of files (FileCacheEntry), and data structures derived from contents of files.
+ */
+final class FileCache {
+    const MINIMUM_CACHE_SIZE = 5;
+    /**
+     * @var int - Maximum cache size
+     */
+    private static $max_size;
+
+    /**
+     * @var FileCacheEntry[] - An ordered php associative array, with most recently used at the end of the array.
+     */
+    private static $cache_entries = [];
+
+    public static function setMaxCacheSize(int $max_size) {
+        self::$max_size = max($max_size, self::MINIMUM_CACHE_SIZE);
+        while (\count(self::$cache_entries) > self::$max_size) {
+            \array_shift(self::$cache_entries);
+        }
+    }
+
+    /**
+     * @return FileCacheEntry
+     */
+    public static function addEntry(string $file_name, string $contents) : FileCacheEntry {
+        $old_entry = self::$cache_entries[$file_name] ?? null;
+        if ($old_entry) {
+            unset(self::$cache_entries[$file_name]);
+            if ($old_entry->getContents() === $contents) {
+                // If the contents didn't change, keep the cache entry and move it to the end (Most recently used).
+                self::$cache_entries[$file_name] = $old_entry;
+                return $old_entry;
+            }
+        }
+        $entry = new FileCacheEntry($contents);
+        self::$cache_entries[$file_name] = $entry;
+        if (\count(self::$cache_entries) > self::$max_size) {
+            // Ensure that the size <= self::$max_size. Remove the least recently used entry (front of list).
+            \array_shift(self::$cache_entries);
+        }
+        return $entry;
+    }
+
+    /**
+     * @return ?FileCacheEntry
+     */
+    public static function getEntry(string $file_name) {
+        $entry = self::$cache_entries[$file_name] ?? null;
+        if ($entry) {
+            // Move the entry to the end (most recently used) and return it.
+            unset(self::$cache_entries[$file_name]);
+            self::$cache_entries[$file_name] = $entry;
+            return $entry;
+        }
+        return null;
+    }
+
+    /**
+     * @throws \RuntimeException if the file could not be loaded
+     * @return FileCacheEntry
+     */
+    public static function getOrReadEntry(string $file_name) : FileCacheEntry
+    {
+        $entry = self::getEntry($file_name);
+        if ($entry !== null) {
+            return $entry;
+        }
+        if (!\file_exists($file_name)) {
+            throw new \RuntimeException("FileCache::getOrReadEntry: unable to find '$file_name'\n");
+        }
+        if (!\is_readable($file_name)) {
+            throw new \RuntimeException("FileCache::getOrReadEntry: unable to read '$file_name'\n");
+        }
+        $contents = file_get_contents($file_name);
+        if (!\is_string($contents)) {
+            throw new \RuntimeException("FileCache::getOrReadEntry: file_get_contents failed for '$file_name'\n");
+        }
+        assert(\is_string($contents));
+        $entry = self::addEntry($file_name, $contents);
+        return $entry;
+    }
+
+    /**
+     * Clear the cache (E.g. after pausing, accepting a daemon mode request, then resuming)
+     * @return void
+     */
+    public static function clear() {
+        self::$cache_entries = [];
+    }
+
+    /**
+     * @return string[] list of file paths with most recently used entries at the end.
+     */
+    public static function getCachedFileList() : array {
+        return array_keys(self::$cache_entries);
+    }
+}

--- a/src/Phan/Library/FileCacheEntry.php
+++ b/src/Phan/Library/FileCacheEntry.php
@@ -1,0 +1,46 @@
+<?php declare(strict_Types=1);
+namespace Phan\Library;
+
+class FileCacheEntry {
+    /** @var string contents of the file */
+    private $contents;
+    /**
+     * @var ?array lines of the contents of the file. Lazily populated.
+     */
+    private $lines = null;
+
+    public function __construct(string $contents) {
+        $this->contents = $contents;
+    }
+
+    public function getContents() : string {
+        return $this->contents;
+    }
+
+    /**
+     * @return string[] a 1-based array of lines
+     */
+    public function getLines() : array {
+        $lines = $this->lines;
+        if (is_array($lines)) {
+            return $lines;
+        }
+        $lines = preg_split("/^/m", $this->contents);
+        unset($lines[0]);
+        $this->lines = $lines;
+        return $lines;
+    }
+
+
+    /**
+     * Helper method to get individual lines from a file.
+     * This is more efficient than using \SplFileObject if multiple lines may need to be fetched.
+     *
+     * @param int $lineno - A line number, starting with line 1
+     * @return ?string
+     */
+    public function getLine(int $lineno) {
+        $lines = $this->getLines();
+        return $lines[$lineno] ?? null;
+    }
+}

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -2,6 +2,7 @@
 namespace Phan;
 
 use Phan\Daemon\Request;
+use Phan\Library\FileCache;
 use Phan\Output\BufferedPrinterInterface;
 use Phan\Output\Collector\BufferingCollector;
 use Phan\Output\IgnoredFilesFilterInterface;
@@ -76,6 +77,7 @@ class Phan implements IgnoredFilesFilterInterface {
         CodeBase $code_base,
         \Closure $file_path_lister
     ) : bool {
+        FileCache::setMaxCacheSize(FileCache::MINIMUM_CACHE_SIZE);
         self::checkForSlowPHPOptions();
         $is_daemon_request = Config::getValue('daemonize_socket') || Config::getValue('daemonize_tcp_port');
         if ($is_daemon_request) {

--- a/tests/Phan/Library/FileCacheTest.php
+++ b/tests/Phan/Library/FileCacheTest.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types = 1);
+namespace Phan\Tests\Library;
+
+use Phan\Tests\BaseTest;
+use Phan\Library\FileCache;
+
+/**
+ */
+class FileCacheTest extends BaseTest
+{
+    const MOCK_PATH = '/path/to/a';
+    const MOCK_CONTENTS = "Mock contents\nOther lines\n";
+
+    public function setUp() {
+        parent::setUp();
+        FileCache::clear();
+        FileCache::setMaxCacheSize(FileCache::MINIMUM_CACHE_SIZE);
+    }
+
+    public function tearDown() {
+        parent::setUp();
+        FileCache::clear();
+    }
+
+    public function testAddRead()
+    {
+        $entry = FileCache::addEntry(self::MOCK_PATH, self::MOCK_CONTENTS);
+        $read_entry = FileCache::getEntry(self::MOCK_PATH);
+        $this->assertSame($read_entry, $entry);
+        $this->assertSame(self::MOCK_CONTENTS, $entry->getContents());
+        $this->assertSame([1 => "Mock contents\n", 2 => "Other lines\n"], $entry->getLines());
+        $this->assertSame("Other lines\n", $entry->getLine(2));
+        $this->assertNull($entry->getLine(3));
+        $this->assertNull($entry->getLine(0));
+    }
+
+    public function testLRU()
+    {
+        $expectedPaths = [];
+        $this->assertTrue(FileCache::MINIMUM_CACHE_SIZE >= 5);
+        for ($i = 0; $i < FileCache::MINIMUM_CACHE_SIZE; $i++) {
+            $path = "/path/to/$i";
+            $expectedPaths[] = $path;
+            FileCache::addEntry($path, "contents of $i");
+        }
+        $this->assertSame($expectedPaths, FileCache::getCachedFileList());
+
+        $this->assertSame("contents of 0", FileCache::getEntry("/path/to/0")->getContents());
+
+        $firstEntry = array_shift($expectedPaths);
+        $expectedPaths[] = $firstEntry;
+        $this->assertSame($expectedPaths, FileCache::getCachedFileList());
+
+        FileCache::addEntry("/path/to/extra", "Other contents");
+        $this->assertNull(FileCache::getEntry("/path/to/1"), "Least recently used entry should be evicted");
+        $this->assertSame("Other contents", FileCache::getEntry("/path/to/extra")->getContents(), "Most recently inserted entry should be kept");
+        $this->assertSame("contents of 2", FileCache::getEntry("/path/to/2")->getContents(), "Second least recently used entry should be kept");
+    }
+
+    public function testGetOrReadEntry() {
+        $this->assertNull(FileCache::getEntry(__FILE__));
+        $line = __LINE__;  // Comment placeholder
+        $expectedLineContents = "        \$line = __LINE__;  // Comment placeholder\n";
+        $entry = FileCache::getOrReadEntry(__FILE__);
+        $this->assertSame($expectedLineContents, $entry->getLine($line));
+    }
+
+    public function testGetOrReadEntryThrows() {
+        try {
+            FileCache::getOrReadEntry('/path/to/missingfile');
+            $this->fail('should throw');
+        } catch (\RuntimeException $e) {
+            $this->assertContains('FileCache::getOrReadEntry: unable to find', $e->getMessage());
+        }
+    }
+}


### PR DESCRIPTION
1. Cache the file contents.
   This is moderately useful when reading the same file twice in a row,
   in daemon mode.
2. Cache multiple files at the same time.
   When `quick_mode` is false, multiple files may be fetched while
   analyzing the same file. Currently, only the backwards compatibility
   checks need this, but more things may use FileCache in the future.
2. Lazily cache the lines of a file.
   This is useful for backwards_compatibility_check
   - The SPLFileObject doesn't need to be opened.
   - If multiple nodes have to be checked for syntax incompatibilities in
     the same file, then it's faster to look up lines if there's more
     than one (or the same line is processed multiple times)

Also, make Phan stop relying on php-ast implementation details to emit
PhanEmptyFile.

This relies on PHP's array ordering -
The most recently added entry to an array will always be at the end
of the array, and the least recently added will be at the front,
and can be removed by array_shift

Fixes #842