### PR TITLE
Fix #1011; Start working on 0.9.4-dev

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,9 @@ Phan NEWS
 0.9.4 ??? ??, 2017 (dev)
 ------------------
 
+Bug Fixes
++ Work around notice about COMPILER_HALT_OFFSET on windows.
+
 0.9.3 Jul 11, 2017
 ------------------
 

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -16,7 +16,7 @@ class CLI
     /**
      * This should be updated to x.y.z-dev after every release, and x.y.z before a release.
      */
-    const PHAN_VERSION = '0.9.3';
+    const PHAN_VERSION = '0.9.4-dev';
 
     /**
      * @var OutputInterface

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -253,6 +253,10 @@ class CodeBase
                 $const_obj = GlobalConstant::fromGlobalConstantName($this, $const_name);
                 $this->addGlobalConstant($const_obj);
             } catch (\InvalidArgumentException $e) {
+                // Workaround for windows bug in #1011
+                if (\strncmp($const_name, "\0__COMPILER_HALT_OFFSET__\0", 26) === 0) {
+                    continue;
+                }
                 fprintf(STDERR, "Failed to load global constant value for %s, continuing: %s\n", var_export($const_name, true), $e->getMessage());
             }
         }


### PR DESCRIPTION
Don't print a notice for windows if __COMPILER_HALT_OFFSET__ for the
phan binary doesn't exist.
That constant is useless for analyzing other codebases.