### PR TITLE
Fix false positive warnings about accessing protected method from trait

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -41,6 +41,10 @@ Bug Fixes
   Warn if the class name is definitely invalid.
 + Fix false positives about undefined variables in isset()/empty() (Issue #1039)
   (Fixes bug introduced in Phan 0.9.3)
++ Fix false positive warnings about accessing protected methods from traits (Issue #1033)
+  Act as though the class which used a trait is the place where the method was defined,
+  so that method visibility checks work properly.
+  Additionally, fix false positive warnings about visibility of method aliases from traits.
 
 Changes In Emitted Issues
 + Improve `InvalidVariableIssetPlugin`. Change the names and messages for issue types.

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -254,9 +254,15 @@ class Method extends ClassElement implements FunctionInterface
     }
 
     /**
+     * @param Clazz $clazz - The class to treat as the defining class of the alias. (i.e. the inheriting class)
+     * @param string $alias_method_name - The alias method name.
      * @param int $new_visibility_flags (0 if unchanged)
      * @return Method
-     * An alias from a trait use
+     *
+     * An alias from a trait use, which is treated as though it was defined in $clazz
+     * E.g. if you import a trait's method as private/protected, it becomes private/protected **to the class which used the trait**
+     *
+     * The resulting alias doesn't inherit the \ast\Node of the method body, so aliases won't have a redundant analysis step.
      */
     public function createUseAlias(
         Clazz $clazz,
@@ -295,15 +301,10 @@ class Method extends ClassElement implements FunctionInterface
             break;
         }
 
-        // Workaround: If you import a trait's method as private, it becomes private **to the class which used the trait**
-        // (But preserving the defining FQSEN is fine for this)
-        if (!Flags::bitVectorHasState($method->getFlags(), \ast\flags\MODIFIER_PRIVATE)) {
-            $method->setDefiningFQSEN($method_fqsen);
+        if ($method->isPublic()) {
+            $method->setDefiningFQSEN($this->getDefiningFQSEN());
         }
 
-        // TODO: setDefiningFQSEN?
-
-        // TODO: Update and add setNumberOfRealRequiredParameters once other PR is merged?
         $method->setParameterList($this->getParameterList());
         $method->setRealParameterList($this->getRealParameterList());
         $method->setRealReturnType($this->getRealReturnType());

--- a/tests/files/expected/0296_private_trait_adaptations.php.expected
+++ b/tests/files/expected/0296_private_trait_adaptations.php.expected
@@ -1,4 +1,3 @@
-%s:29 PhanAccessMethodPrivate Cannot access private method \A296::asPrivateAlias defined at %s:5
 %s:38 PhanAccessMethodPrivate Cannot access private method \B296::asPrivateAlias defined at %s:5
 %s:55 PhanAccessMethodPrivate Cannot access private method \A296::fPrivateAsPublic defined at %s:10
 %s:56 PhanAccessMethodPrivate Cannot access private method \A296::fPrivateAsProtected defined at %s:11

--- a/tests/files/expected/0349_protected_method_from_trait.php.expected
+++ b/tests/files/expected/0349_protected_method_from_trait.php.expected
@@ -1,0 +1,4 @@
+%s:38 PhanUndeclaredProperty Reference to undeclared property \AbstractClass->missingProp
+%s:47 PhanAccessMethodProtected Cannot access protected method \ExtendingClass::protectedAlias defined at %s:18
+%s:48 PhanAccessMethodProtected Cannot access protected method \ExtendingClass::foo3 defined at %s:15
+%s:50 PhanAccessPropertyProtected Cannot access protected property \ExtendingClass::$prop

--- a/tests/files/expected/0350_private_prop_from_trait.php.expected
+++ b/tests/files/expected/0350_private_prop_from_trait.php.expected
@@ -1,0 +1,2 @@
+%s:8 PhanUndeclaredProperty Reference to undeclared property \T350->b
+%s:19 PhanTypeMismatchArgument Argument 1 (x) is string but \C350::foo2() takes int defined at %s:5

--- a/tests/files/src/0296_private_trait_adaptations.php
+++ b/tests/files/src/0296_private_trait_adaptations.php
@@ -26,7 +26,7 @@ class A296 {
     }
 
     public function accessAPrivate() {
-        return $this->asPrivateAlias();
+        return $this->asPrivateAlias();  // should not warn.
     }
 
     private function privateNonTrait() {

--- a/tests/files/src/0349_protected_method_from_trait.php
+++ b/tests/files/src/0349_protected_method_from_trait.php
@@ -1,0 +1,50 @@
+<?php
+
+abstract class AbstractClass {
+    use TraitClass {
+        foo as foo2;
+        foo as protected foo3;
+        foo as public foo4;
+        publicFn as protected protectedAlias;
+    }
+}
+
+trait TraitClass {
+	protected $prop = 4;
+
+    protected function foo() {
+        echo "bar\n";
+	}
+    public function publicFn() {
+        echo "bar\n";
+	}
+}
+
+class ExtendingClass extends AbstractClass {
+	public function foo() {
+		parent::foo();
+	}
+
+    // should not warn.
+	public function foo2() {
+		parent::foo2();
+        parent::foo3();
+        parent::foo4();
+        parent::protectedAlias();
+	}
+
+	public function other() {
+        printf("prop=%s\n", $this->prop);
+        printf("prop=%s\n", $this->missingProp);  // should warn
+	}
+}
+
+$traitClass = new ExtendingClass();
+$traitClass->foo();  // should not warn
+$traitClass->foo2();  // should not warn
+$traitClass->foo4();  // should not warn
+
+$traitClass->protectedAlias();  // should warn
+$traitClass->foo3(); // should warn
+$traitClass->publicFn();  // should not warn
+echo $traitClass->prop;

--- a/tests/files/src/0350_private_prop_from_trait.php
+++ b/tests/files/src/0350_private_prop_from_trait.php
@@ -1,0 +1,23 @@
+<?php
+
+trait T350 {
+    private $a = 5;
+    private function foo(int $x) : int {
+        $old = $x;
+        $this->a  = $x;
+        $this->b  = $x * 2;
+        return $old;
+    }
+}
+
+class C350 {
+    use T350 {
+        foo as foo2;
+    }
+    public function bar() {
+        $this->foo(55);
+        $this->foo2("56");
+    }
+}
+$c350 = new C350();
+$c350->bar();


### PR DESCRIPTION
Fixes #1033

Phan would act as though the defining class of a private method
inherited from a trait was the class using the trait.

- Start doing the same thing for protected methods from traits as well,
  so that subclasses will have the correct visibility.

Additionally, fix edge cases of visibility of trait uses creating aliases of
methods from traits.