### PR TITLE
Always dump flags of ASTs if non-zero.

### DIFF
--- a/src/Phan/Debug.php
+++ b/src/Phan/Debug.php
@@ -237,7 +237,7 @@ class Debug
                 }
             }
 
-            if (\ast\kind_uses_flags($ast->kind)) {
+            if (\ast\kind_uses_flags($ast->kind) || $ast->flags != 0) {
                 $result .= "\n    flags: " . self::formatFlags($ast->kind, $ast->flags);
             }
             if ($ast instanceof \ast\Node\Decl && isset($ast->name)) {


### PR DESCRIPTION
Bring this up to date with f67f95d of php-ast

Only affects debug statements.