### PR TITLE
Miscellaneous improvements for InvalidVariableIssetPlugin

### DIFF
--- a/.phan/plugins/InvalidVariableIssetPlugin.php
+++ b/.phan/plugins/InvalidVariableIssetPlugin.php
@@ -4,6 +4,7 @@
 use Phan\AST\AnalysisVisitor;
 use Phan\CodeBase;
 use Phan\Language\Context;
+use Phan\Language\Element\Variable;
 use Phan\PluginV2;
 use Phan\PluginV2\AnalyzeNodeCapability;
 use Phan\PluginV2\PluginAwareAnalysisVisitor;
@@ -57,17 +58,27 @@ class InvalidVariableIssetVisitor extends PluginAwareAnalysisVisitor {
 
         // emit issue if name is not declared
         // Check for edge cases such as isset($$var)
-        if (is_string($name) && !$this->context->getScope()->hasVariableWithName($name)){
-            $this->emit(
-                'PhanUndeclaredVariable',
-                "undeclared variables in isset()",
-                []
-            );
-        } elseif ($argument->kind !== ast\AST_DIM){
+        if (is_string($name) && $name) {
+            if (!Variable::isHardcodedVariableInScopeWithName($name, $this->context->isInGlobalScope()) &&
+                    !$this->context->getScope()->hasVariableWithName($name)) {
+                $this->emit(
+                    'PhanPluginUndeclaredVariableIsset',
+                    'undeclared variable ${NAME} in isset()',
+                    [$name]
+                );
+            }
+        } elseif ($argument->kind !== ast\AST_VAR) {
             // emit issue if argument is not array access
             $this->emit(
                 'PhanPluginInvalidVariableIsset',
-                "non array access in isset()",
+                "non array/property access in isset()",
+                []
+            );
+        } else if (!is_string($name)) {
+            // emit issue if argument is not array access
+            $this->emit(
+                'PhanPluginComplexVariableIsset',
+                "Unanalyzable complex variable expression in isset",
                 []
             );
         }

--- a/NEWS
+++ b/NEWS
@@ -31,6 +31,12 @@ New Features (CLI, Configs)
 Bug Fixes
 + Work around notice about COMPILER_HALT_OFFSET on windows.
 
+Changes In Emitted Issues
++ Improve `InvalidVariableIssetPlugin`. Change the names and messages for issue types.
+  Emit `PhanPluginUndeclaredVariableInIsset` and `PhanPluginComplexVariableIsset`
+  instead of `PhanUndeclaredVariable`.
+  Stop erroneously warning about valid property fetches and checks of fields of superglobals.
+
 0.9.3 Jul 11, 2017
 ------------------
 

--- a/tests/plugin_test/expected/all_output.expected
+++ b/tests/plugin_test/expected/all_output.expected
@@ -3,9 +3,9 @@ src/000_plugins.php:4 PhanUndeclaredClassInstanceof Checking instanceof against 
 src/000_plugins.php:10 PhanPluginDollarDollar $$ Variables are not allowed.
 src/000_plugins.php:17 PhanPluginDuplicateArrayKey Duplicate/Equivalent array key literal(0) detected in array - the earlier entry will be ignored.
 src/000_plugins.php:21 PhanPluginMixedKeyNoKey Should not mix array entries of the form [key => value,] with entries of the form [value,].
-src/000_plugins.php:28 PhanUndeclaredVariable undeclared variables in isset()
+src/000_plugins.php:28 PhanPluginUndeclaredVariableIsset undeclared variable $foo in isset()
+src/000_plugins.php:29 PhanPluginComplexVariableIsset Unanalyzable complex variable expression in isset
 src/000_plugins.php:29 PhanPluginDollarDollar $$ Variables are not allowed.
-src/000_plugins.php:29 PhanPluginInvalidVariableIsset non array access in isset()
 src/000_plugins.php:33 PhanPluginNonBoolBranch Non bool value evaluated in if clause
 src/000_plugins.php:40 PhanPluginNonBoolInLogicalArith Non bool value in logical arithmetic
 src/000_plugins.php:47 PhanPluginNumericalComparison non numerical values compared by the operators '==' or '!=='


### PR DESCRIPTION
Don't warn about `isset($x->prop)` if that property could be valid.

Don't erroneously warn about superglobals
Rename the emitted issues, and change the message format for those
issues.
Emit `PhanPluginUndeclaredVariableInIsset` and
`PhanPluginComplexVariableIsset` instead of `PhanUndeclaredVariable`
in that plugin (Plugins should use different issue type names in general)