### PR TITLE
Clean up unused variables and parameters in Phan's codebase.

### DIFF
--- a/.phan/plugins/DemoLegacyPlugin.php
+++ b/.phan/plugins/DemoLegacyPlugin.php
@@ -69,7 +69,7 @@ class DemoLegacyPlugin extends PluginImplementation {
         CodeBase $code_base,
         Context $context,
         Node $node,
-        Node $parent_node = null
+        Node $unused_parent_node = null
     ) {
         // Invoke the `DemoLegacyNodeVisitor` (defined later in
         // this file) on the given node, allowing it to run
@@ -199,22 +199,22 @@ class DemoLegacyNodeVisitor extends AnalysisVisitor {
     /**
      * Default visitor that does nothing
      *
-     * @param Node $node
+     * @param Node $unused_node
      * A node to analyze
      *
      * @return void
      *
      * @override
      */
-    public function visit(Node $node)
+    public function visit(Node $unused_node)
     {
         // This method will be called on all nodes for which
         // there is no implementation of it's kind visitor.
         //
         // To see what kinds of nodes are passing through here,
-        // you can run `Debug::printNode($node)`.
+        // you can run `Debug::printNode($unused_node)`.
 
-        // Debug::printNode($node);
+        // Debug::printNode($unused_node);
     }
 
     /**

--- a/.phan/plugins/README.md
+++ b/.phan/plugins/README.md
@@ -62,6 +62,10 @@ Checks for syntactically unreachable statements in the global scope or function 
 
 This is in development, and has some edge cases related to try blocks.
 
+#### Unused variable detection
+
+See https://github.com/etsy/phan/issues/345
+
 ### 3. Plugins Specific to Code Styles
 
 These plugins may be useful to enforce certain code styles,

--- a/phan_client
+++ b/phan_client
@@ -173,7 +173,6 @@ class PhanPHPLinter {
         }
         stream_socket_shutdown($client, STREAM_SHUT_RD);
         fclose($client);
-        $client = null;
         $response_bytes = implode('', $response_lines);
         // This uses the 'phplike' format imitating php's error format. "%s in %s on line %d"
         $response = json_decode($response_bytes, true);

--- a/src/Phan/AST/ASTSimplifier.php
+++ b/src/Phan/AST/ASTSimplifier.php
@@ -367,7 +367,6 @@ class ASTSimplifier {
         \assert($node->children[0]->children['cond']->flags === \ast\flags\UNARY_BOOL_NOT);
         \assert($node->children[1]->children['cond'] === null);
         $new_node = clone($node);
-        $if_elem = $new_node->children[0];
         $new_node->children = [clone($new_node->children[1]), clone($new_node->children[0])];
         $new_node->children[0]->children['cond'] = $node->children[0]->children['cond']->children['expr'];
         $new_node->children[1]->children['cond'] = null;

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -314,14 +314,12 @@ class ContextNode
         }
 
         $node = $this->node;
-        $parent = $node;
 
         while (($node instanceof \ast\Node)
             && ($node->kind != \ast\AST_VAR)
             && ($node->kind != \ast\AST_STATIC)
             && ($node->kind != \ast\AST_MAGIC_CONST)
         ) {
-            $parent = $node;
             $node = \array_values($node->children ?? [])[0];
         }
 
@@ -522,10 +520,9 @@ class ContextNode
         // looking for
         foreach ($class_list as $i => $class) {
             if ($class->hasMethodWithName($this->code_base, $method_name, $is_direct)) {
-                return $class->getMethodByNameInContext(
+                return $class->getMethodByName(
                     $this->code_base,
-                    $method_name,
-                    $this->context
+                    $method_name
                 );
             } else if (!$is_static && $class->allowsCallingUndeclaredInstanceMethod($this->code_base)) {
                 return $class->getCallMethod($this->code_base);
@@ -654,10 +651,9 @@ class ContextNode
                     continue;
                 }
 
-                $method = $class->getMethodByNameInContext(
+                $method = $class->getMethodByName(
                     $this->code_base,
-                    '__invoke',
-                    $this->context
+                    '__invoke'
                 );
 
                 // Check the call for parameter and argument types

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -139,7 +139,7 @@ class UnionTypeVisitor extends AnalysisVisitor
      * Default visitor for node kinds that do not have
      * an overriding method
      *
-     * @param Node $node
+     * @param Node $node (@phan-unused-param)
      * An AST node we'd like to determine the UnionType
      * for
      *
@@ -260,7 +260,7 @@ class UnionTypeVisitor extends AnalysisVisitor
     /**
      * Visit a node with kind `\ast\AST_EMPTY`
      *
-     * @param Node $node
+     * @param Node $node (@phan-unused-param)
      * A node of the type indicated by the method name that we'd
      * like to figure out the type that it produces.
      *
@@ -276,7 +276,7 @@ class UnionTypeVisitor extends AnalysisVisitor
     /**
      * Visit a node with kind `\ast\AST_ISSET`
      *
-     * @param Node $node
+     * @param Node $node (@phan-unused-param)
      * A node of the type indicated by the method name that we'd
      * like to figure out the type that it produces.
      *
@@ -292,7 +292,7 @@ class UnionTypeVisitor extends AnalysisVisitor
     /**
      * Visit a node with kind `\ast\AST_INCLUDE_OR_EVAL`
      *
-     * @param Node $node
+     * @param Node $node (@phan-unused-param)
      * A node of the type indicated by the method name that we'd
      * like to figure out the type that it produces.
      *
@@ -349,7 +349,7 @@ class UnionTypeVisitor extends AnalysisVisitor
     /**
      * Visit a node with kind `\ast\AST_SHELL_EXEC`
      *
-     * @param Node $node
+     * @param Node $node (@phan-unused-param)
      * A node of the type indicated by the method name that we'd
      * like to figure out the type that it produces.
      *
@@ -892,7 +892,8 @@ class UnionTypeVisitor extends AnalysisVisitor
         UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $node->children['expr']);
         try {
             // Confirm that the right-side exists
-            $union_type = $this->visitClassNode(
+            // Compute the union type but don't use it.
+            $this->visitClassNode(
                 $node->children['class']
             );
         } catch (TypeException $exception) {
@@ -1083,7 +1084,7 @@ class UnionTypeVisitor extends AnalysisVisitor
     /**
      * Visit a node with kind `\ast\AST_ENCAPS_LIST`
      *
-     * @param Node $node
+     * @param Node $node (@phan-unused-param)
      * A node of the type indicated by the method name that we'd
      * like to figure out the type that it produces.
      *
@@ -1364,13 +1365,10 @@ class UnionTypeVisitor extends AnalysisVisitor
         );
 
         try {
-            $class_fqsen = null;
             foreach ($this->classListFromNode(
                     $node->children['class'] ?? $node->children['expr']
                 ) as $class
             ) {
-                $class_fqsen = $class->getFQSEN();
-
                 if (!$class->hasMethodWithName(
                     $this->code_base,
                     $method_name
@@ -1379,10 +1377,9 @@ class UnionTypeVisitor extends AnalysisVisitor
                 }
 
                 try {
-                    $method = $class->getMethodByNameInContext(
+                    $method = $class->getMethodByName(
                         $this->code_base,
-                        $method_name,
-                        $this->context
+                        $method_name
                     );
 
                     $union_type = $method->getUnionType();

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -453,10 +453,9 @@ class ArgumentType
                     }
 
                     try {
-                        $method = $class->getMethodByNameInContext(
+                        $method = $class->getMethodByName(
                             $code_base,
-                            $method_name,
-                            $context
+                            $method_name
                         );
                         // Return true if any of the possible methods (expect that just one is found) returns a reference.
                         if ($method->returnsRef()) {
@@ -565,8 +564,8 @@ class ArgumentType
                         $context,
                         $code_base,
                         ArrayType::instance(false)->asUnionType(),
-                        function (UnionType $node_type) use ($context, $method) {
-                        // "arg#1(pieces) is %s but {$method->getFQSEN()}() takes array when passed only 1 arg"
+                        function (UnionType $unused_node_type) use ($context, $method) {
+                            // "arg#1(pieces) is %s but {$method->getFQSEN()}() takes array when passed only 1 arg"
                             return Issue::fromType(Issue::ParamSpecial2)(
                                 $context->getFile(),
                                 $context->getLineNumberStart(), [
@@ -660,8 +659,8 @@ class ArgumentType
                     $context,
                     $code_base,
                     CallableType::instance(false)->asUnionType(),
-                    function (UnionType $node_type) use ($context, $method) {
-                    // "The last argument to {$method->getFQSEN()} must be a callable"
+                    function (UnionType $unused_node_type) use ($context, $method) {
+                        // "The last argument to {$method->getFQSEN()} must be a callable"
                         return Issue::fromType(Issue::ParamSpecial3)(
                         $context->getFile(),
                         $context->getLineNumberStart(), [
@@ -717,7 +716,7 @@ class ArgumentType
                     $context,
                     $code_base,
                     CallableType::instance(false)->asUnionType(),
-                    function (UnionType $node_type) use ($context, $method) {
+                    function (UnionType $unused_node_type) use ($context, $method) {
                     // "The last argument to {$method->getFQSEN()} must be a callable"
                         return Issue::fromType(Issue::ParamSpecial3)(
                         $context->getFile(),
@@ -734,7 +733,7 @@ class ArgumentType
                     $context,
                     $code_base,
                     CallableType::instance(false)->asUnionType(),
-                    function (UnionType $node_type) use ($context, $method) {
+                    function (UnionType $unused_node_type) use ($context, $method) {
                     // "The second last argument to {$method->getFQSEN()} must be a callable"
                         return Issue::fromType(Issue::ParamSpecial4)(
                         $context->getFile(),

--- a/src/Phan/Analysis/ArgumentVisitor.php
+++ b/src/Phan/Analysis/ArgumentVisitor.php
@@ -47,7 +47,7 @@ class ArgumentVisitor extends KindVisitorImplementation
      * Default visitor for node kinds that do not have
      * an overriding method
      *
-     * @param Node $node
+     * @param Node $node (@phan-unused-param)
      * A node to parse
      *
      * @return void
@@ -58,22 +58,25 @@ class ArgumentVisitor extends KindVisitorImplementation
     }
 
     /**
-     * @param Node $node
+     * @param Node $node (@phan-unused-param)
      * A node to parse
      *
      * @return void
      */
     public function visitVar(Node $node)
     {
+        /*
         try {
             $variable = (new ContextNode(
                 $this->code_base,
                 $this->context,
                 $node
             ))->getOrCreateVariable();
+            // Not going to add a reference to $variable
         } catch (\Exception $exception) {
             // Swallow it
         }
+         */
     }
 
     /**

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -41,7 +41,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         parent::__construct($code_base, $context);
     }
 
-    public function visit(Node $node) : Context
+    public function visit(Node $unused_node) : Context
     {
         return $this->context;
     }
@@ -131,10 +131,9 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
             );
         }
 
-        $method = $clazz->getMethodByNameInContext(
+        $method = $clazz->getMethodByName(
             $this->code_base,
-            $method_name,
-            $this->context
+            $method_name
         );
 
         // Parse the comment above the method to get
@@ -286,7 +285,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
     /**
      * @return ?FullyQualifiedClassName
      */
-    private static function getOverrideClassFQSEN(CodeBase $code_base, Context $context, Func $func)
+    private static function getOverrideClassFQSEN(CodeBase $code_base, Func $func)
     {
         $closure_scope = $func->getInternalScope();
 		if ($closure_scope instanceof ClosureScope) {
@@ -324,7 +323,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         Context $context,
         Func $func
     ) {
-        $override_this_fqsen = self::getOverrideClassFQSEN($code_base, $context, $func);
+        $override_this_fqsen = self::getOverrideClassFQSEN($code_base, $func);
         if ($override_this_fqsen !== null) {
             if ($context->getScope()->hasVariableWithName('this') || !$context->isInClassScope()) {
                 // Handle @phan-closure-scope - Should set $this to the overriden class, as well as handling self:: and parent::
@@ -528,7 +527,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         if ($node->children['value']->kind == \ast\AST_ARRAY) {
             foreach ($node->children['value']->children ?? [] as $child_node) {
 
-                $key_node = $child_node->children['key'] ?? null;
+                // $key_node = $child_node->children['key'] ?? null;
                 $value_node = $child_node->children['value'] ?? null;
 
                 // for syntax like: foreach ([] as list(, $a));

--- a/src/Phan/Language/Element/AddressableElement.php
+++ b/src/Phan/Language/Element/AddressableElement.php
@@ -121,7 +121,7 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
     }
 
     /**
-     * @param CodeBase $code_base
+     * @param CodeBase $code_base (@phan-unused-param, may be used by subclasses)
      * The code base in which this element exists.
      *
      * @return bool
@@ -198,7 +198,7 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
     }
 
     /**
-     * @param CodeBase $code_base
+     * @param CodeBase $code_base (@phan-unused-param)
      * Some elements may need access to the code base to
      * figure out their total reference count.
      *
@@ -227,12 +227,12 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
         $this->hydrateOnce($code_base);
     }
 
-    protected function hydrateOnce(CodeBase $code_base)
+    protected function hydrateOnce(CodeBase $unused_code_base)
     {
         // Do nothing unless overridden
     }
 
-    public function getElementNamespace(CodeBase $code_base) : string
+    public function getElementNamespace(CodeBase $unused_code_base) : string
     {
         $element_fqsen = $this->getFQSEN();
         \assert($element_fqsen instanceof FullyQualifiedGlobalStructuralElement);

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -218,9 +218,8 @@ class Method extends ClassElement implements FunctionInterface
      * @return Method
      * A default constructor for the given class
      */
-    public static function defaultConstructorForClassInContext(
+    public static function defaultConstructorForClass(
         Clazz $clazz,
-        Context $context,
         CodeBase $code_base
     ) : Method {
         if ($clazz->getFQSEN()->getNamespace() === '\\' && $clazz->hasMethodWithName($code_base, $clazz->getName())) {
@@ -261,7 +260,6 @@ class Method extends ClassElement implements FunctionInterface
      */
     public function createUseAlias(
         Clazz $clazz,
-        CodeBase $code_base,
         string $alias_method_name,
         int $new_visibility_flags
     ) : Method {

--- a/src/Phan/Language/Element/TypedElement.php
+++ b/src/Phan/Language/Element/TypedElement.php
@@ -308,7 +308,7 @@ abstract class TypedElement implements TypedElementInterface
      *
      * @return void
      */
-    public function hydrate(CodeBase $code_base)
+    public function hydrate(CodeBase $unused_code_base)
     {
         // Do nothing unless overridden
     }

--- a/src/Phan/Language/Type/MixedType.php
+++ b/src/Phan/Language/Type/MixedType.php
@@ -13,20 +13,20 @@ final class MixedType extends NativeType
 
     // mixed or ?mixed can cast to/from anything.
     // For purposes of analysis, there's no difference between mixed and nullable mixed.
-    public function canCastToType(Type $type) : bool {
+    public function canCastToType(Type $unused_type) : bool {
         return true;
     }
 
     // mixed or ?mixed can cast to/from anything.
     // For purposes of analysis, there's no difference between mixed and nullable mixed.
-    protected function canCastToNonNullableType(Type $type) : bool {
+    protected function canCastToNonNullableType(Type $unused_type) : bool {
         return true;
     }
 
     public function isExclusivelyNarrowedFormOrEquivalentTo(
         UnionType $union_type,
-        Context $context,
-        CodeBase $code_base
+        Context $unused_context,
+        CodeBase $unused_code_base
     ) : bool {
         // Type casting rules allow mixed to cast to anything.
         // But we don't want `@param mixed $x` to take precedence over `int $x` in the signature.

--- a/src/Phan/Language/Type/NullType.php
+++ b/src/Phan/Language/Type/NullType.php
@@ -21,9 +21,9 @@ final class NullType extends ScalarType
      * @param UnionType[] $template_parameter_type_list
      * A (possibly empty) list of template parameter types
      *
-     * @param bool $is_nullable
+     * @param bool $is_nullable (@phan-unused-param)
      * True if this type can be null, false if it cannot
-     * be null.
+     * be null. (NullType can always be null)
      */
     protected function __construct(
         string $namespace,
@@ -84,7 +84,7 @@ final class NullType extends ScalarType
     }
 
     /**
-     * @param bool $is_nullable
+     * @param bool $is_nullable (@phan-unused-param)
      * Set to true if the type should be nullable, else pass
      * false
      *

--- a/src/Phan/Language/Type/ScalarType.php
+++ b/src/Phan/Language/Type/ScalarType.php
@@ -40,9 +40,9 @@ abstract class ScalarType extends NativeType
     }
 
     /**
-     * @param CodeBase $code_base
+     * @param CodeBase $code_base (@phan-unused-param)
      *
-     * @param Type $parent
+     * @param Type $parent (@phan-unused-param)
      *
      * @return bool
      * True if this type represents a class which is a sub-type of
@@ -82,8 +82,8 @@ abstract class ScalarType extends NativeType
      */
     public function isExclusivelyNarrowedFormOrEquivalentTo(
         UnionType $union_type,
-        Context $context,
-        CodeBase $code_base
+        Context $unused_context,
+        CodeBase $unused_code_base
     ) : bool {
         return $union_type->hasType($this) || $this->asUnionType()->canCastToUnionType($union_type);
     }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -121,7 +121,7 @@ class UnionType implements \Serializable
         }
 
         return new UnionType(
-            \array_map(function (string $type_name) use ($context, $type_string, $source) {
+            \array_map(function (string $type_name) use ($context, $source) {
                 \assert($type_name !== '', "Type cannot be empty.");
                 return Type::fromStringInContext(
                     $type_name,
@@ -1144,9 +1144,6 @@ class UnionType implements \Serializable
     }
 
     /**
-     * @param CodeBase $code_base
-     * The code base in which to find classes
-     *
      * @param Context $context
      * The context in which we're resolving this union
      * type.
@@ -1167,7 +1164,6 @@ class UnionType implements \Serializable
      * TODO: Add a method to ContextNode to directly get FQSEN instead?
      */
     public function asClassFQSENList(
-        CodeBase $code_base,
         Context $context
     ) {
         // Iterate over each viable class type to see if any

--- a/src/Phan/Library/Hasher/Sequential.php
+++ b/src/Phan/Library/Hasher/Sequential.php
@@ -19,6 +19,7 @@ class Sequential implements Hasher {
     }
 
     /**
+     * @param string $key (Used by sibling class Consistent) (@phan-unused-param)
      * @return int - an integer between 0 and $this->_groupCount - 1, inclusive
      */
     public function getGroup(string $key) : int {

--- a/src/Phan/Library/Some.php
+++ b/src/Phan/Library/Some.php
@@ -37,7 +37,7 @@ class Some extends Option
     }
 
     /**
-     * @param T $else
+     * @param T $else used in the None sibling class (@phan-unused-param)
      * @return T
      */
     public function getOrElse($else)

--- a/src/Phan/Output/Collector/ParallelParentCollector.php
+++ b/src/Phan/Output/Collector/ParallelParentCollector.php
@@ -135,7 +135,7 @@ class ParallelParentCollector implements IssueCollectorInterface
      * Remove all collected issues (from the parse phase) for the given file paths.
      * Called from daemon mode.
      *
-     * @param string[] $files - the relative paths to those files
+     * @param string[] $files - the relative paths to those files (@phan-unused-param)
      * @return void
      */
     public function removeIssuesForFiles(array $files) {

--- a/src/Phan/Output/Filter/AnyFilter.php
+++ b/src/Phan/Output/Filter/AnyFilter.php
@@ -8,7 +8,7 @@ final class AnyFilter implements IssueFilterInterface
 {
 
     /**
-     * @param IssueInstance $issue
+     * @param IssueInstance $issue (@phan-unused-param)
      * @return bool
      */
     public function supports(IssueInstance $issue):bool

--- a/src/Phan/Output/Printer/PlainTextPrinter.php
+++ b/src/Phan/Output/Printer/PlainTextPrinter.php
@@ -38,18 +38,18 @@ final class PlainTextPrinter implements IssuePrinterInterface
                 break;
             }
             $issue = Colorizing::colorizeTemplate("{FILE}:{LINE} $issue_type_template %s", [
-                $instance->getFile(),
-                $instance->getLine(),
-                $instance->getIssue()->getType(),
-                $instance->getMessage(),
+                $file,
+                $line,
+                $type,
+                $message
             ]);
         } else {
             $issue = sprintf(
                 '%s:%d %s %s',
-                $instance->getFile(),
-                $instance->getLine(),
-                $instance->getIssue()->getType(),
-                $instance->getMessage()
+                $file,
+                $line,
+                $type,
+                $message
             );
         }
 

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -1203,7 +1203,7 @@ class ParseVisitor extends ScopeVisitor
 
             // If we find a class definition, then return it. There should be 0 or 1.
             // (Expressions such as 'int::class' are syntactically valid, but would have 0 results).
-            foreach ($class_type->asClassFQSENList($this->code_base, $this->context) as $class_fqsen) {
+            foreach ($class_type->asClassFQSENList($this->context) as $class_fqsen) {
                 return $class_fqsen;
             }
         }

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -183,9 +183,6 @@ class Phan implements IgnoredFilesFilterInterface {
             $code_base->disableUndoTracking();
         }
 
-        global $start_time;
-        $start_time = microtime(true);
-
         // With parsing complete, we need to tell the code base to
         // start hydrating any requested elements on their way out.
         // Hydration expands class types, imports parent methods,

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -295,7 +295,6 @@ final class ConfigPluginSet extends PluginV2 implements
                 if (!\is_subclass_of($plugin_analysis_class, PluginAwarePreAnalysisVisitor::class)) {
                     throw new \TypeError(sprintf("Result of %s::getAnalyzeNodeVisitorClassName must be the name of a subclass of '%s', but '%s' is not", get_class($plugin), PluginAwarePreAnalysisVisitor::class, $plugin_analysis_class));
                 }
-                $empty_object = (new \ReflectionClass($plugin_analysis_class))->newInstanceWithoutConstructor();
                 /**
                  * Create an instance of $plugin_analysis_class and run the visit*() method corresponding to $node->kind.
                  *

--- a/src/Phan/Plugin/PluginImplementation.php
+++ b/src/Phan/Plugin/PluginImplementation.php
@@ -26,15 +26,15 @@ class PluginImplementation extends Plugin {
      * update types in the CodeBase before analysis
      * happens.
      *
-     * @param CodeBase $code_base
+     * @param CodeBase $code_base (@phan-unused-param)
      * The code base in which the node exists
      *
-     * @param Context $context
+     * @param Context $context (@phan-unused-param)
      * The context in which the node exits. This is
      * the context inside the given node rather than
      * the context outside of the given node
      *
-     * @param Node $node
+     * @param Node $node (@phan-unused-param)
      * The php-ast Node being analyzed.
      *
      * @return void
@@ -47,18 +47,18 @@ class PluginImplementation extends Plugin {
     }
 
     /**
-     * @param CodeBase $code_base
+     * @param CodeBase $code_base (@phan-unused-param)
      * The code base in which the node exists
      *
-     * @param Context $context
+     * @param Context $context (@phan-unused-param)
      * The context in which the node exits. This is
      * the context inside the given node rather than
      * the context outside of the given node
      *
-     * @param Node $node
+     * @param Node $node (@phan-unused-param)
      * The php-ast Node being analyzed.
      *
-     * @param Node $node
+     * @param ?Node $parent_node (@phan-unused-param)
      * The parent node of the given node (if one exists).
      *
      * @return void
@@ -72,10 +72,10 @@ class PluginImplementation extends Plugin {
     }
 
     /**
-     * @param CodeBase $code_base
+     * @param CodeBase $code_base (@phan-unused-param)
      * The code base in which the class exists
      *
-     * @param Clazz $class
+     * @param Clazz $class (@phan-unused-param)
      * A class being analyzed
      *
      * @return void
@@ -87,10 +87,10 @@ class PluginImplementation extends Plugin {
     }
 
     /**
-     * @param CodeBase $code_base
+     * @param CodeBase $code_base (@phan-unused-param)
      * The code base in which the method exists
      *
-     * @param Method $method
+     * @param Method $method (@phan-unused-param)
      * A method being analyzed
      *
      * @return void
@@ -102,10 +102,10 @@ class PluginImplementation extends Plugin {
     }
 
     /**
-     * @param CodeBase $code_base
+     * @param CodeBase $code_base (@phan-unused-param)
      * The code base in which the function exists
      *
-     * @param Func $function
+     * @param Func $function (@phan-unused-param)
      * A function being analyzed
      *
      * @return void

--- a/src/Phan/PluginV2/PluginAwareBaseAnalysisVisitor.php
+++ b/src/Phan/PluginV2/PluginAwareBaseAnalysisVisitor.php
@@ -18,6 +18,7 @@ abstract class PluginAwareBaseAnalysisVisitor extends AnalysisVisitor {
      * This is an empty visit() body.
      * Don't override this unless you need to, analysis is more efficient if Phan knows it doesn't need to call a plugin on a node type.
      * @see self::isDefinedInSubclass
+     * @param $node @phan-unused-param (unused because the body is empty)
      *
      * @return void
      */

--- a/src/Phan/Profile.php
+++ b/src/Phan/Profile.php
@@ -40,7 +40,6 @@ trait Profile
 
         // Emit a log message
         $delta = ($end_time - $start_time);
-        $message = "$label\t$delta\n";
 
         self::$label_delta_map[$label][] = $delta;
 

--- a/tests/Phan/ASTRewriterTest.php
+++ b/tests/Phan/ASTRewriterTest.php
@@ -25,9 +25,9 @@ class ASTRewriterTest extends AbstractPhanFileTest {
      * to the ASTs of the counterparts in
      * `tests/files/expected`
      *
-     * @param string[] $test_file_list (unused)
+     * @param string[] $test_file_list @phan-unused-param
      * @param string $expected_file_path
-     * @param ?string $config_file_path
+     * @param ?string $config_file_path @phan-unused-param
      * @dataProvider getTestFiles
      * @override
      */

--- a/tests/Phan/AnalyzerTest.php
+++ b/tests/Phan/AnalyzerTest.php
@@ -57,10 +57,9 @@ class AnalyzerTest extends BaseTest {
 
     public function testClassInCodeBase() {
 
-        $context =
-            $this->contextForCode("
-                Class A {}
-            ");
+        $this->contextForCode("
+            Class A {}
+        ");
 
         self::assertTrue(
             $this->code_base->hasClassWithFQSEN(
@@ -70,11 +69,10 @@ class AnalyzerTest extends BaseTest {
     }
 
     public function testNamespaceClassInCodeBase() {
-        $context =
-            $this->contextForCode("
-                namespace A;
-                Class B {}
-            ");
+        $this->contextForCode("
+            namespace A;
+            Class B {}
+        ");
 
         self::assertTrue(
             $this->code_base->hasClassWithFQSEN(
@@ -84,15 +82,14 @@ class AnalyzerTest extends BaseTest {
     }
 
     public function testMethodInCodeBase() {
-        $context =
-            $this->contextForCode("
-                namespace A;
-                Class B {
-                    public function c() {
-                        return 42;
-                    }
+        $this->contextForCode("
+            namespace A;
+            Class B {
+                public function c() {
+                    return 42;
                 }
-            ");
+            }
+        ");
 
         $class_fqsen =
             FullyQualifiedClassName::fromFullyQualifiedString('\A\B');

--- a/tests/Phan/ForkPoolTest.php
+++ b/tests/Phan/ForkPoolTest.php
@@ -33,7 +33,7 @@ class ForkPoolTest extends BaseTest
             /** @return void */
             function() { },
             /** @return void */
-            function($i, $data) use(&$worker_data) {
+            function($unused_i, $data) use(&$worker_data) {
                 $worker_data[] = $data;
             },
             function() use(&$worker_data) : array {
@@ -57,7 +57,7 @@ class ForkPoolTest extends BaseTest
                 $did_startup = true;
             },
             /** @return void */
-            function($i, $data) {
+            function($unused_i, $unused_data) {
             },
             function() use(&$did_startup) : array {
                 return [$did_startup];

--- a/tests/Phan/PhanTestListener.php
+++ b/tests/Phan/PhanTestListener.php
@@ -56,6 +56,9 @@ class PhanTestListener
         }
     }
 
+    /**
+     * @param $time @phan-unused-param
+     */
     public function endTest(Test $test, $time) {
         if ($test instanceof CodeBaseAwareTestInterface) {
             $test->setCodeBase(null);

--- a/tests/plugin_test/test.sh
+++ b/tests/plugin_test/test.sh
@@ -9,7 +9,7 @@ echo "Running phan in '$PWD' ..."
 rm $ACTUAL_PATH -f || exit 1
 ../../phan | tee $ACTUAL_PATH
 # diff returns a non-zero exit code if files differ or are missing
-# This outputs the 
+# This outputs the difference between actual and expected output.
 echo
 echo "Comparing the output:"
 diff $EXPECTED_PATH $ACTUAL_PATH


### PR DESCRIPTION
Remove code with no side effects from
\Phan\Analysis\ArgumentType->visitVariable

Link to in development plugin for unused variable detection

Related to #345