### PR TITLE
Revert "Refuse to fork() with grpc extension enabled for now."

### DIFF
--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -83,7 +83,6 @@ class Phan implements IgnoredFilesFilterInterface {
         if ($is_daemon_request) {
             $code_base->enableUndoTracking();
         }
-        self::checkExtensionCompatibility($is_daemon_request);
 
         $file_path_list = $file_path_lister();
 
@@ -375,29 +374,6 @@ class Phan implements IgnoredFilesFilterInterface {
         }
 
         return array_unique($dependency_file_path_list);
-    }
-
-    /**
-     * Prints error messages if this is incompatible with various PHP modules. (e.g. grpc)
-     * Modifies global config if possible to work around those.
-     * Exits on failure.
-     *
-     * @param bool $is_daemon_request - Is the user attempting to run this in daemon mode
-     * @return void
-     */
-    private static function checkExtensionCompatibility(bool $is_daemon_request) {
-        if (extension_loaded('grpc')) {
-            // https://github.com/etsy/phan/issues/889
-            // In version 1.3.2, ReflectionExtension said the version was 0.10. Give up on version checking
-            if ($is_daemon_request) {
-                fprintf(STDERR, "Daemon mode will not work with grpc extension enabled in 1.4.0-dev (1.3.2 should work), quitting. See Issue #889\n");
-                exit(EXIT_FAILURE);
-            }
-            if (Config::getValue('processes') > 1) {
-                fprintf(STDERR, "Multi-process analysis will not work with grpc extension enabled in 1.4.0-dev (1.3.2 should work), limiting analysis to a single process. See Issue #889\n");
-                Config::setValue('processes', 1);
-            }
-        }
     }
 
     /**

--- a/tests/Phan/ForkPoolTest.php
+++ b/tests/Phan/ForkPoolTest.php
@@ -8,19 +8,12 @@ use Phan\ForkPool;
  */
 class ForkPoolTest extends BaseTest
 {
-    private function checkIfShouldSkipForkingTests() {
-        if (extension_loaded('grpc')) {
-            $this->markTestSkipped('The latest grpc extension (1.4.0RC2) has issues with forking. Disabling tests with all versions until it is fixed');
-        }
-    }
-
     /**
      * Test that workers are able to send their data back
      * to the parent process.
      */
     public function testBasicForkJoin()
     {
-        $this->checkIfShouldSkipForkingTests();
         $data = [
             [1, 2, 3, 4],
             [5, 6, 7, 8],
@@ -48,7 +41,6 @@ class ForkPoolTest extends BaseTest
      */
     public function testStartupFunction()
     {
-        $this->checkIfShouldSkipForkingTests();
         $did_startup = false;
         $pool = new ForkPool(
             [[1], [2], [3], [4]],


### PR DESCRIPTION
If grpc is used, update it to 1.4.4 or newer, or avoid running phan
daemon or running phan with multiple processes.

This reverts commit 337ae0b1832bb0542742f4792e3447c417bacd6b.

Conflicts:
	NEWS
	src/Phan/Phan.php