### PR TITLE
Fixes #462 : Valid instanceof class name can only be string or object

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -30,6 +30,9 @@ New Features (CLI, Configs)
 
 Bug Fixes
 + Work around notice about COMPILER_HALT_OFFSET on windows.
++ Fixes #462 : Fix type inferences for instanceof for checks with dynamic class names are provided.
+  Valid class names are either a string or an instance of the class to check against.
+  Warn if the class name is definitely invalid.
 
 Changes In Emitted Issues
 + Improve `InvalidVariableIssetPlugin`. Change the names and messages for issue types.

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -56,6 +56,7 @@ class Issue
     const TypeInvalidClosureScope   = 'PhanTypeInvalidClosureScope';
     const TypeInvalidLeftOperand    = 'PhanTypeInvalidLeftOperand';
     const TypeInvalidRightOperand   = 'PhanTypeInvalidRightOperand';
+    const TypeInvalidInstanceof     = 'PhanTypeInvalidInstanceof';
     const TypeMagicVoidWithReturn   = 'PhanTypeMagicVoidWithReturn';
     const TypeMismatchArgument      = 'PhanTypeMismatchArgument';
     const TypeMismatchArgumentInternal = 'PhanTypeMismatchArgumentInternal';
@@ -874,7 +875,14 @@ class Issue
                 self::REMEDIATION_B,
                 10026
             ),
-
+            new Issue(
+                self::TypeInvalidInstanceof,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                'Found an instanceof class name of type {TYPE}, but class name must be a valid object or a string',
+                self::REMEDIATION_B,
+                10029
+            ),
             // Issue::CATEGORY_VARIABLE
             new Issue(
                 self::VariableUseClause,
@@ -2088,8 +2096,9 @@ class Issue
      * @param int $lineno
      * The line number where the issue was found
      *
-     * @param mixed ...$parameters
-     * Template parameters for the issue's error message
+     * @param string|int|float|bool|object ...$parameters
+     * Template parameters for the issue's error message.
+     * If these are objects, they should define __toString()
      *
      * @return void
      */

--- a/tests/files/expected/0346_dynamic_instanceof.php.expected
+++ b/tests/files/expected/0346_dynamic_instanceof.php.expected
@@ -1,0 +1,3 @@
+%s:11 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \C346 but \intdiv() takes int
+%s:19 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \C346 but \intdiv() takes int
+%s:24 PhanTypeInvalidInstanceof Found an instanceof class name of type int, but class name must be a valid object or a string

--- a/tests/files/src/0346_dynamic_instanceof.php
+++ b/tests/files/src/0346_dynamic_instanceof.php
@@ -1,0 +1,27 @@
+<?php
+
+class C346 {}
+
+function f346(C346 $p) {}
+function test346() {
+    $v1 = 'C346';
+    $v2 = new C346;
+    if ($v2 instanceof $v1) {
+        f346($v2);
+        intdiv($v2, 3);  // should warn.
+    }
+}
+
+function test346B($v1) {
+    $v2 = new C346;
+    if ($v1 instanceof $v2) {
+        f346($v1);
+        echo intdiv($v1, 2);  // should warn.
+    }
+}
+function test346C($v1) {
+    $v2 = 2;
+    if ($v1 instanceof $v2) {  // should warn but should never set the type to int.
+        f346($v1);
+    }
+}


### PR DESCRIPTION
If the dynamic class name is a string,
then just ensure that the resulting type is narrowed to object type(s)