### PR TITLE
Implement a plugin to detect unreachable code. Fix bugs.

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -398,6 +398,7 @@ return [
         '.phan/plugins/AlwaysReturnPlugin.php',
         '.phan/plugins/DemoPlugin.php',
         '.phan/plugins/DollarDollarPlugin.php',
+        '.phan/plugins/UnreachableCodePlugin.php',
         // NOTE: src/Phan/Language/Internal/FunctionSignatureMap.php mixes value without key as return type with values having keys deliberately.
         // '.phan/plugins/DuplicateArrayKeyPlugin.php',
 

--- a/.phan/plugins/README.md
+++ b/.phan/plugins/README.md
@@ -55,6 +55,13 @@ Warns about common errors in php array keys. Has the following checks (Doesn't t
 Checks if a function or method with a non-void return type will **unconditionally** return or throw.
 This is stricter than Phan's default checks (Phan accepts a function or method that **may** return something, or functions that unconditionally throw).
 
+#### UnconditionalCodePlugin.php
+
+Checks for syntactically unreachable statements in the global scope or function bodies.
+(E.g. function calls after unconditional continue/break/throw/return/exit())
+
+This is in development, and has some edge cases related to try blocks.
+
 ### 3. Plugins Specific to Code Styles
 
 These plugins may be useful to enforce certain code styles,

--- a/.phan/plugins/UnreachableCodePlugin.php
+++ b/.phan/plugins/UnreachableCodePlugin.php
@@ -1,0 +1,102 @@
+<?php declare(strict_types=1);
+
+use Phan\AST\AnalysisVisitor;
+use Phan\CodeBase;
+use Phan\Analysis\BlockExitStatusChecker;
+use Phan\Language\Context;
+use Phan\Language\UnionType;
+use Phan\PluginV2;
+use Phan\PluginV2\AnalyzeNodeCapability;
+use Phan\PluginV2\PluginAwareAnalysisVisitor;
+use ast\Node;
+
+/**
+ * This file checks for syntactically unreachable statements in
+ * the global scope or function bodies.
+ *
+ * It hooks into one event:
+ *
+ * - getAnalyzeNodeVisitorClassName
+ *   This method returns a class that is called on every AST node from every
+ *   file being analyzed
+ *
+ * A plugin file must
+ *
+ * - Contain a class that inherits from \Phan\Plugin
+ *
+ * - End by returning an instance of that class.
+ *
+ * It is assumed without being checked that plugins aren't
+ * mangling state within the passed code base or context.
+ *
+ * Note: When adding new plugins,
+ * add them to the corresponding section of README.md
+ */
+final class UnreachableCodePlugin extends PluginV2
+    implements AnalyzeNodeCapability {
+
+    /**
+     * @return string - The name of the visitor that will be called (formerly analyzeNode)
+     */
+    public static function getAnalyzeNodeVisitorClassName() : string
+    {
+        return UnreachableCodeVisitor::class;
+    }
+}
+
+/**
+ * When __invoke on this class is called with a node, a method
+ * will be dispatched based on the `kind` of the given node.
+ *
+ * Visitors such as this are useful for defining lots of different
+ * checks on a node based on its kind.
+ */
+final class UnreachableCodeVisitor extends PluginAwareAnalysisVisitor {
+    // A plugin's visitors should NOT implement visit(), unless they need to.
+
+    /**
+     * @param Node $node
+     * A node to analyze
+     *
+     * @return void
+     *
+     * @override
+     */
+    public function visitStmtList(Node $node)
+    {
+        $child_nodes = $node->children;
+        // Debug::printNode($node);
+
+        $last_node_index = count($child_nodes) - 1;
+        foreach ($child_nodes as $i => $node) {
+            if ($i >= $last_node_index) {
+                break;
+            }
+            if (!($node instanceof Node)) {
+                continue;
+            }
+            if (!BlockExitStatusChecker::willUnconditionallyThrowOrReturn($node)) {
+                continue;
+            }
+            // Skip over empty statements and scalar statements.
+            for ($j = $i + 1; array_key_exists($j, $child_nodes); $j++) {
+                $next_node = $child_nodes[$j];
+                if ($next_node instanceof Node && $next_node->lineno > 0) {
+                    $context = clone($this->context)->withLineNumberStart($next_node->lineno);
+                    $this->emitPluginIssue(
+                        $this->code_base,
+                        $context,
+                        'PhanPluginUnreachableCode',
+                        'Unreachable statement detected',
+                        []
+                    );
+                    break;
+                }
+            }
+            break;
+        }
+    }
+}
+// Every plugin needs to return an instance of itself at the
+// end of the file in which its defined.
+return new UnreachableCodePlugin;

--- a/NEWS
+++ b/NEWS
@@ -22,6 +22,10 @@ New Features (Analysis)
 + Add a new plugin file `AlwaysReturnPlugin`. (Issue #996)
   This will add a stricter check that a function with a non-null return type *unconditionally* returns a value (or explicitly throws, or exit()s).
   Currently, Phan just checks if a function *may* return, or unconditionally throws.
++ Add a new plugin file `UnreachableCodePlugin` (in development).
+  This will warn about statements that appear to be unreachable
+  (statements occurring after unconditional return/break/throw/return/exit statements)
+
 
 New Features (CLI, Configs)
 + Add config setting `prefer_narrowed_phpdoc_return_type` (See "New Features (CLI, Configs)),

--- a/tests/plugin_test/.phan/config.php
+++ b/tests/plugin_test/.phan/config.php
@@ -72,6 +72,7 @@ return [
         '../../.phan/plugins/NonBoolBranchPlugin.php',
         '../../.phan/plugins/NonBoolInLogicalArithPlugin.php',
         '../../.phan/plugins/NumericalComparisonPlugin.php',
+        '../../.phan/plugins/UnreachableCodePlugin.php',
         '../../.phan/plugins/UnusedSuppressionPlugin.php',
     ],
 

--- a/tests/plugin_test/expected/all_output.expected
+++ b/tests/plugin_test/expected/all_output.expected
@@ -21,3 +21,7 @@ src/001_globals_type_map.php:5 PhanTypeMismatchArgumentInternal Argument 1 (nume
 src/001_globals_type_map.php:8 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \Error|\Throwable but \intdiv() takes int
 src/001_globals_type_map.php:12 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \Exception|\Throwable but \intdiv() takes int
 src/001_globals_type_map.php:15 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \Error|\Throwable but \intdiv() takes int
+src/002_unreachable_code.php:5 PhanPluginUnreachableCode Unreachable statement detected
+src/002_unreachable_code.php:20 PhanPluginUnreachableCode Unreachable statement detected
+src/002_unreachable_code.php:22 PhanPluginUnreachableCode Unreachable statement detected
+src/002_unreachable_code.php:37 PhanPluginUnreachableCode Unreachable statement detected

--- a/tests/plugin_test/src/002_unreachable_code.php
+++ b/tests/plugin_test/src/002_unreachable_code.php
@@ -1,0 +1,53 @@
+<?php
+
+function unreachableCode() {
+    throw new \RuntimeException("Exception");
+    return null;
+}
+unreachableCode();
+
+class testUnreachableCode {
+    public function __construct($x) {
+        if (rand() % 2 > 0) {
+            return;
+        } else {
+            if ($x > 0) {
+                echo "It's positive";
+                return;
+            } else {
+                exit(1);
+            }
+            echo "Testing";
+        }
+        echo "More statements\n";
+        echo "Even more unreachable statements\n";
+    }
+
+    // Should warn about unreachable statement "Should not happen",
+    // and should not warn about failing to return.
+    public function unreachableSwitch(int $x) : bool {
+        if (rand() % 2 > 0) {
+            switch($x) {
+            case 0:
+            case 3:
+            default:
+                echo "anything\n";
+                return false;
+            }
+            echo "Should not happen\n";
+        } else {
+            switch($x) {
+            case 0:
+            case 3:
+            default:
+                echo "not 2\n";
+                return false;
+            case 2:
+                break;
+            }
+            return true;
+        }
+    }
+}
+$c = new testUnreachableCode(0);
+$c->unreachableSwitch(4);


### PR DESCRIPTION
Fix bugs analyzing try blocks and the fallthrough of switch statements.

These plugins (UnreachableCodePlugin and AlwaysReturnPlugin) are in development,
and also double as a sanity check of the values returned by BlockExitStatusChecker