### PR TITLE
Narrow functions to their phpdoc return type if valid. Check individu…

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -78,13 +78,20 @@ return [
     'check_docblock_signature_param_type_match' => true,
 
     // (*Requires check_docblock_signature_param_type_match to be true*)
-    // If true, make narrowed types from phpdoc override
+    // If true, make narrowed types from phpdoc params override
     // the real types from the signature, when real types exist.
-    // Ignore incompatible or wider phpdoc union types.
     // (E.g. allows specifying desired lists of subclasses,
     //  or to indicate a preference for non-nullable types over nullable types)
     // Affects analysis of the body of the method and the param types passed in by callers.
-    'prefer_narrowed_phpdoc_param_types' => true,
+    'prefer_narrowed_phpdoc_param_type' => true,
+
+    // (*Requires check_docblock_signature_return_type_match to be true*)
+    // If true, make narrowed types from phpdoc returns override
+    // the real types from the signature, when real types exist.
+    // (E.g. allows specifying desired lists of subclasses,
+    //  or to indicate a preference for non-nullable types over nullable types)
+    // Affects analysis of return statements in the body of the method and the return types passed in by callers.
+    'prefer_narrowed_phpdoc_return_type' => true,
 
     // If enabled, check all methods that override a
     // parent method to make sure its signature is

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,20 @@
 Phan NEWS
 
+?? ??? 2017, Phan 0.9.4 (dev)
+-----------------------
+
+New Features (Analysis)
++ Check (the first 5) elements of returned arrays against the declared return union types, individually(#935)
+  (E.g. `/** @return int[] */ function foo() {return [2, "x"]; }` will now warn with `PhanTypeMismatchReturn` about returning `string[]`)
++ Check both sides of ternary conditionals against the declared return union types
+  (E.g. `function foo($x) : int {return is_string($x) ? $x : 0; }` will now warn with `PhanTypeMismatchReturn`
+  about returning a string).
+
+New Features (CLI, Configs)
++ Add config setting `prefer_narrowed_phpdoc_return_type` (See "New Features (CLI, Configs)),
+  which will use only the phpdoc return types for inferences, if they're narrowed.
+  This config is enabled by default, and requires `check_docblock_signature_return_type_match` to be enabled.
+
 Bug Fixes
 + Work around notice about COMPILER_HALT_OFFSET on windows.
 

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -516,7 +516,7 @@ class UnionTypeVisitor extends AnalysisVisitor
      * @param int|float|string|Node $cond
      * @return ?bool
      */
-    private function checkCondUnconditionalTruthiness($cond) {
+    public static function checkCondUnconditionalTruthiness($cond) {
         if ($cond instanceof Node) {
             if ($cond->kind === \ast\AST_CONST) {
                 $name = $cond->children['name'];
@@ -559,7 +559,7 @@ class UnionTypeVisitor extends AnalysisVisitor
     public function visitConditional(Node $node) : UnionType
     {
         $cond_node = $node->children['cond'];
-        $cond_truthiness = $this->checkCondUnconditionalTruthiness($cond_node);
+        $cond_truthiness = self::checkCondUnconditionalTruthiness($cond_node);
         // For the shorthand $a ?: $b, the cond node will be the truthy value.
         // Note: an ast node will never be null(can be unset), it will be a const AST node with the name null.
         $true_node = $node->children['true'] ?? $cond_node;

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -797,7 +797,7 @@ class ParameterTypesAnalyzer
      *           if Phan should proceed using phpdoc type instead of real types. (Converting T|null to ?T)
      *         - null if the type is an invalid narrowing, and Phan should warn.
      */
-    private static function normalizeNarrowedParamType(UnionType $phpdoc_param_union_type, UnionType $real_param_type)
+    public static function normalizeNarrowedParamType(UnionType $phpdoc_param_union_type, UnionType $real_param_type)
     {
         // "@param null $x" is almost always a mistake. Forbid it for now.
         // But allow "@param T|null $x"

--- a/src/Phan/Analysis/ReturnTypesAnalyzer.php
+++ b/src/Phan/Analysis/ReturnTypesAnalyzer.php
@@ -12,6 +12,7 @@ use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\Type\IterableType;
 use Phan\Language\Type\MixedType;
 use Phan\Language\Type\TemplateType;
+use Phan\Language\UnionType;
 
 class ReturnTypesAnalyzer
 {
@@ -26,7 +27,9 @@ class ReturnTypesAnalyzer
         FunctionInterface $method
     ) {
         $real_return_type = $method->getRealReturnType();
-        $phpdoc_return_type = $method->getUnionType();
+        $phpdoc_return_type = $method->getPHPDocReturnType();
+        // TODO: use method->getPHPDocUnionType() to check compatibility, like analyzeParameterTypesDocblockSignaturesMatch
+
         // Look at each parameter to make sure their types
         // are valid
 
@@ -66,19 +69,19 @@ class ReturnTypesAnalyzer
                 }
             }
         }
-        if (Config::getValue('check_docblock_signature_return_type_match') && !$real_return_type->isEmpty() && !$phpdoc_return_type->isEmpty()) {
+        if (Config::getValue('check_docblock_signature_return_type_match') && !$real_return_type->isEmpty() && ($phpdoc_return_type instanceof UnionType) && !$phpdoc_return_type->isEmpty()) {
             $context = $method->getContext();
             $resolved_real_return_type = $real_return_type->withStaticResolvedInContext($context);
             foreach ($phpdoc_return_type->getTypeSet() as $phpdoc_type) {
+                $is_exclusively_narrowed = $phpdoc_type->isExclusivelyNarrowedFormOrEquivalentTo(
+                    $resolved_real_return_type,
+                    $context,
+                    $code_base
+                );
                 // Make sure that the commented type is a narrowed
                 // or equivalent form of the syntax-level declared
                 // return type.
-                if (!$phpdoc_type->isExclusivelyNarrowedFormOrEquivalentTo(
-                        $resolved_real_return_type,
-                        $context,
-                        $code_base
-                    )
-                ) {
+                if (!$is_exclusively_narrowed) {
                     if (!$method->hasSuppressIssue(Issue::TypeMismatchDeclaredReturn)) {
                         Issue::maybeEmit(
                             $code_base,
@@ -89,6 +92,26 @@ class ReturnTypesAnalyzer
                             $phpdoc_type->__toString(),
                             $real_return_type->__toString()
                         );
+                    }
+                }
+                if ($is_exclusively_narrowed && Config::getValue('prefer_narrowed_phpdoc_return_type')) {
+                    $normalized_phpdoc_return_type = ParameterTypesAnalyzer::normalizeNarrowedParamType($phpdoc_return_type, $real_return_type);
+                    if ($normalized_phpdoc_return_type) {
+                        $method->setUnionType($normalized_phpdoc_return_type);
+                    } else {
+                        // This check isn't urgent to fix, and is specific to nullable casting rules,
+                        // so use a different issue type.
+                        if (!$method->hasSuppressIssue(Issue::TypeMismatchDeclaredReturnNullable)) {
+                            Issue::maybeEmit(
+                                $code_base,
+                                $context,
+                                Issue::TypeMismatchDeclaredReturnNullable,
+                                $context->getLineNumberStart(),
+                                $method->getName(),
+                                $phpdoc_type->__toString(),
+                                $real_return_type->__toString()
+                            );
+                        }
                     }
                 }
             }

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -220,12 +220,20 @@ class Config
         'check_docblock_signature_param_type_match' => true,
 
         // (*Requires check_docblock_signature_param_type_match to be true*)
-        // If true, make narrowed types from phpdoc override
+        // If true, make narrowed types from phpdoc params override
         // the real types from the signature, when real types exist.
         // (E.g. allows specifying desired lists of subclasses,
         //  or to indicate a preference for non-nullable types over nullable types)
         // Affects analysis of the body of the method and the param types passed in by callers.
         'prefer_narrowed_phpdoc_param_type' => true,
+
+        // (*Requires check_docblock_signature_return_type_match to be true*)
+        // If true, make narrowed types from phpdoc returns override
+        // the real types from the signature, when real types exist.
+        // (E.g. allows specifying desired lists of subclasses,
+        //  or to indicate a preference for non-nullable types over nullable types)
+        // Affects analysis of return statements in the body of the method and the return types passed in by callers.
+        'prefer_narrowed_phpdoc_return_type' => true,
 
         // Set to true in order to attempt to detect dead
         // (unreferenced) code. Keep in mind that the

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -66,6 +66,7 @@ class Issue
     const TypeMismatchProperty      = 'PhanTypeMismatchProperty';
     const TypeMismatchReturn        = 'PhanTypeMismatchReturn';
     const TypeMismatchDeclaredReturn = 'PhanTypeMismatchDeclaredReturn';
+    const TypeMismatchDeclaredReturnNullable = 'PhanTypeMismatchDeclaredReturnNullable';
     const TypeMismatchDeclaredParam = 'PhanTypeMismatchDeclaredParam';
     const TypeMismatchDeclaredParamNullable = 'PhanTypeMismatchDeclaredParamNullable';
     const TypeMissingReturn         = 'PhanTypeMissingReturn';
@@ -704,6 +705,14 @@ class Issue
                 "Doc-block of {METHOD} contains declared return type {TYPE} which is incompatible with the return type {TYPE} declared in the signature",
                 self::REMEDIATION_B,
                 10020
+            ),
+            new Issue(
+                self::TypeMismatchDeclaredReturnNullable,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "Doc-block of {METHOD} has declared return type {TYPE} which is not a permitted replacement of the nullable return type {TYPE} declared in the signature ('?T' should be documented as 'T|null' or '?T')",
+                self::REMEDIATION_B,
+                10028
             ),
             new Issue(
                 self::TypeMismatchDeclaredParam,

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -42,14 +42,14 @@ class Clazz extends AddressableElement
     private $parent_type = null;
 
     /**
-     * @var \Phan\Language\FQSEN[]
+     * @var \Phan\Language\FullyQualifiedClassName[]
      * A possibly empty list of interfaces implemented
      * by this class
      */
     private $interface_fqsen_list = [];
 
     /**
-     * @var \Phan\Language\FQSEN[]
+     * @var \Phan\Language\FullyQualifiedClassName[]
      * A possibly empty list of traits used by this class
      */
     private $trait_fqsen_list = [];
@@ -548,7 +548,7 @@ class Clazz extends AddressableElement
     }
 
     /**
-     * @return FQSEN[]
+     * @return FullyQualifiedClassName[]
      * Get the list of interfaces implemented by this class
      */
     public function getInterfaceFQSENList() : array
@@ -1490,7 +1490,7 @@ class Clazz extends AddressableElement
     }
 
     /**
-     * @return FQSEN[]
+     * @return FullyQualifiedClassName[]
      * A list of FQSEN's for included traits
      */
     public function getTraitFQSENList() : array

--- a/src/Phan/Language/Element/Func.php
+++ b/src/Phan/Language/Element/Func.php
@@ -251,6 +251,7 @@ class Func extends AddressableElement implements FunctionInterface
                 "Function referencing self in $context");
 
             $func->getUnionType()->addUnionType($union_type);
+            $func->setPHPDocReturnType($union_type);
         }
 
         // Add params to local scope for user functions

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -213,6 +213,17 @@ interface FunctionInterface extends AddressableElementInterface {
     public function getPHPDocParameterTypeMap();
 
     /**
+     * @param ?UnionType the raw phpdoc union type
+     * @return void
+     */
+    public function setPHPDocReturnType($parameter_map);
+
+    /**
+     * @return ?UnionType the raw phpdoc union type
+     */
+    public function getPHPDocReturnType();
+
+    /**
      * @return bool
      * True if this function or method returns a reference
      */

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -106,6 +106,13 @@ trait FunctionTrait {
     private $phpdoc_parameter_type_map = [];
 
     /**
+     * @var ?UnionType
+     * The unmodified *phpdoc* union type for this method.
+     * Will be null without any (at)return statements.
+     */
+    private $phpdoc_return_type;
+
+    /**
      * @var UnionType
      * The *real* (not from phpdoc) return type from this method.
      * This does not change after initialization.
@@ -635,6 +642,23 @@ trait FunctionTrait {
     public function getPHPDocParameterTypeMap()
     {
         return $this->phpdoc_parameter_type_map;
+    }
+
+    /**
+     * @param ?UnionType $type the raw phpdoc union type
+     * @return void
+     */
+    public function setPHPDocReturnType($type)
+    {
+        $this->phpdoc_return_type = $type;
+    }
+
+    /**
+     * @return ?UnionType the raw phpdoc union type
+     */
+    public function getPHPDocReturnType()
+    {
+        return $this->phpdoc_return_type;
     }
 
     /**

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -447,6 +447,7 @@ class Method extends ClassElement implements FunctionInterface
             }
 
             $method->getUnionType()->addUnionType($comment_return_union_type);
+            $method->setPHPDocReturnType($comment_return_union_type);
         }
 
         // Add params to local scope for user functions

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -328,7 +328,7 @@ final class ConfigPluginSet extends PluginV2 implements
     }
 
     /**
-     * @return \Closure[][] - [function(CodeBase $code_base, Context $context, Node $node, Node $parent_node = null): void]
+     * @return \Closure[] - [function(CodeBase $code_base, Context $context, Node $node, Node $parent_node = null): void]
      * @var \Closure[][] $closures_for_kind
      * @suppress PhanNonClassMethodCall
      */

--- a/tests/files/expected/0195_trait_return_type_self.php.expected
+++ b/tests/files/expected/0195_trait_return_type_self.php.expected
@@ -1,2 +1,2 @@
-%s:27 PhanUndeclaredMethod Call to undeclared method \B::z
+%s:27 PhanUndeclaredMethod Call to undeclared method \A::z
 %s:28 PhanUndeclaredMethod Call to undeclared method \A::z

--- a/tests/files/expected/0253_return_type_match.php.expected
+++ b/tests/files/expected/0253_return_type_match.php.expected
@@ -2,5 +2,6 @@
 %s:21 PhanTypeMismatchDeclaredReturn Doc-block of a5 contains declared return type iterable which is incompatible with the return type array declared in the signature
 %s:33 PhanTypeMismatchDeclaredReturn Doc-block of a8 contains declared return type string which is incompatible with the return type iterable declared in the signature
 %s:42 PhanTypeMismatchDeclaredReturn Doc-block of a10 contains declared return type ?int which is incompatible with the return type int declared in the signature
+%s:47 PhanTypeMismatchDeclaredReturnNullable Doc-block of a11 has declared return type int which is not a permitted replacement of the nullable return type ?int declared in the signature ('?T' should be documented as 'T|null' or '?T')
 %s:57 PhanTypeMismatchDeclaredReturn Doc-block of f6 contains declared return type \C253_1 which is incompatible with the return type \C253_2 declared in the signature
 %s:61 PhanTypeMismatchDeclaredReturn Doc-block of f7 contains declared return type \C253_1 which is incompatible with the return type \C253_2 declared in the signature

--- a/tests/files/expected/0339_bad_arrayreturn.php.expected
+++ b/tests/files/expected/0339_bad_arrayreturn.php.expected
@@ -1,0 +1,2 @@
+%s:6 PhanTypeMismatchReturn Returning type int[][] but testarrayreturn() is declared to return int[]
+%s:6 PhanTypeMismatchReturn Returning type string[] but testarrayreturn() is declared to return int[]

--- a/tests/files/expected/0340_badternary_return.php.expected
+++ b/tests/files/expected/0340_badternary_return.php.expected
@@ -1,0 +1,4 @@
+%s:4 PhanTypeMismatchReturn Returning type string but foo340() is declared to return int
+%s:8 PhanTypeMismatchReturn Returning type array but foo340b() is declared to return int
+%s:8 PhanTypeMismatchReturn Returning type bool but foo340b() is declared to return int
+%s:12 PhanTypeMismatchReturn Returning type string but foo() is declared to return int

--- a/tests/files/src/0195_trait_return_type_self.php
+++ b/tests/files/src/0195_trait_return_type_self.php
@@ -1,7 +1,7 @@
 <?php
 trait B {
     abstract function f();
-    /** @return static : TODO: Make phan recognize that @return static overrides real type of self */
+    /** @return static (Phan recognizes that `static` is a narrower form of `self`) */
     public function g(): self
     {
         return $this;

--- a/tests/files/src/0253_return_type_match.php
+++ b/tests/files/src/0253_return_type_match.php
@@ -27,7 +27,7 @@ class C253_1 {
     }
     /** @return Traversable (narrowing, allowed) */
     public function a7() : iterable {
-        return array('a', 'b', 'c');
+        yield 'a';
     }
     /** @return string (incompatible, not allowed) */
     public function a8() : iterable {
@@ -43,7 +43,7 @@ class C253_1 {
         return 42;
     }
 
-    /** @return int (narrowing) */
+    /** @return int (phpdoc narrowing, currently assumed to be a mistake) */
     public function a11() : ?int {
         return 42;
     }

--- a/tests/files/src/0339_bad_arrayreturn.php
+++ b/tests/files/src/0339_bad_arrayreturn.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * @return int[]
+ */
+function testarrayreturn() : array {
+    return [42, "value", [2]];
+}

--- a/tests/files/src/0340_badternary_return.php
+++ b/tests/files/src/0340_badternary_return.php
@@ -1,0 +1,14 @@
+<?php
+
+function foo340($x, int $y) : int {
+    return is_string($x) ? $x : $y;
+}
+
+function foo340b($x, $y, array $z) : int {
+    return is_string($x) ? ($y === true ?: strlen($x)) : $z;
+}
+class A340 {
+    function foo($x, int $y) : int {
+        return is_string($x) ? $x : $y;
+    }
+}


### PR DESCRIPTION
…al return statements.

Also, When returning a ternary operator or an array literal, check each
individual type (or generic array type) against the declared return
type.  (Fixes #935)

Fix issues detected with PHPDoc, where the phpdoc was too vague(FQSEN) or had
incorrect array dimensions (ConfigPluginSet)