### PR TITLE
Update php-ast dep to version 50, update development version from 0.9.x to 0.10.x for php 7.1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,13 @@ Phan NEWS
 ?? ??? 2017, Phan 0.9.5 (dev)
 -----------------------
 
+Maintenance
++ Increased minimum `ext-ast` version constraint to 0.1.5, switched to AST version 50.
+
+Plugins
++ Increased minimum `ext-ast` version constraint to 0.1.5, switched to AST version 50.
+  Third party plugins will need to create a different version, Decls were changed into regular Nodes
+
 15 Aug 2017, Phan 0.9.4
 -----------------------
 

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,6 @@
 Phan NEWS
 
-?? ??? 2017, Phan 0.9.5 (dev)
+?? ??? 2017, Phan 0.10.0 (dev)
 -----------------------
 
 Maintenance

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ composer require --dev etsy/phan
 With Phan installed, you'll want to [create a `.phan/config.php` file](https://github.com/etsy/phan/wiki/Getting-Started#creating-a-config-file) in
 your project to tell Phan how to analyze your source code. Once configured, you can run it via `./vendor/bin/phan`.
 
-This version (branch) of Phan depends on PHP 7.1.x with the [php-ast](https://github.com/nikic/php-ast) extension (0.1.5 or newer) and supports PHP version 7.1+ syntax.
+This version (branch) of Phan depends on PHP 7.1.x with the [php-ast](https://github.com/nikic/php-ast) extension (0.1.5 or newer, uses AST version 50) and supports PHP version 7.1+ syntax.
+The 0.9.x releases work with older versions of php-ast (0.1.4 or newer, Phan uses AST version 40. Use this if third party integrations (e.g. plugins) are still expecting AST version 40 (`\ast\Node\Decl`)).
 For PHP 7.0.x use the [0.8 branch](https://github.com/etsy/phan/tree/0.8).
 Having PHP's `pcntl` extension installed is strongly recommended (not available on Windows), in order to support using parallel processes for analysis (or to support daemon mode).
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ composer require --dev etsy/phan
 With Phan installed, you'll want to [create a `.phan/config.php` file](https://github.com/etsy/phan/wiki/Getting-Started#creating-a-config-file) in
 your project to tell Phan how to analyze your source code. Once configured, you can run it via `./vendor/bin/phan`.
 
-This version (branch) of Phan depends on PHP 7.1.x with the [php-ast](https://github.com/nikic/php-ast) extension and supports PHP version 7.1+ syntax.
+This version (branch) of Phan depends on PHP 7.1.x with the [php-ast](https://github.com/nikic/php-ast) extension (0.1.5 or newer) and supports PHP version 7.1+ syntax.
 For PHP 7.0.x use the [0.8 branch](https://github.com/etsy/phan/tree/0.8).
 Having PHP's `pcntl` extension installed is strongly recommended (not available on Windows), in order to support using parallel processes for analysis (or to support daemon mode).
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "php": "~7.1.0",
-        "ext-ast": "^0.1.4",
+        "ext-ast": "^0.1.5",
         "symfony/console": "~2.3|~3.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ab54bf34f5d59b37b3cae314a774b14a",
+    "content-hash": "a9119b755400f8f9ab9657ec300f4cb3",
     "packages": [
         {
             "name": "psr/log",
@@ -1696,7 +1696,7 @@
     "prefer-lowest": false,
     "platform": {
         "php": "~7.1.0",
-        "ext-ast": "^0.1.4"
+        "ext-ast": "^0.1.5"
     },
     "platform-dev": []
 }

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -37,7 +37,6 @@ use Phan\Library\FileCache;
 use Phan\Library\None;
 use Phan\Library\Some;
 use ast\Node;
-use ast\Node\Decl;
 
 /**
  * Methods for an AST node in context
@@ -51,7 +50,7 @@ class ContextNode
     /** @var Context */
     private $context;
 
-    /** @var Decl|Node|string|null */
+    /** @var Node|string|null */
     private $node;
 
     /**

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -39,7 +39,6 @@ use Phan\Language\Type\VoidType;
 use Phan\Language\UnionType;
 use Phan\Library\ArraySet;
 use ast\Node;
-use ast\Node\Decl;
 
 /**
  * Determine the UnionType associated with a
@@ -1008,7 +1007,7 @@ class UnionTypeVisitor extends AnalysisVisitor
     /**
      * Visit a node with kind `\ast\AST_CLOSURE`
      *
-     * @param Decl $node
+     * @param Node $node
      * A node of the type indicated by the method name that we'd
      * like to figure out the type that it produces.
      *
@@ -1016,7 +1015,7 @@ class UnionTypeVisitor extends AnalysisVisitor
      * The set of types that are possibly produced by the
      * given node
      */
-    public function visitClosure(Decl $node) : UnionType
+    public function visitClosure(Node $node) : UnionType
     {
         // The type of a closure is the fqsen pointing
         // at its definition

--- a/src/Phan/AST/Visitor/Element.php
+++ b/src/Phan/AST/Visitor/Element.php
@@ -3,7 +3,6 @@ namespace Phan\AST\Visitor;
 
 use Phan\Debug;
 use ast\Node;
-use ast\Node\Decl;
 
 class Element
 {

--- a/src/Phan/AST/Visitor/KindVisitor.php
+++ b/src/Phan/AST/Visitor/KindVisitor.php
@@ -2,7 +2,6 @@
 namespace Phan\AST\Visitor;
 
 use ast\Node;
-use ast\Node\Decl;
 
 /**
  * A visitor of AST nodes based on the node's kind value
@@ -68,7 +67,7 @@ interface KindVisitor
     /**
      * Visit a node with kind `\ast\AST_CLASS`
      */
-    public function visitClass(Decl $node);
+    public function visitClass(Node $node);
 
     /**
      * Visit a node with kind `\ast\AST_CLASS_CONST`
@@ -83,7 +82,7 @@ interface KindVisitor
     /**
      * Visit a node with kind `\ast\AST_CLOSURE`
      */
-    public function visitClosure(Decl $node);
+    public function visitClosure(Node $node);
 
     /**
      * Visit a node with kind `\ast\AST_CLOSURE_USES`
@@ -163,7 +162,7 @@ interface KindVisitor
     /**
      * Visit a node with kind `\ast\AST_FUNC_DECL`
      */
-    public function visitFuncDecl(Decl $node);
+    public function visitFuncDecl(Node $node);
 
     /**
      * Visit a node with kind `\ast\AST_ISSET`
@@ -213,7 +212,7 @@ interface KindVisitor
     /**
      * Visit a node with kind `\ast\AST_METHOD`
      */
-    public function visitMethod(Decl $node);
+    public function visitMethod(Node $node);
 
     /**
      * Visit a node with kind `\ast\AST_METHOD_CALL`

--- a/src/Phan/AST/Visitor/KindVisitorImplementation.php
+++ b/src/Phan/AST/Visitor/KindVisitorImplementation.php
@@ -2,7 +2,6 @@
 namespace Phan\AST\Visitor;
 
 use ast\Node;
-use ast\Node\Decl;
 
 /**
  * A visitor of AST nodes based on the node's kind value
@@ -77,7 +76,7 @@ abstract class KindVisitorImplementation implements KindVisitor
         return $this->visit($node);
     }
 
-    public function visitClass(Decl $node)
+    public function visitClass(Node $node)
     {
         return $this->visit($node);
     }
@@ -92,7 +91,7 @@ abstract class KindVisitorImplementation implements KindVisitor
         return $this->visit($node);
     }
 
-    public function visitClosure(Decl $node)
+    public function visitClosure(Node $node)
     {
         return $this->visit($node);
     }
@@ -172,7 +171,7 @@ abstract class KindVisitorImplementation implements KindVisitor
         return $this->visit($node);
     }
 
-    public function visitFuncDecl(Decl $node)
+    public function visitFuncDecl(Node $node)
     {
         return $this->visit($node);
     }
@@ -222,7 +221,7 @@ abstract class KindVisitorImplementation implements KindVisitor
         return $this->visit($node);
     }
 
-    public function visitMethod(Decl $node)
+    public function visitMethod(Node $node)
     {
         return $this->visit($node);
     }

--- a/src/Phan/Analysis/ArgumentVisitor.php
+++ b/src/Phan/Analysis/ArgumentVisitor.php
@@ -8,7 +8,6 @@ use Phan\Exception\IssueException;
 use Phan\Issue;
 use Phan\Language\Context;
 use ast\Node;
-use ast\Node\Decl;
 
 class ArgumentVisitor extends KindVisitorImplementation
 {
@@ -140,12 +139,12 @@ class ArgumentVisitor extends KindVisitorImplementation
     }
 
     /**
-     * @param Decl $node
+     * @param Node $node
      * A node to parse
      *
      * @return void
      */
-    public function visitClosure(Decl $node)
+    public function visitClosure(Node $node)
     {
         try {
             $method = (new ContextNode(

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -26,7 +26,6 @@ use Phan\Language\Type\NullType;
 use Phan\Language\Type\VoidType;
 use Phan\Language\UnionType;
 use ast\Node;
-use ast\Node\Decl;
 
 class PostOrderAnalysisVisitor extends AnalysisVisitor
 {
@@ -570,14 +569,14 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
     }
 
     /**
-     * @param Decl $node
+     * @param Node $node
      * A node to parse
      *
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitClosure(Decl $node) : Context
+    public function visitClosure(Node $node) : Context
     {
         $func = $this->context->getFunctionLikeInScope($this->code_base);
 
@@ -1280,14 +1279,14 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
     }
 
     /**
-     * @param Decl $node
+     * @param Node $node
      * A node to parse
      *
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitMethod(Decl $node) : Context
+    public function visitMethod(Node $node) : Context
     {
         \assert($this->context->isInFunctionLikeScope(),
             "Must be in function-like scope to get method");
@@ -1363,14 +1362,14 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
     /**
      * Visit a node with kind `\ast\AST_FUNC_DECL`
      *
-     * @param Decl $node
+     * @param Node $node
      * A node to parse
      *
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitFuncDecl(Decl $node) : Context
+    public function visitFuncDecl(Node $node) : Context
     {
         $method =
             $this->context->getFunctionLikeInScope($this->code_base);
@@ -2113,14 +2112,14 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
     }
 
     /**
-     * @param Decl $node
+     * @param Node $node
      * A decl to check to see if it's only effect
      * is the throw an exception
      *
      * @return bool
      * True when the decl can only throw an exception or return or exit()
      */
-    private function declOnlyThrows(Decl $node) : bool {
+    private function declOnlyThrows(Node $node) : bool {
         return BlockExitStatusChecker::willUnconditionallyThrowOrReturn($node->children['stmts']);
     }
 }

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -22,7 +22,6 @@ use Phan\Language\Scope\ClosureScope;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
 use ast\Node;
-use ast\Node\Decl;
 
 class PreOrderAnalysisVisitor extends ScopeVisitor
 {
@@ -49,14 +48,14 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
     /**
      * Visit a node with kind `\ast\AST_CLASS`
      *
-     * @param Decl $node
+     * @param Node $node
      * A node to parse
      *
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitClass(Decl $node) : Context
+    public function visitClass(Node $node) : Context
     {
         if ($node->flags & \ast\flags\CLASS_ANONYMOUS) {
             $class_name =
@@ -66,7 +65,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
                     $node
                 ))->getUnqualifiedNameForAnonymousClass();
         } else {
-            $class_name = (string)$node->name;
+            $class_name = (string)$node->children['name'];
         }
 
         \assert(!empty($class_name), "Class name cannot be empty");
@@ -105,16 +104,16 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
     /**
      * Visit a node with kind `\ast\AST_METHOD`
      *
-     * @param Decl $node
+     * @param Node $node
      * A node to parse
      *
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitMethod(Decl $node) : Context
+    public function visitMethod(Node $node) : Context
     {
-        $method_name = (string)$node->name;
+        $method_name = (string)$node->children['name'];
 
         \assert($this->context->isInClassScope(),
             "Must be in class context to see a method");
@@ -139,7 +138,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         // Parse the comment above the method to get
         // extra meta information about the method.
         $comment = Comment::fromStringInContext(
-            $node->docComment ?? '',
+            $node->children['docComment'] ?? '',
             $this->code_base,
             $this->context,
             $node->lineno ?? 0,
@@ -194,16 +193,16 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
     /**
      * Visit a node with kind `\ast\AST_FUNC_DECL`
      *
-     * @param Decl $node
+     * @param Node $node
      * A node to parse
      *
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitFuncDecl(Decl $node) : Context
+    public function visitFuncDecl(Node $node) : Context
     {
-        $function_name = (string)$node->name;
+        $function_name = (string)$node->children['name'];
 
         try {
             $canonical_function = (new ContextNode(
@@ -249,7 +248,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         // Parse the comment above the function to get
         // extra meta information about the method.
         $comment = Comment::fromStringInContext(
-            $node->docComment ?? '',
+            $node->children['docComment'] ?? '',
             $this->code_base,
             $this->context,
             $node->lineno ?? 0,
@@ -351,14 +350,14 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
     /**
      * Visit a node with kind `\ast\AST_CLOSURE`
      *
-     * @param Decl $node
+     * @param Node $node
      * A node to parse
      *
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitClosure(Decl $node) : Context
+    public function visitClosure(Node $node) : Context
     {
         $closure_fqsen = FullyQualifiedFunctionName::fromClosureInContext(
             $this->context->withLineNumberStart($node->lineno ?? 0),

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -14,7 +14,6 @@ use Phan\Language\Scope\BranchScope;
 use Phan\Language\Scope\GlobalScope;
 use Phan\Plugin\ConfigPluginSet;
 use ast\Node;
-use ast\Node\Decl;
 
 /**
  * Analyze blocks of code
@@ -682,49 +681,49 @@ class BlockAnalysisVisitor extends AnalysisVisitor {
     }
 
     /**
-     * @param Decl $node
+     * @param Node $node
      * An AST node we'd like to analyze the statements for
      *
      * @return Context
      * The updated context after visiting the node
      */
-    public function visitClass(Decl $node) : Context
+    public function visitClass(Node $node) : Context
     {
         return $this->visitClosedContext($node);
     }
 
     /**
-     * @param Decl $node
+     * @param Node $node
      * An AST node we'd like to analyze the statements for
      *
      * @return Context
      * The updated context after visiting the node
      */
-    public function visitMethod(Decl $node) : Context
+    public function visitMethod(Node $node) : Context
     {
         return $this->visitClosedContext($node);
     }
 
     /**
-     * @param Decl $node
+     * @param Node $node
      * An AST node we'd like to analyze the statements for
      *
      * @return Context
      * The updated context after visiting the node
      */
-    public function visitFuncDecl(Decl $node) : Context
+    public function visitFuncDecl(Node $node) : Context
     {
         return $this->visitClosedContext($node);
     }
 
     /**
-     * @param Decl $node
+     * @param Node $node
      * An AST node we'd like to analyze the statements for
      *
      * @return Context
      * The updated context after visiting the node
      */
-    public function visitClosure(Decl $node) : Context
+    public function visitClosure(Node $node) : Context
     {
         return $this->visitClosedContext($node);
     }

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -16,7 +16,7 @@ class CLI
     /**
      * This should be updated to x.y.z-dev after every release, and x.y.z before a release.
      */
-    const PHAN_VERSION = '0.9.5-dev';
+    const PHAN_VERSION = '0.10.0-dev';
 
     /**
      * @var OutputInterface

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -11,9 +11,9 @@ class Config
     /**
      * The version of the AST (defined in php-ast) that we're using.
      * Other versions are likely to have edge cases we no longer support,
-     * and version 45 will probably get rid of Decl.
+     * and version 50 got rid of Decl.
      */
-    const AST_VERSION = 40;
+    const AST_VERSION = 50;
 
     /**
      * The version of the Phan plugin system.

--- a/src/Phan/Debug.php
+++ b/src/Phan/Debug.php
@@ -2,7 +2,7 @@
 namespace Phan;
 
 use ast\Node;
-use ast\Node\Decl;
+use ast\flags;
 
 /**
  * Debug utilities
@@ -121,14 +121,13 @@ class Debug
             $string .= ' #' . $node->lineno;
         }
 
-        if ($node instanceof Decl) {
-            if (isset($node->endLineno)) {
-                $string .= ':' . $node->endLineno;
-            }
+        $endLineno = Util::getEndLineno($node);
+        if (!\is_null($endLineno)) {
+            $string .= ':' . $endLineno;
         }
 
-        if (isset($node->name)) {
-            $string .= ' name:' . $node->name;
+        if (isset($node->children['name'])) {
+            $string .= ' name:' . $node->children['name'];
         }
 
         $string .= "\n";
@@ -232,19 +231,20 @@ class Debug
 
             if ($options & self::AST_DUMP_LINENOS) {
                 $result .= " @ $ast->lineno";
-                if ($ast instanceof \ast\Node\Decl && isset($ast->endLineno)) {
-                    $result .= "-$ast->endLineno";
+                $endLineno = Util::getEndLineno($ast);
+                if (!\is_null($endLineno)) {
+                    $result .= "-$endLineno";
                 }
             }
 
             if (\ast\kind_uses_flags($ast->kind) || $ast->flags != 0) {
                 $result .= "\n    flags: " . self::formatFlags($ast->kind, $ast->flags);
             }
-            if ($ast instanceof \ast\Node\Decl && isset($ast->name)) {
-                $result .= "\n    name: $ast->name";
+            if (isset($ast->children['name'])) {
+                $result .= "\n    name: {$ast->children['name']}";
             }
-            if ($ast instanceof \ast\Node\Decl && isset($ast->docComment)) {
-                $result .= "\n    docComment: $ast->docComment";
+            if (isset($ast->children['docComment'])) {
+                $result .= "\n    docComment: {$ast->children['docComment']}";
             }
             foreach ($ast->children as $i => $child) {
                 $result .= "\n    $i: " . str_replace("\n", "\n    ", self::astDump($child, $options));
@@ -271,127 +271,131 @@ class Debug
         }
 
         $modifiers = [
-            \ast\flags\MODIFIER_PUBLIC => 'MODIFIER_PUBLIC',
-            \ast\flags\MODIFIER_PROTECTED => 'MODIFIER_PROTECTED',
-            \ast\flags\MODIFIER_PRIVATE => 'MODIFIER_PRIVATE',
-            \ast\flags\MODIFIER_STATIC => 'MODIFIER_STATIC',
-            \ast\flags\MODIFIER_ABSTRACT => 'MODIFIER_ABSTRACT',
-            \ast\flags\MODIFIER_FINAL => 'MODIFIER_FINAL',
-            \ast\flags\RETURNS_REF => 'RETURNS_REF',
+            flags\MODIFIER_PUBLIC => 'MODIFIER_PUBLIC',
+            flags\MODIFIER_PROTECTED => 'MODIFIER_PROTECTED',
+            flags\MODIFIER_PRIVATE => 'MODIFIER_PRIVATE',
+            flags\MODIFIER_STATIC => 'MODIFIER_STATIC',
+            flags\MODIFIER_ABSTRACT => 'MODIFIER_ABSTRACT',
+            flags\MODIFIER_FINAL => 'MODIFIER_FINAL',
+            flags\FUNC_RETURNS_REF => 'FUNC_RETURNS_REF',
+            flags\FUNC_GENERATOR => 'FUNC_GENERATOR',
         ];
         $types = [
-            \ast\flags\TYPE_NULL => 'TYPE_NULL',
-            \ast\flags\TYPE_BOOL => 'TYPE_BOOL',
-            \ast\flags\TYPE_LONG => 'TYPE_LONG',
-            \ast\flags\TYPE_DOUBLE => 'TYPE_DOUBLE',
-            \ast\flags\TYPE_STRING => 'TYPE_STRING',
-            \ast\flags\TYPE_ARRAY => 'TYPE_ARRAY',
-            \ast\flags\TYPE_OBJECT => 'TYPE_OBJECT',
-            \ast\flags\TYPE_CALLABLE => 'TYPE_CALLABLE',
-            \ast\flags\TYPE_VOID => 'TYPE_VOID',
-            \ast\flags\TYPE_ITERABLE => 'TYPE_ITERABLE',
+            flags\TYPE_NULL => 'TYPE_NULL',
+            flags\TYPE_BOOL => 'TYPE_BOOL',
+            flags\TYPE_LONG => 'TYPE_LONG',
+            flags\TYPE_DOUBLE => 'TYPE_DOUBLE',
+            flags\TYPE_STRING => 'TYPE_STRING',
+            flags\TYPE_ARRAY => 'TYPE_ARRAY',
+            flags\TYPE_OBJECT => 'TYPE_OBJECT',
+            flags\TYPE_CALLABLE => 'TYPE_CALLABLE',
+            flags\TYPE_VOID => 'TYPE_VOID',
+            flags\TYPE_ITERABLE => 'TYPE_ITERABLE',
         ];
         $useTypes = [
-            \ast\flags\USE_NORMAL => 'USE_NORMAL',
-            \ast\flags\USE_FUNCTION => 'USE_FUNCTION',
-            \ast\flags\USE_CONST => 'USE_CONST',
+            flags\USE_NORMAL => 'USE_NORMAL',
+            flags\USE_FUNCTION => 'USE_FUNCTION',
+            flags\USE_CONST => 'USE_CONST',
         ];
         $sharedBinaryOps = [
-            \ast\flags\BINARY_BITWISE_OR => 'BINARY_BITWISE_OR',
-            \ast\flags\BINARY_BITWISE_AND => 'BINARY_BITWISE_AND',
-            \ast\flags\BINARY_BITWISE_XOR => 'BINARY_BITWISE_XOR',
-            \ast\flags\BINARY_CONCAT => 'BINARY_CONCAT',
-            \ast\flags\BINARY_ADD => 'BINARY_ADD',
-            \ast\flags\BINARY_SUB => 'BINARY_SUB',
-            \ast\flags\BINARY_MUL => 'BINARY_MUL',
-            \ast\flags\BINARY_DIV => 'BINARY_DIV',
-            \ast\flags\BINARY_MOD => 'BINARY_MOD',
-            \ast\flags\BINARY_POW => 'BINARY_POW',
-            \ast\flags\BINARY_SHIFT_LEFT => 'BINARY_SHIFT_LEFT',
-            \ast\flags\BINARY_SHIFT_RIGHT => 'BINARY_SHIFT_RIGHT',
+            flags\BINARY_BITWISE_OR => 'BINARY_BITWISE_OR',
+            flags\BINARY_BITWISE_AND => 'BINARY_BITWISE_AND',
+            flags\BINARY_BITWISE_XOR => 'BINARY_BITWISE_XOR',
+            flags\BINARY_CONCAT => 'BINARY_CONCAT',
+            flags\BINARY_ADD => 'BINARY_ADD',
+            flags\BINARY_SUB => 'BINARY_SUB',
+            flags\BINARY_MUL => 'BINARY_MUL',
+            flags\BINARY_DIV => 'BINARY_DIV',
+            flags\BINARY_MOD => 'BINARY_MOD',
+            flags\BINARY_POW => 'BINARY_POW',
+            flags\BINARY_SHIFT_LEFT => 'BINARY_SHIFT_LEFT',
+            flags\BINARY_SHIFT_RIGHT => 'BINARY_SHIFT_RIGHT',
         ];
 
         $exclusive = [
             \ast\AST_NAME => [
-                \ast\flags\NAME_FQ => 'NAME_FQ',
-                \ast\flags\NAME_NOT_FQ => 'NAME_NOT_FQ',
-                \ast\flags\NAME_RELATIVE => 'NAME_RELATIVE',
+                flags\NAME_FQ => 'NAME_FQ',
+                flags\NAME_NOT_FQ => 'NAME_NOT_FQ',
+                flags\NAME_RELATIVE => 'NAME_RELATIVE',
             ],
             \ast\AST_CLASS => [
-                \ast\flags\CLASS_ABSTRACT => 'CLASS_ABSTRACT',
-                \ast\flags\CLASS_FINAL => 'CLASS_FINAL',
-                \ast\flags\CLASS_TRAIT => 'CLASS_TRAIT',
-                \ast\flags\CLASS_INTERFACE => 'CLASS_INTERFACE',
-                \ast\flags\CLASS_ANONYMOUS => 'CLASS_ANONYMOUS',
+                flags\CLASS_ABSTRACT => 'CLASS_ABSTRACT',
+                flags\CLASS_FINAL => 'CLASS_FINAL',
+                flags\CLASS_TRAIT => 'CLASS_TRAIT',
+                flags\CLASS_INTERFACE => 'CLASS_INTERFACE',
+                flags\CLASS_ANONYMOUS => 'CLASS_ANONYMOUS',
             ],
             \ast\AST_PARAM => [
-                \ast\flags\PARAM_REF => 'PARAM_REF',
-                \ast\flags\PARAM_VARIADIC => 'PARAM_VARIADIC',
+                flags\PARAM_REF => 'PARAM_REF',
+                flags\PARAM_VARIADIC => 'PARAM_VARIADIC',
             ],
             \ast\AST_TYPE => $types,
             \ast\AST_CAST => $types,
             \ast\AST_UNARY_OP => [
-                \ast\flags\UNARY_BOOL_NOT => 'UNARY_BOOL_NOT',
-                \ast\flags\UNARY_BITWISE_NOT => 'UNARY_BITWISE_NOT',
-                \ast\flags\UNARY_MINUS => 'UNARY_MINUS',
-                \ast\flags\UNARY_PLUS => 'UNARY_PLUS',
-                \ast\flags\UNARY_SILENCE => 'UNARY_SILENCE',
+                flags\UNARY_BOOL_NOT => 'UNARY_BOOL_NOT',
+                flags\UNARY_BITWISE_NOT => 'UNARY_BITWISE_NOT',
+                flags\UNARY_MINUS => 'UNARY_MINUS',
+                flags\UNARY_PLUS => 'UNARY_PLUS',
+                flags\UNARY_SILENCE => 'UNARY_SILENCE',
             ],
             \ast\AST_BINARY_OP => $sharedBinaryOps + [
-                \ast\flags\BINARY_BOOL_AND => 'BINARY_BOOL_AND',
-                \ast\flags\BINARY_BOOL_OR => 'BINARY_BOOL_OR',
-                \ast\flags\BINARY_BOOL_XOR => 'BINARY_BOOL_XOR',
-                \ast\flags\BINARY_IS_IDENTICAL => 'BINARY_IS_IDENTICAL',
-                \ast\flags\BINARY_IS_NOT_IDENTICAL => 'BINARY_IS_NOT_IDENTICAL',
-                \ast\flags\BINARY_IS_EQUAL => 'BINARY_IS_EQUAL',
-                \ast\flags\BINARY_IS_NOT_EQUAL => 'BINARY_IS_NOT_EQUAL',
-                \ast\flags\BINARY_IS_SMALLER => 'BINARY_IS_SMALLER',
-                \ast\flags\BINARY_IS_SMALLER_OR_EQUAL => 'BINARY_IS_SMALLER_OR_EQUAL',
-                \ast\flags\BINARY_IS_GREATER => 'BINARY_IS_GREATER',
-                \ast\flags\BINARY_IS_GREATER_OR_EQUAL => 'BINARY_IS_GREATER_OR_EQUAL',
-                \ast\flags\BINARY_SPACESHIP => 'BINARY_SPACESHIP',
-                \ast\flags\BINARY_COALESCE => 'BINARY_COALESCE',
+                flags\BINARY_BOOL_AND => 'BINARY_BOOL_AND',
+                flags\BINARY_BOOL_OR => 'BINARY_BOOL_OR',
+                flags\BINARY_BOOL_XOR => 'BINARY_BOOL_XOR',
+                flags\BINARY_IS_IDENTICAL => 'BINARY_IS_IDENTICAL',
+                flags\BINARY_IS_NOT_IDENTICAL => 'BINARY_IS_NOT_IDENTICAL',
+                flags\BINARY_IS_EQUAL => 'BINARY_IS_EQUAL',
+                flags\BINARY_IS_NOT_EQUAL => 'BINARY_IS_NOT_EQUAL',
+                flags\BINARY_IS_SMALLER => 'BINARY_IS_SMALLER',
+                flags\BINARY_IS_SMALLER_OR_EQUAL => 'BINARY_IS_SMALLER_OR_EQUAL',
+                flags\BINARY_IS_GREATER => 'BINARY_IS_GREATER',
+                flags\BINARY_IS_GREATER_OR_EQUAL => 'BINARY_IS_GREATER_OR_EQUAL',
+                flags\BINARY_SPACESHIP => 'BINARY_SPACESHIP',
+                flags\BINARY_COALESCE => 'BINARY_COALESCE',
             ],
             \ast\AST_ASSIGN_OP => $sharedBinaryOps + [
                 // Old version 10 flags
-                \ast\flags\ASSIGN_BITWISE_OR => 'ASSIGN_BITWISE_OR',
-                \ast\flags\ASSIGN_BITWISE_AND => 'ASSIGN_BITWISE_AND',
-                \ast\flags\ASSIGN_BITWISE_XOR => 'ASSIGN_BITWISE_XOR',
-                \ast\flags\ASSIGN_CONCAT => 'ASSIGN_CONCAT',
-                \ast\flags\ASSIGN_ADD => 'ASSIGN_ADD',
-                \ast\flags\ASSIGN_SUB => 'ASSIGN_SUB',
-                \ast\flags\ASSIGN_MUL => 'ASSIGN_MUL',
-                \ast\flags\ASSIGN_DIV => 'ASSIGN_DIV',
-                \ast\flags\ASSIGN_MOD => 'ASSIGN_MOD',
-                \ast\flags\ASSIGN_POW => 'ASSIGN_POW',
-                \ast\flags\ASSIGN_SHIFT_LEFT => 'ASSIGN_SHIFT_LEFT',
-                \ast\flags\ASSIGN_SHIFT_RIGHT => 'ASSIGN_SHIFT_RIGHT',
+                flags\ASSIGN_BITWISE_OR => 'ASSIGN_BITWISE_OR',
+                flags\ASSIGN_BITWISE_AND => 'ASSIGN_BITWISE_AND',
+                flags\ASSIGN_BITWISE_XOR => 'ASSIGN_BITWISE_XOR',
+                flags\ASSIGN_CONCAT => 'ASSIGN_CONCAT',
+                flags\ASSIGN_ADD => 'ASSIGN_ADD',
+                flags\ASSIGN_SUB => 'ASSIGN_SUB',
+                flags\ASSIGN_MUL => 'ASSIGN_MUL',
+                flags\ASSIGN_DIV => 'ASSIGN_DIV',
+                flags\ASSIGN_MOD => 'ASSIGN_MOD',
+                flags\ASSIGN_POW => 'ASSIGN_POW',
+                flags\ASSIGN_SHIFT_LEFT => 'ASSIGN_SHIFT_LEFT',
+                flags\ASSIGN_SHIFT_RIGHT => 'ASSIGN_SHIFT_RIGHT',
             ],
             \ast\AST_MAGIC_CONST => [
-                \ast\flags\MAGIC_LINE => 'MAGIC_LINE',
-                \ast\flags\MAGIC_FILE => 'MAGIC_FILE',
-                \ast\flags\MAGIC_DIR => 'MAGIC_DIR',
-                \ast\flags\MAGIC_NAMESPACE => 'MAGIC_NAMESPACE',
-                \ast\flags\MAGIC_FUNCTION => 'MAGIC_FUNCTION',
-                \ast\flags\MAGIC_METHOD => 'MAGIC_METHOD',
-                \ast\flags\MAGIC_CLASS => 'MAGIC_CLASS',
-                \ast\flags\MAGIC_TRAIT => 'MAGIC_TRAIT',
+                flags\MAGIC_LINE => 'MAGIC_LINE',
+                flags\MAGIC_FILE => 'MAGIC_FILE',
+                flags\MAGIC_DIR => 'MAGIC_DIR',
+                flags\MAGIC_NAMESPACE => 'MAGIC_NAMESPACE',
+                flags\MAGIC_FUNCTION => 'MAGIC_FUNCTION',
+                flags\MAGIC_METHOD => 'MAGIC_METHOD',
+                flags\MAGIC_CLASS => 'MAGIC_CLASS',
+                flags\MAGIC_TRAIT => 'MAGIC_TRAIT',
             ],
             \ast\AST_USE => $useTypes,
             \ast\AST_GROUP_USE => $useTypes,
             \ast\AST_USE_ELEM => $useTypes,
             \ast\AST_INCLUDE_OR_EVAL => [
-                \ast\flags\EXEC_EVAL => 'EXEC_EVAL',
-                \ast\flags\EXEC_INCLUDE => 'EXEC_INCLUDE',
-                \ast\flags\EXEC_INCLUDE_ONCE => 'EXEC_INCLUDE_ONCE',
-                \ast\flags\EXEC_REQUIRE => 'EXEC_REQUIRE',
-                \ast\flags\EXEC_REQUIRE_ONCE => 'EXEC_REQUIRE_ONCE',
+                flags\EXEC_EVAL => 'EXEC_EVAL',
+                flags\EXEC_INCLUDE => 'EXEC_INCLUDE',
+                flags\EXEC_INCLUDE_ONCE => 'EXEC_INCLUDE_ONCE',
+                flags\EXEC_REQUIRE => 'EXEC_REQUIRE',
+                flags\EXEC_REQUIRE_ONCE => 'EXEC_REQUIRE_ONCE',
             ],
             \ast\AST_ARRAY => [
-                \ast\flags\ARRAY_SYNTAX_LIST => 'ARRAY_SYNTAX_LIST',
-                \ast\flags\ARRAY_SYNTAX_LONG => 'ARRAY_SYNTAX_LONG',
-                \ast\flags\ARRAY_SYNTAX_SHORT => 'ARRAY_SYNTAX_SHORT',
+                flags\ARRAY_SYNTAX_LIST => 'ARRAY_SYNTAX_LIST',
+                flags\ARRAY_SYNTAX_LONG => 'ARRAY_SYNTAX_LONG',
+                flags\ARRAY_SYNTAX_SHORT => 'ARRAY_SYNTAX_SHORT',
             ],
+            \ast\AST_CLOSURE_VAR => [
+                flags\CLOSURE_USE_REF => 'CLOSURE_USE_REF',
+            ]
         ];
 
         $combinable = [];

--- a/src/Phan/Language/Element/Func.php
+++ b/src/Phan/Language/Element/Func.php
@@ -16,7 +16,6 @@ use Phan\Language\UnionType;
 use Phan\Library\None;
 use Phan\Library\Option;
 use ast\Node;
-use ast\Node\Decl;
 
 class Func extends AddressableElement implements FunctionInterface
 {
@@ -83,7 +82,7 @@ class Func extends AddressableElement implements FunctionInterface
         CodeBase $code_base,
         Context $context,
         Type $closure_scope,
-        Decl $node
+        Node $node
     ) {
         if ($node->kind !== \ast\AST_CLOSURE) {
             return null;
@@ -125,7 +124,7 @@ class Func extends AddressableElement implements FunctionInterface
      *
      * @param CodeBase $code_base
      *
-     * @param Decl $node
+     * @param Node $node
      * An AST node representing a function
      *
      * @param FullyQualifiedFunctionName $fqsen
@@ -138,7 +137,7 @@ class Func extends AddressableElement implements FunctionInterface
     public static function fromNode(
         Context $context,
         CodeBase $code_base,
-        Decl $node,
+        Node $node,
         FullyQualifiedFunctionName $fqsen
     ) : Func {
 
@@ -146,7 +145,7 @@ class Func extends AddressableElement implements FunctionInterface
         // we know so far
         $func = new Func(
             $context,
-            (string)$node->name,
+            (string)$node->children['name'],
             new UnionType(),
             $node->flags ?? 0,
             $fqsen
@@ -155,7 +154,7 @@ class Func extends AddressableElement implements FunctionInterface
         // Parse the comment above the function to get
         // extra meta information about the function.
         $comment = Comment::fromStringInContext(
-            $node->docComment ?? '',
+            (string)$node->children['docComment'],
             $code_base,
             $context,
             $node->lineno ?? 0,

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -8,7 +8,7 @@ use Phan\Language\Context;
 use Phan\Language\Type\MixedType;
 use Phan\Language\Type\NullType;
 use Phan\Language\UnionType;
-use ast\Node\Decl;
+use ast\Node;
 
 trait FunctionTrait {
 
@@ -465,7 +465,7 @@ trait FunctionTrait {
      *
      * @param CodeBase $code_base
      *
-     * @param Decl $node
+     * @param Node $node
      * An AST node representing a method
      *
      * @param FunctionInterface $function - A Func or Method to add params to the local scope of.
@@ -477,7 +477,7 @@ trait FunctionTrait {
     public static function addParamsToScopeOfFunctionOrMethod(
         Context $context,
         CodeBase $code_base,
-        Decl $node,
+        Node $node,
         FunctionInterface $function,
         Comment $comment
     ) {
@@ -532,7 +532,7 @@ trait FunctionTrait {
     public static function addParamToScopeOfFunctionOrMethod(
         Context $context,
         CodeBase $code_base,
-        Decl $node,
+        Node $node,
         FunctionInterface $function,
         Comment $comment,
         int $parameter_offset,

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -15,7 +15,6 @@ use Phan\Language\Type\MixedType;
 use Phan\Language\Type\NullType;
 use Phan\Language\UnionType;
 use ast\Node;
-use ast\Node\Decl;
 
 class Method extends ClassElement implements FunctionInterface
 {
@@ -320,7 +319,7 @@ class Method extends ClassElement implements FunctionInterface
      *
      * @param CodeBase $code_base
      *
-     * @param Decl $node
+     * @param Node $node
      * An AST node representing a method
      *
      * @return Method
@@ -330,7 +329,7 @@ class Method extends ClassElement implements FunctionInterface
     public static function fromNode(
         Context $context,
         CodeBase $code_base,
-        Decl $node,
+        Node $node,
         FullyQualifiedMethodName $fqsen
     ) : Method {
 
@@ -338,7 +337,7 @@ class Method extends ClassElement implements FunctionInterface
         // we know so far
         $method = new Method(
             $context,
-            (string)$node->name,
+            (string)$node->children['name'],
             new UnionType(),
             $node->flags ?? 0,
             $fqsen
@@ -347,7 +346,7 @@ class Method extends ClassElement implements FunctionInterface
         // Parse the comment above the method to get
         // extra meta information about the method.
         $comment = Comment::fromStringInContext(
-            $node->docComment ?? '',
+            $node->children['docComment'] ?? '',
             $code_base,
             $context,
             $node->lineno ?? 0,

--- a/src/Phan/Language/FQSEN/FullyQualifiedFunctionName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedFunctionName.php
@@ -2,7 +2,6 @@
 namespace Phan\Language\FQSEN;
 
 use Phan\Language\Context;
-use ast\Node\Decl;
 use ast\Node;
 
 /**
@@ -84,12 +83,12 @@ class FullyQualifiedFunctionName extends FullyQualifiedGlobalStructuralElement
 
     public static function fromClosureInContext(
         Context $context,
-        Decl $node
+        Node $node
     ) : FullyQualifiedFunctionName {
         $hash_material = implode('|', [
             $context->getFile(),
             $context->getLineNumberStart(),
-            $node->docComment ?? '',
+            $node->children['docComment'] ?? '',
             implode(',', array_map(function(Node $arg) : string {
                 return serialize([$arg->children['type'], $arg->children['name'], $arg->children['default']]);
             }, $node->children['params']->children)),

--- a/src/Phan/Language/Internal/PropertyMap.php
+++ b/src/Phan/Language/Internal/PropertyMap.php
@@ -402,6 +402,7 @@ return [
         'flags' => 'int',
         'lineno' => 'int',
         'children' => 'array',  // NOTE: in the latest version, this is consistently an array, even for edge cases like statement lists of single statements.
+        'endLineno' => 'int',
     ],
     'ast\node\decl' => [
         'kind' => 'int',

--- a/src/Phan/Util.php
+++ b/src/Phan/Util.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+namespace Phan;
+
+use ast\Node;
+
+/**
+ * Utilities used for things other than debugging.
+ */
+class Util
+{
+    /**
+     * @param ?Node $node
+     * @return ?int
+     * @suppress PhanUndeclaredProperty - The extension deliberately leaves it undeclared.
+     */
+    public static function getEndLineno($node)
+    {
+        return $node->endLineno ?? null;
+    }
+}

--- a/src/phan.php
+++ b/src/phan.php
@@ -39,8 +39,8 @@ if (extension_loaded('ast')) {
     // Warn if the php-ast version is too low.
     // (It's remotely possible \ast\parse_code could a pure PHP substitute for php-ast in the future)
     $ast_version = (new ReflectionExtension('ast'))->getVersion();
-    if (version_compare($ast_version, '0.1.4') < 0) {
-        fprintf(STDERR, "Phan supports php-ast version 0.1.4 or newer, but the installed php-ast version is $ast_version. You may see bugs in some edge cases\n");
+    if (version_compare($ast_version, '0.1.5') < 0) {
+        fprintf(STDERR, "Phan supports php-ast version 0.1.5 or newer, but the installed php-ast version is $ast_version. You may see bugs in some edge cases\n");
     }
 }
 

--- a/tests/files/expected/0289_check_incorrect_soft_types.php.expected
+++ b/tests/files/expected/0289_check_incorrect_soft_types.php.expected
@@ -1,5 +1,4 @@
 %s:3 PhanUndeclaredTypeParameter Parameter of undeclared type \resource
 %s:4 PhanTypeMismatchArgumentInternal Argument 1 (fp) is \resource but \fread() takes resource
 %s:10 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is false|resource but \intdiv() takes int
-%s:14 PhanUndeclaredTypeParameter Parameter of undeclared type \object
 %s:18 PhanUndeclaredTypeParameter Parameter of undeclared type \mixed


### PR DESCRIPTION
Time when this should be merged to master

- some point after phan 0.9.4 is released (Done)
- before the PHP 7.2.0 branch has been released,
- before php-ast version 40 deprecation is released

TODO: Add more specific error for the test case
(Not supported in php <= 7.1)