### PR TITLE
Fixes #1015 : Check for rejected constant names.

### DIFF
--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -249,6 +249,11 @@ class CodeBase
     private function addGlobalConstantsByNames(array $const_name_list)
     {
         foreach ($const_name_list as $const_name) {
+            if (!$const_name) {
+                // #1015 workaround for empty constant names ('' and '0').
+                fprintf(STDERR, "Saw constant with empty name of %s. There may be a bug in a PECL extension you are using (php -m will list those)\n", var_export($const_name, true));
+                continue;
+            }
             try {
                 $const_obj = GlobalConstant::fromGlobalConstantName($this, $const_name);
                 $this->addGlobalConstant($const_obj);


### PR DESCRIPTION
This isn't mentioned in NEWS due to unlikeliness of encountering this
in common use cases. See the linked issue.

Tested locally by manually adding '0'