### PR TITLE
Use BlockExitStatusChecker to improve overall analysis of control flow.

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -395,6 +395,7 @@ return [
 
     // A list of plugin files to execute
     'plugins' => [
+        '.phan/plugins/AlwaysReturnPlugin.php',
         '.phan/plugins/DemoPlugin.php',
         '.phan/plugins/DollarDollarPlugin.php',
         // NOTE: src/Phan/Language/Internal/FunctionSignatureMap.php mixes value without key as return type with values having keys deliberately.

--- a/.phan/plugins/AlwaysReturnPlugin.php
+++ b/.phan/plugins/AlwaysReturnPlugin.php
@@ -1,0 +1,163 @@
+<?php declare(strict_types=1);
+
+use Phan\AST\AnalysisVisitor;
+use Phan\CodeBase;
+use Phan\Analysis\BlockExitStatusChecker;
+use Phan\Language\Context;
+use Phan\Language\Element\Func;
+use Phan\Language\Element\FunctionInterface;
+use Phan\Language\Element\Method;
+use Phan\Language\Type\NullType;
+use Phan\Language\Type\VoidType;
+use Phan\Language\UnionType;
+use Phan\PluginV2;
+use Phan\PluginV2\AnalyzeFunctionCapability;
+use Phan\PluginV2\AnalyzeMethodCapability;
+use ast\Node;
+
+/**
+ * This file checks if a function, closure or method unconditionally returns.
+ * If the function doesn't have a null, void, or nullable return type,
+ * then this plugin will emit an issue.
+ *
+ * It hooks into two events:
+ *
+ * - analyzeMethod
+ *   Once all methods are parsed, this method will be called
+ *   on every method in the code base
+ *
+ * - analyzeFunction
+ *   Once all functions have been parsed, this method will
+ *   be called on every function in the code base.
+ *
+ * A plugin file must
+ *
+ * - Contain a class that inherits from \Phan\Plugin
+ *
+ * - End by returning an instance of that class.
+ *
+ * It is assumed without being checked that plugins aren't
+ * mangling state within the passed code base or context.
+ *
+ * Note: When adding new plugins,
+ * add them to the corresponding section of README.md
+ */
+final class AlwaysReturnPlugin extends PluginV2 implements
+    AnalyzeFunctionCapability,
+    AnalyzeMethodCapability {
+
+    /**
+     * @param CodeBase $code_base
+     * The code base in which the method exists
+     *
+     * @param Method $method
+     * A method being analyzed
+     *
+     * @return void
+     *
+     * @override
+     */
+    public function analyzeMethod(
+        CodeBase $code_base,
+        Method $method
+    ) {
+        $stmts_list = $this->getStatementListToAnalyze($method);
+        if ($stmts_list === null) {
+            // check for abstract methods, generators, etc.
+            return;
+        }
+        if ($method->getFQSEN() !== $method->getDefiningFQSEN()) {
+            // Check if this was inherited by a descendant class.
+            return;
+        }
+
+        $return_type = $method->getUnionType();
+
+        if (self::returnTypeAllowsNull($return_type)) {
+            return;
+        }
+        if (!BlockExitStatusChecker::willUnconditionallyThrowOrReturn($stmts_list)) {
+            $this->emitIssue(
+                $code_base,
+                $method->getContext(),
+                'PhanPluginAlwaysReturnMethod',
+                "Method {METHOD} has a return type of {TYPE}, but may fail to return a value",
+                [(string)$method->getFQSEN(), (string)$return_type]
+            );
+        }
+    }
+
+    /**
+     * @param CodeBase $code_base
+     * The code base in which the function exists
+     *
+     * @param Func $function
+     * A function or closure being analyzed
+     *
+     * @return void
+     *
+     * @override
+     */
+    public function analyzeFunction(
+        CodeBase $code_base,
+        Func $function
+    ) {
+        $stmts_list = $this->getStatementListToAnalyze($function);
+        if ($stmts_list === null) {
+            // check for abstract methods, generators, etc.
+            return;
+        }
+
+        $return_type = $function->getUnionType();
+
+        if (self::returnTypeAllowsNull($return_type)) {
+            return;
+        }
+        if (!BlockExitStatusChecker::willUnconditionallyThrowOrReturn($stmts_list)) {
+            $this->emitIssue(
+                $code_base,
+                $function->getContext(),
+                'PhanPluginAlwaysReturnFunction',
+                "Function {FUNCTION} has a return type of {TYPE}, but may fail to return a value",
+                [(string)$function->getFQSEN(), (string)$return_type]
+            );
+        }
+    }
+
+    /**
+     * @param Func|Method $func
+     * @return ?\ast\Node - returns null if there's no statement list to analyze
+     */
+    private function getStatementListToAnalyze($func) {
+        if (!$func->hasNode()) {
+            return null;
+        } elseif ($func->getHasYield()) {
+            // generators always return Generator.
+            return null;
+        }
+        $node = $func->getNode();
+        if (!$node) {
+            return null;
+        }
+        assert($node->kind === \ast\AST_FUNC_DECL || $node->kind === \ast\AST_CLOSURE || $node->kind === \ast\AST_METHOD);
+        return $node->children['stmts'];
+    }
+
+    /**
+     * @param ?UnionType $return_type
+     * @return bool - Is void(absense of a return type) an acceptable return type.
+     * NOTE: projects can customize this as needed.
+     */
+    private function returnTypeAllowsNull($return_type) : bool
+    {
+        return $return_type instanceof UnionType &&
+            ($return_type->isEmpty()
+            || $return_type->containsNullable()
+            || $return_type->hasType(VoidType::instance(false))
+            || $return_type->hasType(NullType::instance(false)));
+    }
+}
+
+// Every plugin needs to return an instance of itself at the
+// end of the file in which its defined.
+return new AlwaysReturnPlugin;

--- a/.phan/plugins/README.md
+++ b/.phan/plugins/README.md
@@ -34,7 +34,7 @@ or if the relevant parts of the codebase fixed the bug/added annotations)
 
 - **UnusedSuppression**: "Element func/class/etc. suppresses issue Phan... but does not use it"
 
-### 2. General-Use Plugins 
+### 2. General-Use Plugins
 
 These plugins are useful across a wide variety of code styles, and should give low false positives.
 Also see [DollarDollarPlugin.php](#dollardollarpluginphp) for a meaningful real-world example.
@@ -43,12 +43,17 @@ Also see [DollarDollarPlugin.php](#dollardollarpluginphp) for a meaningful real-
 
 Warns about common errors in php array keys. Has the following checks (Doesn't try to resolve constants).
 
-- **PhanPluginDuplicateArrayKey**: a duplicate or equivalent array key literal 
+- **PhanPluginDuplicateArrayKey**: a duplicate or equivalent array key literal
 
   (E.g `[2 => "value", "other" => "s", "2" => "value2"]` duplicates the key `2`)
-- **PhanPluginMixedKeyNoKey**: mixing array entries of the form [key => value,] with entries of the form [value,]. 
+- **PhanPluginMixedKeyNoKey**: mixing array entries of the form [key => value,] with entries of the form [value,].
 
   (E.g. `['key' => 'value', 'othervalue']` is often found in code because the key for `'othervalue'` was forgotten)
+
+#### AlwaysReturnPlugin.php
+
+Checks if a function or method with a non-void return type will **unconditionally** return or throw.
+This is stricter than Phan's default checks (Phan accepts a function or method that **may** return something, or functions that unconditionally throw).
 
 ### 3. Plugins Specific to Code Styles
 

--- a/NEWS
+++ b/NEWS
@@ -4,13 +4,23 @@ Phan NEWS
 -----------------------
 
 New Features (Analysis)
-+ Check (the first 5) elements of returned arrays against the declared return union types, individually(#935)
++ Check (the first 5) elements of returned arrays against the declared return union types, individually (Issue #935)
   (E.g. `/** @return int[] */ function foo() {return [2, "x"]; }` will now warn with `PhanTypeMismatchReturn` about returning `string[]`)
 + Check both sides of ternary conditionals against the declared return union types
   (E.g. `function foo($x) : int {return is_string($x) ? $x : 0; }` will now warn with `PhanTypeMismatchReturn`
   about returning a string).
 + Improved analysis of negations of conditions within ternary conditional operators and else/else if statements. (Issue #538)
-  Support analysis of negation of the `||` operator.
+  Support analysis of negation of the `||` operator. (E.g. `if (!(is_string($x) || is_int($x))) {...}`)
++ Make phan aware of blocks of code which will unconditionally throw or return. (Issue #308, #817, #996, #956)
+
+  Don't infer variable types from blocks of code which unconditionally throw or return.
+
+  Infer the negation of type assertions from if statements that unconditionally throw/return (E.g. `if (!is_string($x)) { return false; } functionUsingX($x);`)
+
+  When checking if a variable is defined by all branches of an if statement, ignore branches which inconditionally throw/return.
++ Add a new plugin file `AlwaysReturnPlugin`. (Issue #996)
+  This will add a stricter check that a function with a non-null return type *unconditionally* returns a value (or explicitly throws, or exit()s).
+  Currently, Phan just checks if a function *may* return, or unconditionally throws.
 
 New Features (CLI, Configs)
 + Add config setting `prefer_narrowed_phpdoc_return_type` (See "New Features (CLI, Configs)),

--- a/NEWS
+++ b/NEWS
@@ -15,9 +15,10 @@ New Features (Analysis)
 
   Don't infer variable types from blocks of code which unconditionally throw or return.
 
-  Infer the negation of type assertions from if statements that unconditionally throw/return (E.g. `if (!is_string($x)) { return false; } functionUsingX($x);`)
+  Infer the negation of type assertions from if statements that unconditionally throw/return/break/continue 
+  (E.g. `if (!is_string($x)) { return false; } functionUsingX($x);`)
 
-  When checking if a variable is defined by all branches of an if statement, ignore branches which inconditionally throw/return.
+  When checking if a variable is defined by all branches of an if statement, ignore branches which inconditionally throw/return/break/continue.
 + Add a new plugin file `AlwaysReturnPlugin`. (Issue #996)
   This will add a stricter check that a function with a non-null return type *unconditionally* returns a value (or explicitly throws, or exit()s).
   Currently, Phan just checks if a function *may* return, or unconditionally throws.

--- a/src/Phan/AST/ASTSimplifier.php
+++ b/src/Phan/AST/ASTSimplifier.php
@@ -15,8 +15,8 @@ class ASTSimplifier {
     /** @var string - for debugging purposes */
     private $_filename;
 
-    public function __construct(\SplObjectStorage $exit_status_cache, string $filename = 'unknown') {
-        $this->_blockChecker = new BlockExitStatusChecker($exit_status_cache, $filename);
+    public function __construct(string $filename = 'unknown') {
+        $this->_blockChecker = new BlockExitStatusChecker();
         $this->_filename = $filename;
     }
 
@@ -429,7 +429,7 @@ class ASTSimplifier {
     }
 
     public static function applyStatic(Node $node, string $filename = 'unknown') : Node {
-        $rewriter = new self(new \SplObjectStorage(), $filename);
+        $rewriter = new self($filename);
         $nodes = $rewriter->apply($node);
         \assert(\count($nodes) === 1);
         return $nodes[0];

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -454,12 +454,8 @@ class UnionTypeVisitor extends AnalysisVisitor
             case \ast\flags\TYPE_VOID:
                 return VoidType::instance(false)->asUnionType();
             default:
-                \assert(
-                    false,
-                    "All flags must match. Found "
-                    . Debug::astFlagDescription($node->flags ?? 0, $node->kind)
-                );
-                break;
+                throw new \AssertionError("All flags must match. Found "
+                    . Debug::astFlagDescription($node->flags ?? 0, $node->kind));
         }
     }
 

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -828,8 +828,6 @@ class UnionTypeVisitor extends AnalysisVisitor
                 return $type;
             }
 
-            \assert($fqsen instanceof FullyQualifiedClassName);
-
             // If we don't have the class, we'll catch that problem
             // elsewhere
             if (!$this->code_base->hasClassWithFQSEN($fqsen)) {

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -90,13 +90,10 @@ class AssignmentVisitor extends AnalysisVisitor
      */
     public function visit(Node $node) : Context
     {
-        \assert(
-            false,
+        throw new \AssertionError(
             "Unknown left side of assignment in {$this->context} with node type "
             . Debug::nodeName($node)
         );
-
-        return $this->visitVar($node);
     }
 
     /**
@@ -294,7 +291,6 @@ class AssignmentVisitor extends AnalysisVisitor
                 // Super weird, right?
                 return $this->context;
             }
-            // assert(\is_string($dim), "dim is not a string");
 
             if (Variable::isHardcodedVariableInScopeWithName($dim, $this->context->isInGlobalScope())) {
                 // Don't override types of superglobals such as $_POST, $argv through $_GLOBALS['_POST'] = expr either. TODO: Warn.
@@ -332,8 +328,6 @@ class AssignmentVisitor extends AnalysisVisitor
         if (!\is_string($property_name)) {
             return $this->context;
         }
-
-        \assert(\is_string($property_name), "Property must be string");
 
         try {
             $class_list = (new ContextNode(
@@ -501,8 +495,6 @@ class AssignmentVisitor extends AnalysisVisitor
         if (!\is_string($property_name)) {
             return $this->context;
         }
-
-        \assert(\is_string($property_name), "Static property must be string");
 
         try {
             $class_list = (new ContextNode(

--- a/src/Phan/Analysis/BlockExitStatusChecker.php
+++ b/src/Phan/Analysis/BlockExitStatusChecker.php
@@ -11,27 +11,69 @@ use Phan\AST\Visitor\KindVisitorImplementation;
  * This caches the status for AST nodes, so references to this object
  * should be removed once the source transformation of a file/function is complete.
  *
+ * This uses the \ast\Node's themselves in order to cache the status.
+ * It reuses $node->flags whenever possible in order to avoid keeping around \ast\Node
+ * instances for longer than those would be used.
+ * This assumes that Nodes aren't manipulated, or manipulations to Nodes will preserve the semantics (including computed exit status) or clear $node->flags.
+ *
+ * - Creating an additional object property would increase overall memory usage, which is why properties are used.
+ * - AST_IF, AST_IF_ELEM, AST_DO_WHILE, AST_FOR, AST_WHILE, AST_STMT_LIST,
+ *   etc (e.g. switch and switch case, try/finally).
+ *   are node types which are known to not have flags in AST version 40.
+ * - In the future, add a new property such as $node->children['__exitStatus'] if used for a node type with flags, or use the higher bits.
+ *
  * TODO: Change to AnalysisVisitor if this ever emits issues.
  * TODO: Analyze switch (if there is a default) in another PR (And handle fallthrough)
  * TODO: Refactor this class to be able to express return values such as "This will return or break, but it won't throw".
  */
-class BlockExitStatusChecker extends KindVisitorImplementation {
-    const STATUS_PROCEED  = 1;  // At least one branch continues to completion.
-    const STATUS_CONTINUE = 2;  // All branches lead to a continue statement (Or possibly a break, throw, or return)
-    const STATUS_BREAK    = 3;  // All branches lead to a break statement (Or possibly a throw or return)
-    const STATUS_THROW    = 4;  // All branches lead to a throw statement (Or possibly a return)
-    const STATUS_RETURN   = 5;  // All branches lead to a return/exit statement
+final class BlockExitStatusChecker extends KindVisitorImplementation {
+    // These should be at most 1 << 31, in order to work in 32-bit php.
+    const STATUS_PROCEED        = (1 << 20);       // At least one branch continues to completion.
+    const STATUS_MAYBE_CONTINUE = (1 << 21);       // We are certain at least one branch does not continue to completion. At least one of those is a "continue;"
+    const STATUS_MAYBE_BREAK    = (1 << 22);       // We are certain at least one branch is a "break;", none are "continue;"
+    const STATUS_MAYBE_THROW    = (1 << 23);       // At least one branch is a "throw", none are break/continue
+    const STATUS_MAYBE_RETURN   = (1 << 24);       // At least one branch is a "return"/"exit", none are throw/break/continue
 
-    /** @var \SplObjectStorage - A shared cache, re-used while analyzing a given file. */
-    private $exit_status_cache;
-    /** @var string - filename, for debugging */
-    private $filename;
+    const STATUS_CONTINUE       = (1 << 25);       // All branches lead to a continue statement (Or possibly a break, throw, or return)
+    const STATUS_BREAK          = (1 << 26);       // All branches lead to a break statement (Or possibly a throw or return)
+    const STATUS_THROW          = (1 << 27);       // All branches lead to a throw statement (Or possibly a return)
+    const STATUS_RETURN         = (1 << 28);       // All branches lead to a return/exit statement
 
-    public function __construct(\SplObjectStorage $exit_status_cache, string $filename = 'unknown')
-    {
-        $this->exit_status_cache = $exit_status_cache;
-        $this->filename = $filename;
-    }
+    const STATUS_THROW_OR_RETURN_BITMASK = self::STATUS_THROW | self::STATUS_RETURN;
+
+    const STATUS_INTERESTING_SWITCH_BITMASK =
+        self::STATUS_MAYBE_THROW |
+        self::STATUS_MAYBE_RETURN |
+        self::STATUS_THROW |
+        self::STATUS_RETURN;
+
+    const STATUS_INTERESTING_TRY_BITMASK =
+        self::STATUS_MAYBE_CONTINUE |
+        self::STATUS_MAYBE_BREAK |
+        self::STATUS_CONTINUE |
+        self::STATUS_BREAK;
+
+    // Bitshift left by this to convert a possible status to a certain status;
+    const BITSHIFT_FOR_MAYBE = 4;
+
+    const STATUS_MAYBE_BITMASK =
+        self::STATUS_MAYBE_CONTINUE |
+        self::STATUS_MAYBE_BREAK |
+        self::STATUS_MAYBE_THROW |
+        self::STATUS_MAYBE_RETURN;
+
+    const STATUS_CERTAIN_BITMASK =
+        self::STATUS_CONTINUE |
+        self::STATUS_BREAK |
+        self::STATUS_THROW |
+        self::STATUS_RETURN;
+
+    const STATUS_BITMASK =
+        self::STATUS_PROCEED |
+        self::STATUS_MAYBE_BITMASK |
+        self::STATUS_CERTAIN_BITMASK;
+
+    public function __construct() { }
 
     public function check(Node $node = null) : int
     {
@@ -41,21 +83,6 @@ class BlockExitStatusChecker extends KindVisitorImplementation {
         $result = $this($node);
         \assert(\is_int($result), 'Expected int');
         return $result;
-    }
-
-    /**
-     * @param Node $node - The node to fetch the status of.
-     * @param \Closure $cb - Callable accepting a node and returning an exit status.
-     * @return int
-     */
-    private function memoizedStatus(Node $node, \Closure $cb)
-    {
-        if (isset($this->exit_status_cache[$node])) {
-            return $this->exit_status_cache[$node];  // Can't use null coalescing operator for SplObjectStorage due to a php bug. Fixed in 7.0.14
-        }
-        $status = $cb($node);
-        $this->exit_status_cache->offsetSet($node, $status);  // TODO: Change to regular field assignment after https://github.com/etsy/phan/issues/254 is fixed.
-        return $status;
     }
 
     /**
@@ -69,7 +96,13 @@ class BlockExitStatusChecker extends KindVisitorImplementation {
     private static function isTruthyLiteral($cond) : bool
     {
         if ($cond instanceof Node) {
-            // TODO: Could look up constants and inline expressions, but doing that has low value.
+            // TODO: Could look up values for remaining constants and inline expressions, but doing that has low value.
+            if ($cond->kind === \ast\AST_CONST) {
+                $condName = $cond->children['name'];
+                if ($condName->kind === \ast\AST_NAME) {
+                    return \strtolower($condName->children['name']) === 'true';
+                }
+            }
             return false;
         }
         // Cast string, int, etc. literal to a bool
@@ -94,6 +127,186 @@ class BlockExitStatusChecker extends KindVisitorImplementation {
         return self::STATUS_THROW;
     }
 
+    public function visitTry(Node $node)
+    {
+        $status = $node->flags & self::STATUS_BITMASK;
+        if ($status) {
+            return $status;
+        }
+        $status = $this->computeStatusOfTry($node);
+        $node->flags = $status;
+        return $status;
+    }
+
+    private function computeStatusOfTry(Node $node) : int
+    {
+        $main_status = $this->check($node->children['try']);
+        if ($main_status === self::STATUS_RETURN) {
+            return self::STATUS_RETURN;
+        }
+        $finally_node = $node->children['finally'];
+        if ($finally_node) {
+            $finally_status = $this->check($finally_node);
+            if ($finally_status >= self::STATUS_THROW) {
+                return $finally_status;
+            }
+        } else {
+            $finally_status = self::STATUS_PROCEED;
+        }
+        $catch_node_list = $node->children['catches']->children;
+        if (\count($catch_node_list) === 0) {
+            return self::mergeFinallyStatus($main_status, $finally_status);
+        }
+        // TODO: Check if each catch statement unconditionally returns?
+        if (($main_status & self::STATUS_INTERESTING_TRY_BITMASK) !== 0) {
+            // Not 100% certain of any status. If anything threw, it could be caught by the 1 or more catch statements..
+            if (($main_status & self::STATUS_CERTAIN_BITMASK) !== 0) {
+                return $main_status >> self::BITSHIFT_FOR_MAYBE;
+            }
+            return $main_status;
+        }
+        // No idea.
+        return self::STATUS_PROCEED;
+    }
+
+    private static function mergeFinallyStatus(int $try_status, int $finally_status) : int
+    {
+        if (($try_status & self::STATUS_CERTAIN_BITMASK) !== 0) {
+            return \max($try_status, $finally_status);
+        }
+        if (($finally_status & self::STATUS_CERTAIN_BITMASK) !== 0) {
+            return $finally_status;
+        }
+        return min($try_status, $finally_status);
+    }
+
+    public function visitSwitch(Node $node)
+    {
+        $status = $node->flags & self::STATUS_BITMASK;
+        if ($status) {
+            return $status;
+        }
+        $status = $this->computeStatusOfSwitch($node);
+        $node->flags = $status;
+        return $status;
+    }
+
+    private function computeStatusOfSwitch(Node $node) : int
+    {
+        $has_default = false;
+        $status = null;
+        $normal_break_is_possible = false;
+        $switch_stmt_case_nodes = $node->children['stmts']->children;
+        foreach ($switch_stmt_case_nodes as $index => $case_node) {
+            if (!array_key_exists('cond', $case_node->children)) {
+                \Phan\Debug::printNode($case_node);
+                continue;
+            }
+            if ($case_node->children['cond'] === null) {
+                $has_default = true;
+            }
+            $case_status = self::getStatusOfSwitchCase($case_node, $index, $switch_stmt_case_nodes);
+            if ($case_status & self::STATUS_INTERESTING_SWITCH_BITMASK) {
+                if (is_null($status) || $case_status < $status) {
+                    $status = $case_status;
+                }
+            } else {
+                // One of the case statements will break, or fall through to the end.
+                $normal_break_is_possible = true;
+            }
+        }
+        if ($status === null) {
+            return self::STATUS_PROCEED;
+        }
+        if (($status & self::STATUS_INTERESTING_SWITCH_BITMASK) === 0) {
+            return self::STATUS_PROCEED;
+        }
+        if ($normal_break_is_possible || !$has_default) {
+            if (($status & self::STATUS_CERTAIN_BITMASK) !== 0) {
+                // E.g. some of the case statements throw unconditionally, others break normally.
+                // So, the final result is that an interesting outcome such as throw/return is possible but not certain.
+                return $status >> self::BITSHIFT_FOR_MAYBE;
+            } else {
+                return $status;
+            }
+        }
+        // Ignore statuses such as break/continue. They take effect inside, not outside.
+        return $status;
+    }
+
+    /**
+     * @param Node[] $siblings
+     */
+    private function getStatusOfSwitchCase(Node $case_node, int $index, array $siblings) : int
+    {
+        $status = $case_node->flags & self::STATUS_BITMASK;
+        if ($status) {
+            return $status;
+        }
+        $status = $this->computeStatusOfSwitchCase($case_node, $index, $siblings);
+        $case_node->flags = $status;
+        return $status;
+    }
+
+    private function computeStatusOfSwitchCase(Node $case_node, int $index, array $siblings) : int
+    {
+        $status = $this->visitStmtList($case_node->children['stmts']);
+        if ($status & self::STATUS_CERTAIN_BITMASK) {
+            return $status;
+        }
+        $next_sibling = $siblings[$index + 1] ?? null;
+        if (!$next_sibling) {
+            return $status;
+        }
+        $next_status = self::getStatusOfSwitchCase($case_node, $index + 1, $siblings);
+        if ($status & self::STATUS_MAYBE_BITMASK) {
+            if ($next_status & self::STATUS_MAYBE_BITMASK) {
+                return min($status, $next_status);
+            } else if ($next_status & self::STATUS_CERTAIN_BITMASK) {
+                return min($status << self::BITSHIFT_FOR_MAYBE, $next_status);
+            }
+            // next_status === STATUS_PROCEED
+            return $status;
+        }
+        // STATUS_PROCEED | self::STATUS_CERTAIN_BITMASK
+        return $status;
+    }
+
+    public function visitWhile(Node $node)
+    {
+        return $this->analyzeLoop($node);
+    }
+
+    public function visitFor(Node $node)
+    {
+        return $this->analyzeLoop($node);
+    }
+
+    private function analyzeLoop(Node $node) : int
+    {
+        $status = $node->flags & self::STATUS_BITMASK;
+        if ($status) {
+            return $status;
+        }
+        $status = $this->computeStatusOfLoopWithTrueCond($node);
+        $node->flags = $status;
+        return $status;
+    }
+
+    private function computeStatusOfLoopWithTrueCond(Node $node) : int
+    {
+        // only know how to analyze "while (1) {exprs}" or "for (; true; ) {exprs}"
+        // TODO: identify infinite loops, mark those as STATUS_NO_PROCEED or STATUS_RETURN.
+        if (!self::isTruthyLiteral($node->children['cond'])) {
+            return self::STATUS_PROCEED;
+        }
+        $status = $this->check($node->children['stmts']);
+        if ($status === self::STATUS_RETURN || $status === self::STATUS_THROW) {
+            return $status;
+        }
+        return self::STATUS_PROCEED;
+    }
+
     // A return statement unconditionally returns (Assume expression doesn't throw)
     public function visitReturn(Node $node)
     {
@@ -113,9 +326,13 @@ class BlockExitStatusChecker extends KindVisitorImplementation {
      */
     public function visitStmtList(Node $node)
     {
-        return $this->memoizedStatus($node, function(Node $node) : int {
-            return $this->getStatusOfBlock($node->children ?? []);
-        });
+        $status = $node->flags & self::STATUS_BITMASK;
+        if ($status) {
+            return $status;
+        }
+        $status = $this->computeStatusOfBlock($node->children ?? []);
+        $node->flags = $status;
+        return $status;
     }
 
     // TODO: Check if for/while/foreach block will execute at least once.
@@ -128,26 +345,77 @@ class BlockExitStatusChecker extends KindVisitorImplementation {
      */
     private function analyzeBranched(Node $node)
     {
-        return $this->memoizedStatus($node, function(Node $node) : int {
-            // A do-while statement and an if branch are executed at least once (or exactly once)
-            // TODO: deduplicate
-            $stmts = $node->children['stmts'];
-            if (\is_null($stmts)) {
-                return self::STATUS_PROCEED;
-            }
-            // We can have a single statement in the 'stmts' field when no braces exist?
-            if (!($stmts instanceof Node)) {
-                return self::STATUS_PROCEED;
-            }
-            // This may be a statement list (or in rare cases, a statement?)
-            $status = $this->check($stmts);
-            if ($node->kind === \ast\AST_DO_WHILE) {
-                // ignore break/continue within a do{}while ($cond);
-                return in_array($status, [self::STATUS_THROW, self::STATUS_RETURN]) ? $status : self::STATUS_PROCEED;
-            }
+        $status = $node->flags & self::STATUS_BITMASK;
+        if ($status) {
             return $status;
-        });
+        }
+        $status = $this->computeStatusOfBranched($node);
+        $node->flags = $status;
+        return $status;
     }
+
+    public function computeStatusOfBranched(Node $node) : int {
+        // A do-while statement and an if branch are executed at least once (or exactly once)
+        // TODO: deduplicate
+        $stmts = $node->children['stmts'];
+        if (\is_null($stmts)) {
+            return self::STATUS_PROCEED;
+        }
+        // We can have a single statement in the 'stmts' field when no braces exist?
+        // TODO: no longer the case in ast version 40?
+        if (!($stmts instanceof Node)) {
+            return self::STATUS_PROCEED;
+        }
+        // This may be a statement list (or in rare cases, a statement?)
+        $status = $this->check($stmts);
+        if ($node->kind === \ast\AST_DO_WHILE) {
+            // ignore break/continue within a do{}while ($cond);
+            return in_array($status, [self::STATUS_THROW, self::STATUS_RETURN]) ? $status : self::STATUS_PROCEED;
+        }
+        return $status;
+    }
+
+    /**
+     * Analyzes a node with kind \ast\AST_IF
+     * @return int the exit status of a block (whether or not it would unconditionally exit, return, throw, etc.
+     * @override
+     */
+    public function visitIf(Node $node)
+    {
+        $status = $node->flags & self::STATUS_BITMASK;
+        if ($status) {
+            return $status;
+        }
+        $status = $this->computeStatusOfIf($node);
+        $node->flags = $status;
+        return $status;
+    }
+
+    private function computeStatusOfIf(Node $node) : int {
+        $has_if_elems_for_all_cases = false;
+        $min_status = self::STATUS_RETURN;
+        foreach ($node->children as $child_node) {
+            $status = $this->check($child_node->children['stmts']);
+            if ($status < $min_status) {
+                $min_status = $status;
+            }
+            if ($min_status === self::STATUS_PROCEED) {
+                break;
+            }
+
+            $cond_node = $child_node->children['cond'];
+            // check for "else" or "elseif (true)"
+            if ($cond_node === null || self::isTruthyLiteral($cond_node)) {
+                $has_if_elems_for_all_cases = true;
+                break;
+            }
+        }
+        if (!$has_if_elems_for_all_cases) {
+            return self::STATUS_PROCEED;
+        }
+        return $min_status;
+    }
+
 
     /**
      * Analyzes a node with kind \ast\AST_DO_WHILE
@@ -160,11 +428,27 @@ class BlockExitStatusChecker extends KindVisitorImplementation {
     }
 
     /**
+     * Analyzes a node with kind \ast\AST_IF_ELEM
+     * @return int the exit status of a block (whether or not it would unconditionally exit, return, throw, etc.
+     */
+    public function visitIfElem(Node $node)
+    {
+        $status = $node->flags & self::STATUS_BITMASK;
+        if ($status) {
+            return $status;
+        }
+        $status = $this->visitStmtList($node->children['stmts']);
+        $node->flags = $status;
+        return $status;
+    }
+
+    /**
      * @param \ast\Node[] $block
      * @return int the exit status of a block (whether or not it would unconditionally exit, return, throw, etc.
      */
-    private function getStatusOfBlock(array $block) : int
+    private function computeStatusOfBlock(array $block) : int
     {
+        $maybe_status = 0;
         foreach ($block as $child) {
             if ($child === null) {
                 continue;
@@ -175,10 +459,27 @@ class BlockExitStatusChecker extends KindVisitorImplementation {
             }
             $status = $this->check($child);
             if ($status !== self::STATUS_PROCEED) {
-                // The statement after this one is unreachable, due to unconditional continue/break/throw/return.
-                return $status;
+                if ($status & self::STATUS_MAYBE_BITMASK) {
+                    if (!$maybe_status || $status < $maybe_status) {
+                        $maybe_status = $status;
+                    }
+                } else {
+                    if ($maybe_status) {
+                        // E.g. if this statement is guaranteed to throw, but an earlier statement may break,
+                        // then the statement list is guarenteed to break/throw.
+                        $equivalent_status = $maybe_status << self::BITSHIFT_FOR_MAYBE;
+                        return min($status, $equivalent_status);
+                    }
+                    // The statement after this one is unreachable, due to unconditional continue/break/throw/return.
+                    return $status;
+                }
             }
         }
         return self::STATUS_PROCEED;
+    }
+
+    public static function willUnconditionallyThrowOrReturn(Node $node) : bool
+    {
+        return ((new self())($node) & self::STATUS_THROW_OR_RETURN_BITMASK) !== 0;
     }
 }

--- a/src/Phan/Analysis/BlockExitStatusChecker.php
+++ b/src/Phan/Analysis/BlockExitStatusChecker.php
@@ -478,6 +478,11 @@ final class BlockExitStatusChecker extends KindVisitorImplementation {
         return self::STATUS_PROCEED;
     }
 
+    public static function willUnconditionallySkipRemainingStatements(Node $node) : bool
+    {
+        return ((new self())($node) & self::STATUS_CERTAIN_BITMASK) !== 0;
+    }
+
     public static function willUnconditionallyThrowOrReturn(Node $node) : bool
     {
         return ((new self())($node) & self::STATUS_THROW_OR_RETURN_BITMASK) !== 0;

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -535,12 +535,6 @@ class ConditionVisitor extends KindVisitorImplementation
             }
             \assert(!\is_null($variable));  // redundant annotation for phan.
 
-            if ($variable->getUnionType()->isEmpty()) {
-                $variable->getUnionType()->addType(
-                    NullType::instance(false)
-                );
-            }
-
             // Make a copy of the variable
             $variable = clone($variable);
 

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -292,7 +292,6 @@ class ConditionVisitor extends KindVisitorImplementation
             if (\is_null($variable)) {
                 return $context;
             }
-            \assert(!\is_null($variable));  // redundant annotation for phan.
 
             // Get the type that we're checking it against
             $type = UnionType::fromNode(
@@ -498,7 +497,6 @@ class ConditionVisitor extends KindVisitorImplementation
         if (!\is_string($raw_function_name)) {
             return $this->context;
         }
-        assert(\is_string($raw_function_name));
         $args = $node->children['args']->children;
         // Only look at things of the form
         // `\is_string($variable)`
@@ -533,7 +531,6 @@ class ConditionVisitor extends KindVisitorImplementation
             if (\is_null($variable)) {
                 return $context;
             }
-            \assert(!\is_null($variable));  // redundant annotation for phan.
 
             // Make a copy of the variable
             $variable = clone($variable);

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -125,7 +125,6 @@ trait ConditionVisitorUtil {
             if (\is_null($variable)) {
                 return $context;
             }
-            \assert(!\is_null($variable));  // redundant annotation for phan.
 
             $union_type = $variable->getUnionType();
             if (!$should_filter_cb($union_type)) {
@@ -163,7 +162,6 @@ trait ConditionVisitorUtil {
             if (\is_null($variable)) {
                 return $context;
             }
-            \assert(!\is_null($variable));  // redundant annotation for phan.
 
             // Make a copy of the variable
             $variable = clone($variable);
@@ -206,7 +204,6 @@ trait ConditionVisitorUtil {
                     if (\is_null($variable)) {
                         return $context;
                     }
-                    \assert(!\is_null($variable));  // redundant annotation for phan.
 
                     // Make a copy of the variable
                     $variable = clone($variable);

--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -237,7 +237,6 @@ class NegatedConditionVisitor extends KindVisitorImplementation
         if (!\is_string($raw_function_name)) {
             return $this->context;
         }
-        assert(\is_string($raw_function_name));
         $args = $node->children['args']->children;
         foreach ($args as $arg) {
             if ($arg instanceof Node) {

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -709,7 +709,6 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             );
             return;
         }
-        \assert($node instanceof Node);
         $kind = $node->kind;
         if ($kind === \ast\AST_CONDITIONAL) {
             yield from self::deduplicateUnionTypes($this->getReturnTypesOfConditional($context, $node));

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -2116,13 +2116,9 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
      * is the throw an exception
      *
      * @return bool
-     * True when the decl can only throw an exception
+     * True when the decl can only throw an exception or return or exit()
      */
-    private function declOnlyThrows(Decl $node) {
-        $stmts = $node->children['stmts'] ?? null;
-        return isset($stmts)
-            && $stmts->kind === \ast\AST_STMT_LIST
-            && \count($stmts->children) === 1
-            && $stmts->children[0]->kind === \ast\AST_THROW;
+    private function declOnlyThrows(Decl $node) : bool {
+        return BlockExitStatusChecker::willUnconditionallyThrowOrReturn($node->children['stmts']);
     }
 }

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -185,7 +185,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
             }
         }
 
-        if ($this->analyzeFunctionLikeIsGenerator($node)) {
+        if ($method->getHasYield()) {
             $this->setReturnTypeOfGenerator($method, $node);
         }
 
@@ -276,8 +276,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
             }
         }
 
-        // TODO: no longer necessary, just call getHasYield()
-        if ($this->analyzeFunctionLikeIsGenerator($node)) {
+        if ($function->getHasYield()) {
             $this->setReturnTypeOfGenerator($function, $node);
         }
 
@@ -462,7 +461,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
             }
         }
 
-        if ($this->analyzeFunctionLikeIsGenerator($node)) {
+        if ($func->getHasYield()) {
             $this->setReturnTypeOfGenerator($func, $node);
         }
 
@@ -504,57 +503,6 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
             }
         }
     }
-
-    /**
-     * @param Node $node
-     * A node to parse
-     *
-     * This must be called before visitReturn is called within a function.
-     *
-     * @return bool
-     * True if the node represents a yield, else false.
-     */
-    public static function analyzeFunctionLikeIsGenerator(Node $node) : bool
-    {
-        foreach ($node->children ?? [] as $child_node) {
-            if (!($child_node instanceof Node)) {
-                continue;
-            }
-            // Check for occurrences of `yield`, including statements such as `return [yield 2];`.
-            if (self::analyzeNodeHasYield($child_node)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    public static function analyzeNodeHasYield(Node $node)
-    {
-        // The ast module doesn't tell us if something has a yield statement.
-        // We want to stop if the type of a node is a closure or a anonymous class
-
-        // Get the method/function/closure we're in
-        switch ($node->kind) {
-        case \ast\AST_YIELD:
-        case \ast\AST_YIELD_FROM:
-            return true;
-        case \ast\AST_METHOD:
-        case \ast\AST_FUNC_DECL:
-        case \ast\AST_CLOSURE:
-        case \ast\AST_CLASS:
-            return false;
-        }
-        foreach ($node->children ?? [] as $child_node) {
-            if (!($child_node instanceof Node)) {
-                continue;
-            }
-            if (self::analyzeNodeHasYield($child_node)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
 
     /**
      * @param Node $node

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -276,6 +276,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
             }
         }
 
+        // TODO: no longer necessary, just call getHasYield()
         if ($this->analyzeFunctionLikeIsGenerator($node)) {
             $this->setReturnTypeOfGenerator($function, $node);
         }

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -295,7 +295,6 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
             if (!$class_fqsen) {
                 return null;
             }
-            assert($class_fqsen instanceof FullyQualifiedClassName);
 
             // Postponed the check for undeclared closure scopes to the analysis phase,
             // because classes are still being parsed in the parse phase.

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -534,7 +534,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor {
             // to reduce false positives.
             // (Variables will be available in `catch` and `finally`)
             // This is mitigated by finally and catch blocks being unaware of new variables from try{} blocks.
-            if (BlockExitStatusChecker::willUnconditionallyThrowOrReturn($child_node->children['stmts'])) {
+            if (BlockExitStatusChecker::willUnconditionallySkipRemainingStatements($child_node->children['stmts'])) {
                 // e.g. "if (!is_string($x)) { return; }"
                 $excluded_elem_count++;
             } else {

--- a/src/Phan/Daemon.php
+++ b/src/Phan/Daemon.php
@@ -69,7 +69,7 @@ class Daemon {
                 }
 
                 if (!\is_resource($conn)) {
-                    // If we didn't get a connection, and it wasn't due
+                    // If we didn't get a connection, and it wasn't due to a signal from a child process, then stop the daemon.
                     break;
                 }
                 $request = Request::accept($code_base, $file_path_lister, $conn);

--- a/src/Phan/Daemon.php
+++ b/src/Phan/Daemon.php
@@ -72,7 +72,6 @@ class Daemon {
                     // If we didn't get a connection, and it wasn't due
                     break;
                 }
-                \assert(\is_resource($conn));
                 $request = Request::accept($code_base, $file_path_lister, $conn);
                 if ($request instanceof Request) {
                     return $request;  // We forked off a worker process successfully, and this is the worker process

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -1878,7 +1878,7 @@ class Issue
 
     /**
      * @return string
-     * A descriptive name of the severity of hte issue
+     * A descriptive name of the severity of the issue
      */
     public function getSeverityName() : string
     {
@@ -1889,6 +1889,8 @@ class Issue
             return 'normal';
         case self::SEVERITY_CRITICAL:
             return 'critical';
+        default:
+            throw new \AssertionError('Unknown severity ' . $this->getSeverity());
         }
     }
 

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -169,8 +169,7 @@ class Context extends FileRef
             );
         }
 
-        \assert(false, "Unknown flag $flags");
-        return $fqsen;
+        throw new \AssertionError("Unknown flag $flags");
     }
 
     /**

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -402,7 +402,7 @@ class Context extends FileRef
             return $code_base->getMethodByFQSEN($fqsen);
         }
 
-        \assert(false, "FQSEN must be for a function or method");
+        throw new \AssertionError("FQSEN must be for a function or method");
     }
 
     /**

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -21,6 +21,7 @@ use Phan\Language\FQSEN\FullyQualifiedPropertyName;
 use Phan\Language\Scope\ClassScope;
 use Phan\Language\Scope\GlobalScope;
 use Phan\Language\Type;
+use Phan\Language\Type\IterableType;
 use Phan\Language\Type\StringType;
 use Phan\Language\Type\TemplateType;
 use Phan\Language\UnionType;
@@ -168,16 +169,17 @@ class Clazz extends AddressableElement
 
         $context = new Context;
 
+        $class_name = $class->getName();
         $class_fqsen = FullyQualifiedClassName::fromStringInContext(
-            $class->getName(),
+            $class_name,
             $context
         );
 
         // Build a base class element
         $clazz = new Clazz(
             $context,
-            $class->getName(),
-            UnionType::fromStringInContext($class->getName(), $context, Type::FROM_TYPE),
+            $class_name,
+            UnionType::fromStringInContext($class_name, $context, Type::FROM_TYPE),
             $flags,
             $class_fqsen
         );
@@ -194,6 +196,11 @@ class Clazz extends AddressableElement
             $parent_type = $parent_class_fqsen->asType();
 
             $clazz->setParentType($parent_type);
+        }
+
+        if ($class_name === "Traversable") {
+            // Make sure that canCastToExpandedUnionType() works as expected for Traversable and its subclasses
+            $clazz->getUnionType()->addType(IterableType::instance(false));
         }
 
         // Note: If there are multiple calls to Clazz->addProperty(),

--- a/src/Phan/Language/Element/Func.php
+++ b/src/Phan/Language/Element/Func.php
@@ -114,7 +114,6 @@ class Func extends AddressableElement implements FunctionInterface
             // shouldn't happen
             return null;
         }
-        \assert($class_fqsen instanceof FullyQualifiedClassName);
 
         return $class_fqsen;
     }

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -282,6 +282,8 @@ trait FunctionTrait {
      */
     public function setHasYield(bool $has_yield)
     {
+        // TODO: In a future release of php-ast, this information will be part of the function node's flags.
+        // (PHP 7.1 only, not supported in PHP 7.0)
         $this->setPhanFlags(Flags::bitVectorWithState(
             $this->getPhanFlags(),
             Flags::HAS_YIELD,

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -172,8 +172,6 @@ class Parameter extends Variable
         CodeBase $code_base,
         Node $node
     ) : array {
-        \assert($node instanceof Node, "node was not an \\ast\\Node");
-
         $parameter_list = [];
         $is_optional_seen = false;
         foreach ($node->children ?? [] as $i => $child_node) {
@@ -253,9 +251,6 @@ class Parameter extends Variable
         CodeBase $code_base,
         Node $node
     ) : Parameter {
-
-        \assert($node instanceof Node, "node was not an \\ast\\Node");
-
         // Get the type of the parameter
         $union_type = UnionType::fromNode(
             $context,

--- a/src/Phan/Language/Scope/ClassScope.php
+++ b/src/Phan/Language/Scope/ClassScope.php
@@ -26,8 +26,7 @@ class ClassScope extends ClosedScope {
             return $fqsen;
         }
 
-        \assert($fqsen instanceof FullyQualifiedClassName,
-            "FQSEN must be a FullyQualifiedClassName");
+        throw new \AssertionError("FQSEN must be a FullyQualifiedClassName");
     }
 
 }

--- a/src/Phan/Language/Scope/FunctionLikeScope.php
+++ b/src/Phan/Language/Scope/FunctionLikeScope.php
@@ -31,7 +31,7 @@ class FunctionLikeScope extends ClosedScope {
             return $fqsen;
         }
 
-        \assert(false, "FQSEN must be a function-like FQSEN");
+        throw new \AssertionError("FQSEN must be a function-like FQSEN");
     }
 
 }

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -531,10 +531,7 @@ class Type
                 return StaticType::instance($is_nullable);
         }
 
-        \assert(
-            false,
-            "No internal type with name $type_name"
-        );
+        throw new \AssertionError("No internal type with name $type_name");
     }
 
     /**
@@ -1445,6 +1442,9 @@ class Type
         }
         // A matrix of allowable type conversions
         static $matrix = [
+            '\Generator' => [
+                'iterable' => true,
+            ],
             '\Traversable' => [
                 'iterable' => true,
             ],

--- a/src/Phan/Language/Type/StaticType.php
+++ b/src/Phan/Language/Type/StaticType.php
@@ -36,9 +36,9 @@ final class StaticType extends Type
         if (empty($instance)) {
             $instance = static::make('\\', static::NAME, [], false, Type::FROM_TYPE);
             \assert($instance instanceof static);
+        } else {
+            \assert($instance instanceof static);
         }
-
-        \assert($instance instanceof static);
         return $instance;
     }
 

--- a/src/Phan/Library/FileCache.php
+++ b/src/Phan/Library/FileCache.php
@@ -79,7 +79,6 @@ final class FileCache {
         if (!\is_string($contents)) {
             throw new \RuntimeException("FileCache::getOrReadEntry: file_get_contents failed for '$file_name'\n");
         }
-        assert(\is_string($contents));
         $entry = self::addEntry($file_name, $contents);
         return $entry;
     }

--- a/src/Phan/Output/Printer/PylintPrinter.php
+++ b/src/Phan/Output/Printer/PylintPrinter.php
@@ -40,6 +40,8 @@ final class PylintPrinter implements IssuePrinterInterface
             return 'W' . $categoryId;
         case Issue::SEVERITY_CRITICAL:
             return 'E' . $categoryId;
+        default:
+            throw new \AssertionError("Unrecognized severity for " . __METHOD__ . ": " . $issue->getSeverity());
         }
     }
 

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -88,9 +88,6 @@ class ParseVisitor extends ScopeVisitor
             return $this->context;
         }
 
-        \assert(!empty($class_name),
-            "Class must have name in {$this->context}");
-
         $class_fqsen = FullyQualifiedClassName::fromStringInContext(
             $class_name,
             $this->context

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -840,9 +840,74 @@ class ParseVisitor extends ScopeVisitor
         );
 
         // Mark the method as returning something
-        $method->setHasReturn(
-            ($node->children['expr'] ?? null) !== null
+        if (($node->children['expr'] ?? null) !== null) {
+            $method->setHasReturn(true);
+        }
+
+        return $this->context;
+    }
+
+    /**
+     * Visit a node with kind `\ast\AST_YIELD`
+     *
+     * @param Node $node
+     * A node to parse
+     *
+     * @return Context
+     * A new or an unchanged context resulting from
+     * parsing the node
+     */
+    public function visitYield(Node $node) : Context
+    {
+        return $this->analyzeYield($node);
+    }
+
+    /**
+     * Visit a node with kind `\ast\AST_YIELD_FROM`
+     *
+     * @param Node $node
+     * A node to parse
+     *
+     * @return Context
+     * A new or an unchanged context resulting from
+     * parsing the node
+     */
+    public function visitYieldFrom(Node $node) : Context
+    {
+        return $this->analyzeYield($node);
+    }
+
+
+    /**
+     * Visit a node with kind `\ast\AST_YIELD_FROM` or kind `\ast_YIELD`
+     *
+     * @param Node $node
+     * A node to parse
+     *
+     * @return Context
+     * A new or an unchanged context resulting from
+     * parsing the node
+     */
+    private function analyzeYield(Node $node) : Context {
+        $this->analyzeBackwardCompatibility($node);
+
+        // Make sure we're actually returning from a method.
+        if (!$this->context->isInFunctionLikeScope()) {
+            return $this->context;
+        }
+
+        // Get the method/function/closure we're in
+        $method = $this->context->getFunctionLikeInScope(
+            $this->code_base
         );
+
+        \assert(!empty($method),
+            "We're supposed to be in either method or closure scope."
+        );
+
+        // Mark the method as yielding something (and returning a generator)
+        $method->setHasYield(true);
+        $method->setHasReturn(true);
 
         return $this->context;
     }

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -168,7 +168,6 @@ class Phan implements IgnoredFilesFilterInterface {
                 error_log("Finished serving requests, exiting");
                 exit(2);
             }
-            \assert($request instanceof Request);
             self::$printer = $request->getPrinter();
 
             // This is the list of all of the parsed files

--- a/src/Phan/Plugin/ClosuresForKind.php
+++ b/src/Phan/Plugin/ClosuresForKind.php
@@ -60,17 +60,17 @@ class ClosuresForKind {
      */
     public function getFlattenedClosures(\Closure $flattener)
     {
-        ksort($this->closures);
+        \ksort($this->closures);
         $merged_closures = [];
         foreach ($this->closures as $kind => $closure_list) {
-            assert(\count($closure_list) > 0);
+            \assert(\count($closure_list) > 0);
             if (\count($closure_list) === 1) {
                 // If there's exactly one closure for a given kind, then execute it directly.
                 $merged_closures[$kind] = $closure_list[0];
             } else {
                 // Create a closure which will execute 2 or more closures.
                 $closure = $flattener($closure_list);
-                assert($closure instanceof \Closure);
+                \assert($closure instanceof \Closure);
                 $merged_closures[$kind] = $closure;
             }
         }

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -87,7 +87,7 @@ class UnionTypeTest extends BaseTest {
     public function testInternalObject() {
         $this->assertUnionTypeStringEqual(
             'new SplStack();',
-            '\\ArrayAccess|\\Countable|\\Iterator|\\Serializable|\\SplDoublyLinkedList|\\SplStack|\\Traversable'
+            '\\ArrayAccess|\\Countable|\\Iterator|\\Serializable|\\SplDoublyLinkedList|\\SplStack|\\Traversable|iterable'
         );
     }
 

--- a/tests/files/expected/0092_enforce_return.php.expected
+++ b/tests/files/expected/0092_enforce_return.php.expected
@@ -1,3 +1,3 @@
 %s:4 PhanTypeMissingReturn Method \A::f is declared to return int but has no return value
 %s:21 PhanTypeMissingReturn Method \h is declared to return int but has no return value
-
+%s:36 PhanTypeMissingReturn Method \j92 is declared to return int but has no return value

--- a/tests/files/expected/0174_is_a_generic.php.expected
+++ b/tests/files/expected/0174_is_a_generic.php.expected
@@ -1,5 +1,5 @@
 %s:7 PhanTypeMismatchArgument Argument 1 (var) is array but \f() takes resource defined at %s:3
 %s:7 PhanTypeMismatchArgument Argument 1 (var) is string[] but \f() takes resource defined at %s:3
 %s:9 PhanTypeMismatchArgument Argument 1 (var) is bool but \f() takes resource defined at %s:3
-%s:12 PhanTypeMismatchReturn Returning type array|bool|null but g() is declared to return resource
+%s:12 PhanTypeMismatchReturn Returning type array|bool but g() is declared to return resource
 %s:12 PhanTypeMismatchReturn Returning type bool|string[] but g() is declared to return resource

--- a/tests/files/expected/0246_iterable.php.expected
+++ b/tests/files/expected/0246_iterable.php.expected
@@ -6,5 +6,5 @@
 %s:29 PhanTypeMismatchArgument Argument 1 (p) is \ArrayAccess but \f246_0() takes iterable defined at %s:2
 %s:30 PhanTypeMismatchArgument Argument 1 (p) is \ArrayAccess but \f246_1() takes array defined at %s:5
 %s:32 PhanTypeMismatchArgument Argument 1 (p) is \ArrayAccess but \f246_3() takes \Traversable defined at %s:11
-%s:50 PhanTypeMismatchArgument Argument 1 (p) is \Traversable but \f246_1() takes array defined at %s:5
-%s:51 PhanTypeMismatchArgument Argument 1 (p) is \Traversable but \f246_2() takes \ArrayAccess defined at %s:8
+%s:50 PhanTypeMismatchArgument Argument 1 (p) is \Traversable|iterable but \f246_1() takes array defined at %s:5
+%s:51 PhanTypeMismatchArgument Argument 1 (p) is \Traversable|iterable but \f246_2() takes \ArrayAccess defined at %s:8

--- a/tests/files/expected/0279_void_return.php.expected
+++ b/tests/files/expected/0279_void_return.php.expected
@@ -1,3 +1,2 @@
 %s:9 PhanTypeMismatchReturn Returning type void but f() is declared to return \DateTime
-%s:14 PhanTypeMissingReturn Method \g is declared to return int but has no return value
 %s:15 PhanTypeMismatchReturn Returning type void but g() is declared to return int

--- a/tests/files/expected/0344_negate_unconditional_return.php.expected
+++ b/tests/files/expected/0344_negate_unconditional_return.php.expected
@@ -1,0 +1,4 @@
+%s:6 PhanTypeMismatchReturn Returning type null but f344() is declared to return int
+%s:10 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
+%s:11 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
+%s:27 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is array but \intdiv() takes int

--- a/tests/files/expected/0345_defined_all_branches.php.expected
+++ b/tests/files/expected/0345_defined_all_branches.php.expected
@@ -1,0 +1,1 @@
+%s:12 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string

--- a/tests/files/src/0092_enforce_return.php
+++ b/tests/files/src/0092_enforce_return.php
@@ -26,3 +26,15 @@ function k() : int {
 function l() : int {
     throw new \Exception();
 }
+function i92() : int {
+    if (rand() % 2) {
+        throw new \Exception();
+    } else {
+        throw new \Exception();
+    }
+}
+function j92() : int {
+    if (rand() % 2) {
+        throw new \Exception();
+    } else;
+}

--- a/tests/files/src/0343_type_narrowing_bleed.php
+++ b/tests/files/src/0343_type_narrowing_bleed.php
@@ -1,0 +1,13 @@
+<?php
+
+function f343(string $p) : string {
+    return $p;
+}
+
+function g343($v) : string {
+    if (is_array($v)) {
+        return 'string';
+    }
+
+    return f343($v);
+}

--- a/tests/files/src/0344_negate_unconditional_return.php
+++ b/tests/files/src/0344_negate_unconditional_return.php
@@ -1,0 +1,48 @@
+<?php
+
+function f344(?string $x) : int {
+    if (!is_string($x)) {
+        $b = 2;
+        return $x;
+    } else {
+        $b = 'x';
+    }
+    echo intdiv($x, 2);  // should warn
+    echo intdiv($b, 2);  // should warn about $b being a string
+    return strlen($x);
+}
+
+/**
+ * @param $x
+ */
+function g344($x) : int {
+    if (!is_array($x)) {
+        if (rand() % 2) {
+            return 4;
+        } else {
+            echo "Some code\n";
+            throw new \Exception("Unconditionally threw or returned");
+        }
+    }
+    echo intdiv($x, 2);  // should warn that $x is an array.
+    return count($x);
+}
+
+/**
+ * @param $x
+ */
+function h344($x) : int {
+    if (!is_array($x)) {  // This may or may not return.
+        if (rand() % 2) {
+            return 4;
+        } else {
+            echo "Some code\n";
+        }
+    }
+    echo intdiv($x, 2);  // currently, doesn't warn, because the type is uncertain.
+    if (!is_int($x)) {
+        return -1;
+    }
+
+    return $x;
+}

--- a/tests/files/src/0345_defined_all_branches.php
+++ b/tests/files/src/0345_defined_all_branches.php
@@ -1,0 +1,14 @@
+<?php
+
+function test($x, $y) : int {
+	if ($x) {
+	   $a = 2;
+	} elseif ($y) {
+	   $a = 3;
+	} else {
+	   return -2;
+	}
+
+	echo strlen($a); // should warn about wrong type.
+	return $a;
+}

--- a/tests/plugin_test/.phan/config.php
+++ b/tests/plugin_test/.phan/config.php
@@ -64,6 +64,7 @@ return [
     // A list of plugin files to execute
     // (Execute all of them.)
     'plugins' => [
+        '../../.phan/plugins/AlwaysReturnPlugin.php',
         '../../.phan/plugins/DemoPlugin.php',
         '../../.phan/plugins/DollarDollarPlugin.php',
         '../../.phan/plugins/DuplicateArrayKeyPlugin.php',

--- a/tests/plugin_test/expected/all_output.expected
+++ b/tests/plugin_test/expected/all_output.expected
@@ -14,6 +14,8 @@ src/000_plugins.php:55 UnusedSuppression Element \testUnusedSuppressionPlugin su
 src/000_plugins.php:61 PhanUnreferencedFunction Possibly zero references to function \testUnreferencedFunction
 src/000_plugins.php:66 PhanUnreferencedClass Possibly zero references to class \__autoload
 src/000_plugins.php:67 PhanUnreferencedConstant Possibly zero references to constant \__autoload
+src/000_plugins.php:69 PhanPluginAlwaysReturnFunction Function \missingReturnType has a return type of int, but may fail to return a value
+src/000_plugins.php:77 PhanPluginAlwaysReturnMethod Method \ReturnChecks::missingReturnTypeSwitch has a return type of int, but may fail to return a value
 src/001_globals_type_map.php:5 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \Exception|\Throwable but \intdiv() takes int
 src/001_globals_type_map.php:8 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \Error|\Throwable but \intdiv() takes int
 src/001_globals_type_map.php:12 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \Exception|\Throwable but \intdiv() takes int

--- a/tests/plugin_test/expected/all_output.expected
+++ b/tests/plugin_test/expected/all_output.expected
@@ -16,6 +16,7 @@ src/000_plugins.php:66 PhanUnreferencedClass Possibly zero references to class \
 src/000_plugins.php:67 PhanUnreferencedConstant Possibly zero references to constant \__autoload
 src/000_plugins.php:69 PhanPluginAlwaysReturnFunction Function \missingReturnType has a return type of int, but may fail to return a value
 src/000_plugins.php:77 PhanPluginAlwaysReturnMethod Method \ReturnChecks::missingReturnTypeSwitch has a return type of int, but may fail to return a value
+src/000_plugins.php:127 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
 src/001_globals_type_map.php:5 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \Exception|\Throwable but \intdiv() takes int
 src/001_globals_type_map.php:8 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \Error|\Throwable but \intdiv() takes int
 src/001_globals_type_map.php:12 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \Exception|\Throwable but \intdiv() takes int

--- a/tests/plugin_test/src/000_plugins.php
+++ b/tests/plugin_test/src/000_plugins.php
@@ -113,7 +113,22 @@ class ReturnChecks {
         echo "In generator\n";
         $x = yield 2;
     }
+
+    /**
+     * @param int[]|string[] $x
+     */
+    public static function skippingWithBreak($x) {
+        // should not falsely detect as missing a return type
+        for ($i = 0; $i < count($x); $i++) {
+            $a = $x[$i];
+            if (!is_int($a)) {
+                break;
+            }
+            echo strlen($a);  // Phan should warn about $a being an int.
+        }
+    }
 }
 ReturnChecks::missingReturnTypeSwitchGood(3);
 ReturnChecks::missingReturnTypeSwitch(5);
 ReturnChecks::generator(3);
+ReturnChecks::skippingWithBreak([3, 4, "strval"]);

--- a/tests/plugin_test/src/000_plugins.php
+++ b/tests/plugin_test/src/000_plugins.php
@@ -65,3 +65,55 @@ function __autoload($className) {}
 // meaningless things with the same names
 class __autoload {}
 const __autoload = 3;
+
+function missingReturnType(?int $x) : int {
+    if (is_int($x)) {
+        return $x;
+    }
+}
+missingReturnType(2);
+
+class ReturnChecks {
+    public static function missingReturnTypeSwitch(int $x) : int {
+        switch($x) {
+        case 2:
+            throw new \RuntimeException("saw 2");
+        case 3:
+            break;
+        default:
+            return $x ?? 3;
+        }
+    }
+
+    public static function missingReturnTypeSwitchGood(int $x) : int {
+        switch($x) {
+        case 2:
+            return 4;
+        case 3:
+            throw new \RuntimeException("saw 3");
+        default:
+            return $x ?? 3;
+        }
+    }
+
+    // should not falsely detect as missing a return type
+    public static function generator(int $x) : Traversable {
+        if ($x > 0) {
+            if (rand() % 2 > 0) {
+                yield from self::otherGenerator();
+            }
+        }
+    }
+
+    /**
+     * @return iterable
+     */
+    public static function otherGenerator() {
+        // should not falsely detect as missing a return type
+        echo "In generator\n";
+        $x = yield 2;
+    }
+}
+ReturnChecks::missingReturnTypeSwitchGood(3);
+ReturnChecks::missingReturnTypeSwitch(5);
+ReturnChecks::generator(3);


### PR DESCRIPTION
Fixes #308 : Type narrowing bleed.

Related to #817 : Don't merge Contexts if the corresponding blocks
always return or throw.

Fixes #996 : When checking if a variable is defined on all branches,
ignore branches which unconditionally throw/return

Fixes #956 : Create an (in development) plugin `AlwaysReturnPlugin`
to check that a method or function will unconditionally return a value.
There are still edge cases analyzing try/finally, switch statements, loops, etc.

Fixes #735 : Implement optimizations for BlockExitStatusChecker.
Rewrite BlockExitStatusChecker to cache the statement or block's exit
status in \ast\Node->flags (For node kinds which don't have uses for flags).
This saves memory (Only stored while node is referenced) and is efficient.
Stop using SplObjectStorage

Within phan, replace assert(false) with `throw new \AssertionError`
so that it unconditionally returns,
and fix switch statements which weren't guaranteed to return.
(Currently, phan overrides the settings anyway)