### PR TITLE
Fixes #1028: Fix bug in UnreachableStatementPlugin

### DIFF
--- a/.phan/plugins/InvalidVariableIssetPlugin.php
+++ b/.phan/plugins/InvalidVariableIssetPlugin.php
@@ -63,7 +63,7 @@ class InvalidVariableIssetVisitor extends PluginAwareAnalysisVisitor {
                     !$this->context->getScope()->hasVariableWithName($name)) {
                 $this->emit(
                     'PhanPluginUndeclaredVariableIsset',
-                    'undeclared variable ${NAME} in isset()',
+                    'undeclared variable ${VARIABLE} in isset()',
                     [$name]
                 );
             }

--- a/tests/plugin_test/expected/all_output.expected
+++ b/tests/plugin_test/expected/all_output.expected
@@ -22,6 +22,7 @@ src/001_globals_type_map.php:8 PhanTypeMismatchArgumentInternal Argument 1 (nume
 src/001_globals_type_map.php:12 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \Exception|\Throwable but \intdiv() takes int
 src/001_globals_type_map.php:15 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \Error|\Throwable but \intdiv() takes int
 src/002_unreachable_code.php:5 PhanPluginUnreachableCode Unreachable statement detected
-src/002_unreachable_code.php:20 PhanPluginUnreachableCode Unreachable statement detected
-src/002_unreachable_code.php:22 PhanPluginUnreachableCode Unreachable statement detected
-src/002_unreachable_code.php:37 PhanPluginUnreachableCode Unreachable statement detected
+src/002_unreachable_code.php:23 PhanPluginUnreachableCode Unreachable statement detected
+src/002_unreachable_code.php:25 PhanPluginUnreachableCode Unreachable statement detected
+src/002_unreachable_code.php:40 PhanPluginUnreachableCode Unreachable statement detected
+src/002_unreachable_code.php:64 PhanPluginUnreachableCode Unreachable statement detected

--- a/tests/plugin_test/src/002_unreachable_code.php
+++ b/tests/plugin_test/src/002_unreachable_code.php
@@ -4,7 +4,10 @@ function unreachableCode() {
     throw new \RuntimeException("Exception");
     return null;
 }
-unreachableCode();
+try {
+    unreachableCode();
+} catch (Exception $e) {
+}
 
 class testUnreachableCode {
     public function __construct($x) {
@@ -51,3 +54,14 @@ class testUnreachableCode {
 }
 $c = new testUnreachableCode(0);
 $c->unreachableSwitch(4);
+
+$d = new ReachableClass();
+reachableFunction();
+return;
+
+class ReachableClass {
+}
+echo "Not reached\n";
+
+function reachableFunction() {
+}


### PR DESCRIPTION
Don't warn about function/class declarations at the top level,
even if they're after a return statement.

Also, fix incorrect placeholder for a plugin issue message