### PR TITLE
Fix for type narrowing bleed for ternary conditional in global scope

### DIFF
--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -8,8 +8,9 @@ use Phan\CodeBase;
 use Phan\Config;
 use Phan\Exception\IssueException;
 use Phan\Issue;
-use Phan\Language\Type;
 use Phan\Language\Context;
+use Phan\Language\Element\Variable;
+use Phan\Language\Type;
 use Phan\Language\Type\ArrayType;
 use Phan\Language\Type\CallableType;
 use Phan\Language\Type\FloatType;
@@ -20,7 +21,6 @@ use Phan\Language\Type\ObjectType;
 use Phan\Language\Type\ResourceType;
 use Phan\Language\Type\ScalarType;
 use Phan\Language\Type\StringType;
-use Phan\Language\Element\Variable;
 use Phan\Language\UnionType;
 use ast\Node;
 

--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -8,8 +8,9 @@ use Phan\CodeBase;
 use Phan\Config;
 use Phan\Exception\IssueException;
 use Phan\Issue;
-use Phan\Language\Type;
 use Phan\Language\Context;
+use Phan\Language\Element\Variable;
+use Phan\Language\Type;
 use Phan\Language\Type\ArrayType;
 use Phan\Language\Type\CallableType;
 use Phan\Language\Type\FloatType;
@@ -20,7 +21,6 @@ use Phan\Language\Type\ObjectType;
 use Phan\Language\Type\ResourceType;
 use Phan\Language\Type\ScalarType;
 use Phan\Language\Type\StringType;
-use Phan\Language\Element\Variable;
 use Phan\Language\UnionType;
 use ast\Node;
 
@@ -406,7 +406,6 @@ class NegatedConditionVisitor extends KindVisitorImplementation
             'is_integer' => $remove_int_callback,
             'is_iterable' => $make_basic_negated_assertion_callback(IterableType::class),  // TODO: Could keep basic array types and classes extending iterable
             'is_long' => $remove_int_callback,
-            'is_null' => $remove_null_cb,
             // 'is_numeric' => $make_basic_assertion_callback('string|int|float'),
             // TODO 'is_object' => $remove_object_callback,
             'is_real' => $remove_float_callback,

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -767,13 +767,19 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         // - Also note that some things such as `true` and `false` are \ast\AST_NAME nodes.
 
         if ($cond_node instanceof Node) {
+            // TODO: Use different contexts and merge those, in case there were assignments or assignments by reference in both sides of the conditional?
+            // Reuse the BranchScope (sort of unintuitive). The ConditionVisitor returns a clone and doesn't modify the original.
+            $base_context = $this->context;
+            // We don't bother analyzing visitReturn in PostOrderAnalysisVisitor, right now.
+            // This may eventually change, just to ensure the expression is checked for issues
+            assert($base_context->isInFunctionLikeScope());
             $true_context = (new ConditionVisitor(
                 $this->code_base,
-                $context
+                $base_context
             ))($cond_node);
             $false_context = (new NegatedConditionVisitor(
                 $this->code_base,
-                $this->context
+                $base_context
             ))($cond_node);
         } else {
             $true_context = $context;

--- a/src/Phan/Language/Scope/GlobalScope.php
+++ b/src/Phan/Language/Scope/GlobalScope.php
@@ -4,6 +4,8 @@ namespace Phan\Language\Scope;
 use Phan\Language\Element\Variable;
 use Phan\Language\Scope;
 
+// TODO: Warn if __clone() is called, the code is doing something wrong.
+//       the underlying static $global_variable_map isn't cloned, so it's a no-op.
 class GlobalScope extends Scope {
 
     /**

--- a/tests/files/expected/0347_global_ternarytest.php.expected
+++ b/tests/files/expected/0347_global_ternarytest.php.expected
@@ -1,0 +1,6 @@
+%s:16 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \A347 but \intdiv() takes int
+%s:17 PhanTypeMismatchArgumentInternal Argument 2 (divisor) is null but \intdiv() takes int
+%s:20 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \A347 but \intdiv() takes int
+%s:22 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is null but \intdiv() takes int
+%s:27 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is null but \intdiv() takes int
+%s:28 PhanTypeMismatchArgumentInternal Argument 2 (divisor) is null but \intdiv() takes int

--- a/tests/files/src/0347_global_ternarytest.php
+++ b/tests/files/src/0347_global_ternarytest.php
@@ -1,0 +1,28 @@
+<?php
+
+class A347 {
+    public function myMethod() {}
+}
+
+/**
+ * @return A347|null
+ */
+function A347F() {
+}
+
+// Regression test for ternary operator in global scope.
+$c = A347F();
+$d = !is_null($c) ?
+    intdiv($c, 2) :
+    intdiv(4, $c);
+$e = A347F();
+if (!is_null($e)) {
+    intdiv($e, 2);
+} else {
+    intdiv($e, 2);
+}
+$f = A347F();
+// Regression test for ternary operator as statement in global scope.
+!is_null($f) ?
+    intdiv($c, 2) :
+    intdiv(4, $c);


### PR DESCRIPTION
Fixes regressions in solution to #538 for ternary operators.

This bug would lead to erroneously inferring the types from
the right hand side of a ternary operator in the global scope,
in statements following a ternary operator.

(Cloning the global scope has no effect;
it has static variables, not instance variables)

Add tests.